### PR TITLE
global leak protection changes missing after move

### DIFF
--- a/lib/bson/binary.js
+++ b/lib/bson/binary.js
@@ -54,7 +54,9 @@ var convertArraytoUtf8BinaryString = function(byteArray, startIndex, endIndex) {
  * @param {Number} [subType] the option binary type.
  * @return {Grid}
  */
-function Binary(buffer, subType) {  
+function Binary(buffer, subType) {
+  if(!(this instanceof Binary)) return new Binary(buffer, subType);
+  
   this._bsontype = 'Binary';
 
   if(buffer instanceof Number) {

--- a/lib/bson/binary_parser.js
+++ b/lib/bson/binary_parser.js
@@ -11,6 +11,8 @@ for (var i = 0; i < 64; i++) {
 }
 
 function BinaryParser (bigEndian, allowExceptions) {
+  if(!(this instanceof BinaryParser)) return new BinaryParser(bigEndian, allowExceptions);
+  
 	this.bigEndian = bigEndian;
 	this.allowExceptions = allowExceptions;
 };

--- a/lib/bson/code.js
+++ b/lib/bson/code.js
@@ -7,6 +7,8 @@
  * @return {Code}
  */
 function Code(code, scope) {
+  if(!(this instanceof Code)) return new Code(code, scope);
+  
   this._bsontype = 'Code';
   this.code = code;
   this.scope = scope == null ? {} : scope;

--- a/lib/bson/db_ref.js
+++ b/lib/bson/db_ref.js
@@ -8,6 +8,8 @@
  * @return {DBRef}
  */
 function DBRef(namespace, oid, db) {
+  if(!(this instanceof DBRef)) return new DBRef(namespace, oid, db);
+  
   this._bsontype = 'DBRef';
   this.namespace = namespace;
   this.oid = oid;

--- a/lib/bson/double.js
+++ b/lib/bson/double.js
@@ -6,6 +6,8 @@
  * @return {Double}
  */
 function Double(value) {
+  if(!(this instanceof Double)) return new Double(value);
+  
   this._bsontype = 'Double';
   this.value = value;
 }

--- a/lib/bson/long.js
+++ b/lib/bson/long.js
@@ -40,6 +40,8 @@
  * @param {Number} high the high (signed) 32 bits of the Long.
  */
 function Long(low, high) {
+  if(!(this instanceof Long)) return new Long(low, high);
+  
   this._bsontype = 'Long';
   /**
    * @type {number}

--- a/lib/bson/max_key.js
+++ b/lib/bson/max_key.js
@@ -5,6 +5,8 @@
  * @return {MaxKey}
  */
 function MaxKey() {
+  if(!(this instanceof MaxKey)) return new MaxKey();
+  
   this._bsontype = 'MaxKey';  
 }
 

--- a/lib/bson/min_key.js
+++ b/lib/bson/min_key.js
@@ -5,6 +5,8 @@
  * @return {MinKey}
  */
 function MinKey() {
+  if(!(this instanceof MinKey)) return new MinKey();
+  
   this._bsontype = 'MinKey';
 }
 

--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -25,6 +25,8 @@ var checkForHexRegExp = new RegExp("^[0-9a-fA-F]{24}$");
 * @return {Object} instance of ObjectID.
 */
 function ObjectID(id) {
+  if(!(this instanceof ObjectID)) return new ObjectID(id);
+  
   this._bsontype = 'ObjectID';
     
   var self = this;

--- a/lib/bson/symbol.js
+++ b/lib/bson/symbol.js
@@ -6,6 +6,7 @@
  * @return {Symbol}
  */
 function Symbol(value) {
+  if(!(this instanceof Symbol)) return new Symbol(value);
   this._bsontype = 'Symbol';
   this.value = value;
 }

--- a/lib/bson/timestamp.js
+++ b/lib/bson/timestamp.js
@@ -40,6 +40,7 @@
  * @param {Number} high the high (signed) 32 bits of the Timestamp.
  */
 function Timestamp(low, high) {
+  if(!(this instanceof Timestamp)) return new Timestamp(low, high);
   this._bsontype = 'Timestamp';
   /**
    * @type {number}


### PR DESCRIPTION
Looks like these changes were lost when the bson library was separated from node-mongodb-native
