### PR TITLE
Support for all Node v0.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 , "config":         { "native" : false }                    
 , "main":             "./lib/bson/index"
 , "directories" :   { "lib" : "./lib/bson" }
-, "engines" :       { "node" : ">=0.4.12" }
+, "engines" :       { "node" : ">=0.4.0" }
 , "scripts": { "install" : "node install.js", "test" : "make test" }
 , "licenses" :    [ { "type" :  "Apache License, Version 2.0"
                     , "url" :   "http://www.apache.org/licenses/LICENSE-2.0" } ]


### PR DESCRIPTION
It appears that 'bson' split off of 'mongodb'.  However, 'mongodb' requires ">=0.4.0" whereas 'bson' requires ">=0.4.12".  I've attempted to see if 'bson' is not compatible with 0.4.10 or other 0.4.x versions of node and have found no such indication, leading me to believe that this is an unnecessarily strict and possibly arbitrary version restriction.

I've used 'nave' to test all thirteen versions of node between 0.4.0 -> 0.4.12, and for each have run nodeunit against bson's 'test/node', and have found that in every version (save 0.4.0) the only error is "Assertion Message: global var leak detected: TAP_Global_Harness" in the bson_array_test:noGlobalsLeaked test.  Interestingly, only node 0.4.0 runs free of errors the 0.4.x family.
