### PR TITLE
Don't return different objects based on shape of user data

### DIFF
--- a/ext/bson.cc
+++ b/ext/bson.cc
@@ -518,15 +518,6 @@ Handle<Value> BSONDeserializer::DeserializeValue(BsonType type)
 			int32_t lowBits = (int32_t) ReadInt32();
 			int32_t highBits = (int32_t) ReadInt32();
 
-		    // If value is < 2^53 and >-2^53
-		    if((highBits < 0x200000 || (highBits == 0x200000 && lowBits == 0)) && highBits >= -0x200000) {
-			  // Adjust the pointer and read as 64 bit value
-			  p -= 8;
-			  // Read the 64 bit value
-		      int64_t finalValue = (int64_t) ReadInt64();
-		      return Number::New(finalValue);
-		    }
-
 			Local<Value> argv[] = { Int32::New(lowBits), Int32::New(highBits) };
 			return bson->longConstructor->NewInstance(2, argv);
 		}

--- a/lib/bson/bson.js
+++ b/lib/bson/bson.js
@@ -42,10 +42,6 @@ BSON.BSON_INT64_MIN = -Math.pow(2, 63);
 BSON.JS_INT_MAX = 0x20000000000000;  // Any integer up to 2^53 can be precisely represented by a double.
 BSON.JS_INT_MIN = -0x20000000000000;  // Any integer down to -2^53 can be precisely represented by a double.
 
-// Internal long versions
-var JS_INT_MAX_LONG = Long.fromNumber(0x20000000000000);  // Any integer up to 2^53 can be precisely represented by a double.
-var JS_INT_MIN_LONG = Long.fromNumber(-0x20000000000000);  // Any integer down to -2^53 can be precisely represented by a double.
-
 /**
  * Number BSON Type
  *  
@@ -1284,7 +1280,7 @@ BSON.deserialize = function(buffer, options, isArray) {
         // Create long object
         var long = new Long(lowBits, highBits);
         // Set the object
-        object[name] = long.lessThanOrEqual(JS_INT_MAX_LONG) && long.greaterThanOrEqual(JS_INT_MIN_LONG) ? long.toNumber() : long;
+        object[name] = long;
         break;
       case BSON.BSON_DATA_SYMBOL:
         // Read the content of the field

--- a/test/node/bson_array_test.js
+++ b/test/node/bson_array_test.js
@@ -217,7 +217,7 @@ exports.shouldCorrectlySerializeUsingTypedArray = function(test) {
   test.deepEqual(motherOfAllDocuments.float, object.float);
   test.deepEqual(motherOfAllDocuments.regexp, object.regexp);
   test.deepEqual(motherOfAllDocuments.boolean, object.boolean);
-  test.deepEqual(motherOfAllDocuments.long.toNumber(), object.long);
+  test.deepEqual(motherOfAllDocuments.long.toNumber(), object.long.toNumber());
   test.deepEqual(motherOfAllDocuments.where, object.where);
   test.deepEqual(motherOfAllDocuments.dbref.oid.toHexString(), object.dbref.oid.toHexString());
   test.deepEqual(motherOfAllDocuments.dbref.namespace, object.dbref.namespace);

--- a/test/node/bson_typed_array_test.js
+++ b/test/node/bson_typed_array_test.js
@@ -167,7 +167,7 @@ exports.shouldCorrectlyDeserializeUsingTypedArray = function(test) {
   test.deepEqual(motherOfAllDocuments.float, object.float);
   test.deepEqual(motherOfAllDocuments.regexp, object.regexp);
   test.deepEqual(motherOfAllDocuments.boolean, object.boolean);
-  test.deepEqual(motherOfAllDocuments.long.toNumber(), object.long);
+  test.deepEqual(motherOfAllDocuments.long.toNumber(), object.long.toNumber());
   test.deepEqual(motherOfAllDocuments.where, object.where);
   test.deepEqual(motherOfAllDocuments.dbref.oid.toHexString(), object.dbref.oid.toHexString());
   test.deepEqual(motherOfAllDocuments.dbref.namespace, object.dbref.namespace);
@@ -222,7 +222,7 @@ exports.shouldCorrectlySerializeUsingTypedArray = function(test) {
   test.deepEqual(motherOfAllDocuments.float, object.float);
   test.deepEqual(motherOfAllDocuments.regexp, object.regexp);
   test.deepEqual(motherOfAllDocuments.boolean, object.boolean);
-  test.deepEqual(motherOfAllDocuments.long.toNumber(), object.long);
+  test.deepEqual(motherOfAllDocuments.long.toNumber(), object.long.toNumber());
   test.deepEqual(motherOfAllDocuments.where, object.where);
   test.deepEqual(motherOfAllDocuments.dbref.oid.toHexString(), object.dbref.oid.toHexString());
   test.deepEqual(motherOfAllDocuments.dbref.namespace, object.dbref.namespace);


### PR DESCRIPTION
Any consumer is then forced to deal with two completely different possible classes for returned values that behave differently depending on user data. I can't believe many developers test with both short Long fields and long ones, so there must be broken apps out there.

Given that this likely breaks some existing code, I don't really expect this pull request to be accepted. I'm just trying to contribute to the betterment of the world by removing a bug that bit me hard and will likely bite others.
