### PR TITLE
Added failed recursion test

### DIFF
--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -307,6 +307,31 @@ exports['Should Correctly Serialize and Deserialize Integer'] = function(test) {
 /**
  * @ignore
  */
+exports['Should Fail when Serialize Recursive Object'] = function(test) {
+  var doc = {doc: {age: 42, name: 'Spongebob', shoe_size: 9.5}};
+  doc.rec = doc;
+  try {
+    var serialized_data = new BSONSE.BSON([Long, ObjectID, Binary, Code, DBRef, Symbol, Double, Timestamp, MaxKey, MinKey]).serialize(doc, false, true);
+
+    var serialized_data2 = new Buffer(new BSONSE.BSON([Long, ObjectID, Binary, Code, DBRef, Symbol, Double, Timestamp, MaxKey, MinKey]).calculateObjectSize(doc, false, true));
+    new BSONSE.BSON([Long, ObjectID, Binary, Code, DBRef, Symbol, Double, Timestamp, MaxKey, MinKey]).serializeWithBufferAndIndex(doc, false, serialized_data2, 0);    
+    assertBuffersEqual(test, serialized_data, serialized_data2, 0);
+
+    test.deepEqual(doc.doc.age, new BSONDE.BSON([Long, ObjectID, Binary, Code, DBRef, Symbol, Double, Timestamp, MaxKey, MinKey]).deserialize(serialized_data).doc.age);
+    test.deepEqual(doc.doc.name, new BSONDE.BSON([Long, ObjectID, Binary, Code, DBRef, Symbol, Double, Timestamp, MaxKey, MinKey]).deserialize(serialized_data).doc.name);
+    test.deepEqual(doc.doc.shoe_size, new BSONDE.BSON([Long, ObjectID, Binary, Code, DBRef, Symbol, Double, Timestamp, MaxKey, MinKey]).deserialize(serialized_data).doc.shoe_size);
+    test.done();        
+  }
+  catch (e) {
+    console.log(e.message);
+    if (/.*Maximum call stack size exceeded.*/.test(e.message))
+      test.done();
+  }
+}
+
+/**
+ * @ignore
+ */
 exports['Should Correctly Serialize and Deserialize Object'] = function(test) {
   var doc = {doc: {age: 42, name: 'Spongebob', shoe_size: 9.5}};
   var serialized_data = new BSONSE.BSON([Long, ObjectID, Binary, Code, DBRef, Symbol, Double, Timestamp, MaxKey, MinKey]).serialize(doc, false, true);


### PR DESCRIPTION
I added the test to look for recursive objects, however it's causing a seg fault soon after. I can try to actually fix the problem but it might end up being obvious to you why it's seg faulting. To repeat my thoughts about how to fix this:
Keep a hash of all objects being looked at during the recurse and throw an exception if you see the same object again.

Change this:

``` c++
template<typename T> void BSONSerializer<T>::SerializeValue(void* typeLocation, const Handle<Value>& value)
```

to something like this. I have not looked that close at the code but it should work in theory to keep a hash of identity hash values for all the objects serialized within a single serialize document or calculate size method call.

``` c++
template<typename T> void BSONSerializer<T>::SerializeValue(void* typeLocation, const Handle<Value>& value, Handle<Object>& check)
{
  if (value->IsObject()) {
    Handle<Object>& object = value->ToObject();
    int hash = object->GetIdentityHash();
    if (object->Has(hash))
      return VException("recursive structure");
    check->ForceSet(hash, true);
  }
```
