### PR TITLE
Remove unnecessary regexp test on the id

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -41,7 +41,7 @@ var ObjectID = function ObjectID(id, _hex) {
     this.id = id;
   } else if(checkForHexRegExp.test(id)) {
     return ObjectID.createFromHexString(id);
-  } else if(!checkForHexRegExp.test(id)) {
+  } else {
     throw new Error("Value passed in is not a valid 24 character hex string");
   }
 


### PR DESCRIPTION
The last else statement in the id checking code doesn't need to test against the RegExp since it was already done in the previous conditional.
