### PR TITLE
Array as top-level BSON document

### DIFF
--- a/test/node/bson_array_test.js
+++ b/test/node/bson_array_test.js
@@ -178,6 +178,32 @@ exports.tearDown = function(callback) {
 // }
 
 /**
+ * Should make sure that arrays by themselves can be either be properly
+ * serialized and deserialized, or that serializing throws an error
+ */
+exports.shouldCorrectlyDeserializeArray = function(test) {
+  var testArray = [1,2,3];
+  var data = null;
+
+  try {
+    data = BSONSE.BSON.serialize(testArray, true, false, false);
+  }
+  catch(e) {
+    // if arrays are not supported, throw an error
+    test.done();
+  }
+
+  //otherwise, I expect an array back, with all its bells and whistles
+  var obj = BSONSE.BSON.deserialize(data);
+
+  test.deepEqual(testArray, obj);
+  test.equal(testArray.length, obj.length);
+  test.equal(true, Array.isArray(obj));
+
+  test.done();
+};
+
+/**
  * @ignore
  */  
 exports.shouldCorrectlySerializeUsingTypedArray = function(test) {


### PR DESCRIPTION
Serializing an Array should either throw an error, or produce output that can be deserialized into a proper Array. At the moment, the object produced by deserializing a serialized Array does not have the length key, and is not an Array.

See the added (failing) test for details.
