### PR TITLE
Should the initial ObjectID counter be random?

### DIFF
--- a/browser_build/bson.js
+++ b/browser_build/bson.js
@@ -3833,7 +3833,7 @@ ObjectID.prototype.getTimestamp = function() {
 * @ignore
 * @api private
 */
-ObjectID.index = 0;
+ObjectID.index = parseInt(Math.random() * 0xFFFFFF, 10);
 
 ObjectID.createPk = function createPk () {
   return new ObjectID();

--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -180,7 +180,7 @@ ObjectID.prototype.getTimestamp = function() {
 * @ignore
 * @api private
 */
-ObjectID.index = 0;
+ObjectID.index = parseInt(Math.random() * 0xFFFFFF, 10);
 
 ObjectID.createPk = function createPk () {
   return new ObjectID();


### PR DESCRIPTION
I was reading the [documentation on ObjectID](http://docs.mongodb.org/manual/reference/object-id/) and noticed that the "counter" bytes are supposed to be initialized to a random value.

> a 3-byte counter, starting with a random value.

The [mongo-java-driver](https://github.com/mongodb/mongo-java-driver/blob/master/src/main/org/bson/types/ObjectId.java#L346) initializes to a random integer.

Does js-bson intentionally not initialize the counter to a random number? If so, why the deviation from the documentation?

Thank you for your time and for creating such a great tool! Cheers :beers:!

PS: I've ran `make test` with no errors. Let me know if you need anything else to do a PR.
