### PR TITLE
add browserify support to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "install" : "(node-gyp rebuild 2> builderror.log) || (exit 0)", 
     "test" : "nodeunit ./test/node && TEST_NATIVE=TRUE nodeunit ./test/node" 
 }
+, "browser": "lib/bson/bson.js"
 , "licenses" :    [ { "type" :  "Apache License, Version 2.0"
                     , "url" :   "http://www.apache.org/licenses/LICENSE-2.0" } ]
 }


### PR DESCRIPTION
This will allow `browserify` to be used directly against the `bson` library without requiring any special configuration.

It should be doing the same thing as the `build_browser.js` file.

Please pull, bump the version, and update the npm so that I can start using this in my project. Thanks!
