### PR TITLE
Print "Failed to load c++ bson extension" to stderr

### DIFF
--- a/ext/index.js
+++ b/ext/index.js
@@ -10,7 +10,7 @@ try {
 	  bson = require('../build/Release/bson');  
 	}	
 } catch(err) {
-	console.log("Failed to load c++ bson extension, using pure JS version");
+	console.error("Failed to load c++ bson extension, using pure JS version");
 	bson = require('../lib/bson/bson');
 }
 


### PR DESCRIPTION
Warning "Failed to load c++ bson extension, using pure JS version" should be printed to stderr instead of stdout.

All diagnostic output should go to stderr. Printing to stdout breaks command line programs, whose output is parsed by other tools.
