### PR TITLE
[fixup] minKey & maxKey toJSON()

### DIFF
--- a/lib/bson/max_key.js
+++ b/lib/bson/max_key.js
@@ -6,8 +6,13 @@
  */
 function MaxKey() {
   if(!(this instanceof MaxKey)) return new MaxKey();
-  
-  this._bsontype = 'MaxKey';  
+
+  this._bsontype = 'MaxKey';
 }
+
+
+MaxKey.prototype.toJSON = function(){
+  return {'$maxKey' : 1};
+};
 
 exports.MaxKey = MaxKey;

--- a/lib/bson/min_key.js
+++ b/lib/bson/min_key.js
@@ -6,8 +6,13 @@
  */
 function MinKey() {
   if(!(this instanceof MinKey)) return new MinKey();
-  
+
   this._bsontype = 'MinKey';
 }
+
+MinKey.prototype.toJSON = function(){
+  return {'$minKey' : 1};
+};
+
 
 exports.MinKey = MinKey;


### PR DESCRIPTION
Just to be consistent with what you see in the mongo shell.

say you're querying `db('config').chunks.find({}, {min: 1, max: 1})` to get a chunk's keyspace.  instead of 

```
keyspace: {"_id":{"_bsontype":"MinKey"}} → {"_id":{"_bsontype":"MaxKey"}}
```

be more human

```
keyspace: {"_id":{"$minxKey":1}} → {"_id":{"$maxKey":1}}
```
