### PR TITLE
Fix #83: don't include offset, etc. in ObjectId

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -43,7 +43,6 @@ var ObjectID = function ObjectID(id) {
     this.id = id;
   }
 
-  this.binId = new Buffer(this.id, 'binary');
   if(ObjectID.cacheHexString) this.__id = this.toHexString();
 };
 


### PR DESCRIPTION
Tests clean upstream against node driver 1.4.3 and mongoose 3.8.9 with this change
