### PR TITLE
Update bson.js

### DIFF
--- a/browser_build/bson.js
+++ b/browser_build/bson.js
@@ -1533,7 +1533,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
         return index;
       } else if(value instanceof Long || value instanceof Timestamp || value['_bsontype'] == 'Long' || value['_bsontype'] == 'Timestamp') {
         // Write the type
-        buffer[index++] = value instanceof Long ? BSON.BSON_DATA_LONG : BSON.BSON_DATA_TIMESTAMP;
+        buffer[index++] = value instanceof Long || value['_bsontype'] == 'Long' ? BSON.BSON_DATA_LONG : BSON.BSON_DATA_TIMESTAMP;
         // Number of written bytes
         var numberOfWrittenBytes = supportsBuffer ? buffer.write(name, index, 'utf8') : writeToTypedArray(buffer, name, index);
         // Encode the name


### PR DESCRIPTION
When I push a message in "field_m" the "t" field is set to Timestamp(0, 0) instead of NumberLong(1401710...) I save the date as NumberLong because this is how other team members need it on Drupal.
"field_m" is an array with elements with this schema:
var MessageSchema = new Schema({
    t: {type: Schema.Types.Long, 'default': Math.round(Date.now() / 1000), required: true},
    u: {type: String, required: true},
    m: {type: String, required: true}
}, {_id: false });

ex:
{...,
 "created" : NumberLong(1401710593),
 "field_m" : [
         {
                 "m" : "test",
                 "u" : "ng0i9bqsubjcbx1orhvxqanpa",
                 "t" : Timestamp(0, 0)
         }
 ],...}
