### PR TITLE
Support .toBSON() returns non object type

### DIFF
--- a/lib/bson/bson.js
+++ b/lib/bson/bson.js
@@ -226,7 +226,12 @@ BSON.calculateObjectSize = function calculateObjectSize(object, serializeFunctio
  */
 function calculateElement(name, value, serializeFunctions) {
   var isBuffer = typeof Buffer !== 'undefined';
-
+  
+  // If we have toBSON defined, override the current object
+  if(value && value.toBSON){
+        value = value.toBSON();
+  }
+  
   switch(typeof value) {
     case 'string':
       return 1 + (!isBuffer ? numberOfBytes(name) : Buffer.byteLength(name, 'utf8')) + 1 + 4 + (!isBuffer ? numberOfBytes(value) : Buffer.byteLength(value, 'utf8')) + 1;
@@ -425,6 +430,12 @@ var supportsBuffer = typeof Buffer != 'undefined';
  * @api private
  */
 var packElement = function(name, value, checkKeys, buffer, index, serializeFunctions) {
+	
+  // If we have toBSON defined, override the current object
+  if(value && value.toBSON){
+        value = value.toBSON();
+  }
+  
   var startIndex = index;
 
   switch(typeof value) {


### PR DESCRIPTION
Added support to serialization when .toBSON() does not returns an object.
