### PR TITLE
added failing tests for ObjectID.isValid

### DIFF
--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1694,6 +1694,7 @@ exports['Should fail to create ObjectID due to illegal hex code'] = function(tes
   test.equal(false, ObjectID.isValid(true));
   test.equal(false, ObjectID.isValid(0));
   test.equal(false, ObjectID.isValid("invalid"));
+  test.equal(false, ObjectID.isValid("zzzzzzzzzzzz"));
   test.equal(false, ObjectID.isValid("zzzzzzzzzzzzzzzzzzzzzzzz"));
   test.equal(true, ObjectID.isValid("000000000000000000000000"));
   test.done();


### PR DESCRIPTION
So basically the whole `ObjectID.isValid` method is messed up. I don't even know what the correct validation code has to look like, since the current code is some of the most confusing code I've seen recently. Instead I added some failing test cases so you can fix it.

``` js
ObjectID.isValid = function isValid(id) {
  if (id != null && 'number' != typeof id && (id.length != 12 && id.length != 24)) {
    return false;
  } else {
    // Check specifically for hex correctness
    if(typeof id == 'string' && id.length == 24) return checkForHexRegExp.test(id);
    return true;
  }
};
```

WAT? Yoda conditions (`'number' != typeof` vs `typeof id == 'string'`), unnecessary parenthesis, two different if/else styles (with and without curly brackets), no comments: this code has it all. Sorry, didn't meant to offend anyone.

I'm not using this module, I just came across someone on twitter having issues with it.
