### PR TITLE
Just remove the js-bson load warning if works fine.

### DIFF
--- a/ext/index.js
+++ b/ext/index.js
@@ -7,7 +7,7 @@ try {
 	} else if(process.platform == "win32" && process.arch == "ia32") {
 	  bson = require('./win32/ia32/bson');  
 	} else {
-	  bson = require('../build/Release/bson');  
+	  bson = require('bson');  
 	}	
 } catch(err) {
 	// Attempt to load the release bson version


### PR DESCRIPTION
First `try` from: `'bson'`, if can not find it then try the path: `'../build/Release/bson'`

Remove the unnecessary js-bson load warning:

```
Failed to load c++ bson extension, using pure JS version
```

Closes #74
