### PR TITLE
Change ObjectID.isValid to reject objects with specific keys

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -246,6 +246,7 @@ ObjectID.isValid = function isValid(id) {
   if(typeof id == 'string') {
     return id.length == 12 || (id.length == 24 && checkForHexRegExp.test(id));
   }
+  return false;
 };
 
 /**

--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -241,12 +241,10 @@ ObjectID.createFromHexString = function createFromHexString (hexString) {
 ObjectID.isValid = function isValid(id) {
   if(id == null) return false;
 
-  if(id != null && 'number' != typeof id && (id.length != 12 && id.length != 24)) {
-    return false;
-  } else {
-    // Check specifically for hex correctness
-    if(typeof id == 'string' && id.length == 24) return checkForHexRegExp.test(id);
+  if(typeof id == 'number')
     return true;
+  if(typeof id == 'string') {
+    return id.length == 12 || (id.length == 24 && checkForHexRegExp.test(id));
   }
 };
 

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1690,6 +1690,7 @@ exports['Should fail to create ObjectID due to illegal hex code'] = function(tes
 
   test.equal(false, ObjectID.isValid(null));
   test.equal(false, ObjectID.isValid({}));
+  test.equal(false, ObjectID.isValid({length: 12}))
   test.equal(false, ObjectID.isValid([]));
   test.equal(false, ObjectID.isValid(true));
   test.equal(true, ObjectID.isValid(0));


### PR DESCRIPTION
Prevent objects with a `length` key of 12 or 24 to be considered valid ObjectIDs.