### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,5 @@
   "test" : "nodeunit ./test/node && TEST_NATIVE=TRUE nodeunit ./test/node"
 }
 , "browser": "lib/bson/bson.js"
-, "licenses" :    [ { "type" :  "Apache License, Version 2.0"
-                    , "url" :   "http://www.apache.org/licenses/LICENSE-2.0" } ]
+, "license": "Apache-2.0"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/