### PR TITLE
ObjectID equality check should return boolean instead of throwing exc…

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -156,10 +156,13 @@ ObjectID.prototype.toJSON = function() {
 * @return {boolean} the result of comparing two ObjectID's
 */
 ObjectID.prototype.equals = function equals (otherID) {
-  if(otherID == null) return false;
-  var id = (otherID instanceof ObjectID || otherID.toHexString)
-    ? otherID.id
-    : ObjectID.createFromHexString(otherID).id;
+  var id;
+  if (otherID != null && (otherID instanceof ObjectID || otherID.toHexString))
+    id = otherID.id;
+  else if (ObjectID.isValid(otherID))
+    id = ObjectID.createFromHexString(otherID).id;
+  else
+    return false;
 
   return this.id === id;
 }

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1742,3 +1742,18 @@ exports['Should correctly deserialize the BSONRegExp type'] = function(test) {
   test.equal('i', doc1.regexp.options);
   test.done();
 }
+
+/**
+ * @ignore
+ */
+exports['Should return boolean for ObjectID equality check'] = function(test) {
+  var id = new ObjectID();
+  test.equal(true, id.equals(new ObjectID(id.toString())));
+  test.equal(true, id.equals(id.toString()));
+  test.equal(false, id.equals('1234567890abcdef12345678'));
+  test.equal(false, id.equals('zzzzzzzzzzzzzzzzzzzzzzzz'));
+  test.equal(false, id.equals('foo'));
+  test.equal(false, id.equals(null));
+  test.equal(false, id.equals(undefined));
+  test.done();
+}


### PR DESCRIPTION
…eption for invalid oid string