### PR TITLE
Double should have an option to check if convert to Number

### DIFF
--- a/lib/bson/parser/deserializer.js
+++ b/lib/bson/parser/deserializer.js
@@ -59,6 +59,7 @@ var deserializeObject = function(buffer, options, isArray) {
   var cacheFunctions = options['cacheFunctions'] == null ? false : options['cacheFunctions'];
   var cacheFunctionsCrc32 = options['cacheFunctionsCrc32'] == null ? false : options['cacheFunctionsCrc32'];
   var promoteLongs = options['promoteLongs'] == null ? true : options['promoteLongs'];
+  var promoteDoubles = options['promoteDoubles'] == null ? true : options['promoteDoubles'];
 	var fieldsAsRaw = options['fieldsAsRaw'] == null ? {} : options['fieldsAsRaw'];
   // Return BSONRegExp objects instead of native regular expressions
   var bsonRegExp = typeof options['bsonRegExp'] == 'boolean' ? options['bsonRegExp'] : false;
@@ -111,7 +112,10 @@ var deserializeObject = function(buffer, options, isArray) {
       object[name] = buffer[index++] | buffer[index++] << 8 | buffer[index++] << 16 | buffer[index++] << 24;
 		} else if(elementType == BSON.BSON_DATA_NUMBER) {
       // Decode the double value
-      object[name] = readIEEE754(buffer, index, 'little', 52, 8);
+      object[name] = Double(readIEEE754(buffer, index, 'little', 52, 8));
+      if(promoteDoubles){
+        object[name] = object[name].value
+      }
       // Update the index
       index = index + 8;
 		} else if(elementType == BSON.BSON_DATA_DATE) {


### PR DESCRIPTION
The problem is:
    Int32 1 -> 1 (number in javascript)
    Double 1.0 -> 1 (number in javascript)
Now there is no way to find if origin value is a double or int32 value. This is good when I just want to read the value, but not good when I want to change value  and set it back to database.

I find that, you add an option 'promoteLongs' to solve kind of problem of Int32 and Int64.
So now I want to add an option like 'promoteDoubles' to solve this problem.