### PR TITLE
Add bower.json to this package to enable usage as a bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "bson",
+  "description": "A bson parser for node.js and the browser",
+  "keywords": [
+    "mongodb",
+    "bson",
+    "parser"
+  ],
+  "author": "Christian Amor Kvalheim <christkv@gmail.com>",
+  "main": "./browser_build/bson.js",
+  "license": "Apache-2.0",
+  "moduleType": [
+    "globals",
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "alternate_parsers",
+    "benchmarks",
+    "bower_components",
+    "node_modules",
+    "test",
+    "tools"
+  ]
+}


### PR DESCRIPTION
This fixes #135. The main benefit of this is the `main` field, such that build tools (wiredep) can automatically insert a bson dependency in your html.