### PR TITLE
Fixed browser pid sometimes set greater than 0xFFFF

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -114,7 +114,7 @@ ObjectID.prototype.generate = function(time) {
   var time4Bytes = BinaryParser.encodeInt(time, 32, true, true);
   /* for time-based ObjectID the bytes following the time will be zeroed */
   var machine3Bytes = BinaryParser.encodeInt(MACHINE_ID, 24, false);
-  var pid2Bytes = BinaryParser.fromShort(typeof process === 'undefined' ? Math.floor(Math.random() * 100000) : process.pid % 0xFFFF);
+  var pid2Bytes = BinaryParser.fromShort((typeof process === 'undefined' ? Math.floor(Math.random() * 100000) : process.pid) % 0xFFFF);
   var index3Bytes = BinaryParser.encodeInt(this.get_inc(), 24, false, true);
 
   return time4Bytes + machine3Bytes + pid2Bytes + index3Bytes;


### PR DESCRIPTION
As @williamkapke mentioned in https://github.com/williamkapke/bson-objectid/issues/6#issuecomment-161053746, there's a small mistake that could possibly cause the pid in a browser environment to be set to a value greater than 0xFFFF.

In bson-objectid, it caused it to incorrectly generate 26-character ObjectID's. I'm not sure if it causes a problem here but I'm making a PR with the fix anyway to be safe.