### PR TITLE
Remove unnecessary dot slashes in paths

### DIFF
--- a/lib/bson/index.js
+++ b/lib/bson/index.js
@@ -17,7 +17,7 @@ try {
   , './symbol'
   , './timestamp'
   , './long'].forEach(function (path) {
-  	var module = require('./' + path);
+  	var module = require(path);
   	for (var i in module) {
   		exports[i] = module[i];
     }
@@ -40,8 +40,8 @@ exports.pure = function() {
     , './symbol'
     , './timestamp'
     , './long'
-    , '././bson'].forEach(function (path) {
-    	var module = require('./' + path);
+    , './bson'].forEach(function (path) {
+    	var module = require(path);
     	for (var i in module) {
     		classes[i] = module[i];
       }
@@ -68,7 +68,7 @@ exports.native = function() {
     , './timestamp'
     , './long'
   ].forEach(function (path) {
-      var module = require('./' + path);
+      var module = require(path);
       for (var i in module) {
         classes[i] = module[i];
       }


### PR DESCRIPTION
https://github.com/mongodb/js-bson/issues/122
https://github.com/Automattic/mongoose/issues/3713
https://github.com/johnpapa/ng-demos/issues/27 (a similar problem)

Seems like these dot slashes are unneccesary. Multiple dot-slashes (`./././`) should be equal to single (`./`), but they are the cause of broken builds if webpack is used.

```
caulfield-osx:test caulfield$ node build/server.js
/Users/caulfield/www/test/build/server.js:35054
		return map[req] || (function() { throw new Error("Cannot find module '" + req + "'.") }());
		                                 ^

Error: Cannot find module '././binary_parser'.
    at /Users/caulfield/www/test/build/server.js:35054:42
    at webpackContextResolve (/Users/caulfield/www/test/build/server.js:35054:90)
    at webpackContext (/Users/caulfield/www/test/build/server.js:35051:30)
    at /Users/caulfield/www/test/build/server.js:628:42
    at Array.forEach (native)
    at Object.<anonymous> (/Users/caulfield/www/test/build/server.js:627:16)
    at __webpack_require__ (/Users/caulfield/www/test/build/server.js:21:30)
    at Object.<anonymous> (/Users/caulfield/www/test/build/server.js:914:13)
    at __webpack_require__ (/Users/caulfield/www/test/build/server.js:21:30)
    at Object.<anonymous> (/Users/caulfield/www/test/build/server.js:113284:17)
```

Is there any reason why these dot slashes are still needed?

Tests: https://travis-ci.org/VodkaBears/js-bson/builds/100598622
Mac OS X El Captain, node.js 4.2.4: tests are green too.
