### PR TITLE
fix(ObjectID): isValid(new ObjectID()) returns true

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -251,6 +251,9 @@ ObjectID.isValid = function isValid(id) {
   if(typeof id == 'string') {
     return id.length == 12 || (id.length == 24 && checkForHexRegExp.test(id));
   }
+  if(id instanceof ObjectID) {
+    return true;
+  }
   return false;
 };
 

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1723,6 +1723,7 @@ exports['Should fail to create ObjectID due to illegal hex code'] = function(tes
   test.equal(true, ObjectID.isValid("zzzzzzzzzzzz"));
   test.equal(false, ObjectID.isValid("zzzzzzzzzzzzzzzzzzzzzzzz"));
   test.equal(true, ObjectID.isValid("000000000000000000000000"));
+  test.equal(true, ObjectID.isValid(new ObjectID("thisis12char")));
   test.done();
 }
 


### PR DESCRIPTION
The fact that `ObjectID.isValid(new ObjectID());` returns false seems a little weird, re: https://github.com/Automattic/mongoose/issues/1959#issuecomment-170195451