### PR TITLE
When deserializing an arbitary index in a buffer, stay relative to the index

### DIFF
--- a/lib/bson/parser/deserializer.js
+++ b/lib/bson/parser/deserializer.js
@@ -18,7 +18,7 @@ var deserialize = function(buffer, options, isArray) {
 	options = options == null ? {} : options;
 	var index = options && options.index ? options.index : 0;
 	// Read the document size
-  var size = buffer[index++] | buffer[index++] << 8 | buffer[index++] << 16 | buffer[index++] << 24;
+  var size = buffer[index] | buffer[index+1] << 8 | buffer[index+2] << 16 | buffer[index+3] << 24;
 
 	// Ensure buffer is valid size
   if(size < 5 || buffer.length < size) {
@@ -26,12 +26,12 @@ var deserialize = function(buffer, options, isArray) {
 	}
 
 	// Illegal end value
-	if(buffer[size - 1] != 0) {
+	if(buffer[index + size - 1] != 0) {
 		throw new Error("One object, sized correctly, with a spot for an EOO, but the EOO isn't 0x00");
 	}
 
 	// Start deserializtion
-	return deserializeObject(buffer, index - 4, options, isArray);
+	return deserializeObject(buffer, index, options, isArray);
 }
 
 var deserializeObject = function(buffer, index, options, isArray) {


### PR DESCRIPTION
In the event that you are providing a `Buffer` and non-zero `startIndex` to `deserialize` or `deserializeStream`, if the `startIndex` points to a valid BSON document, it will incorrectly error out saying `"One object, sized correctly, with a spot for an EOO, but the EOO isn't 0x00"`

This PR fixes that.