### PR TITLE
Fix "TypeError: data.copy is not a function" in Electron

### DIFF
--- a/lib/bson/binary.js
+++ b/lib/bson/binary.js
@@ -2,7 +2,10 @@
  * Module dependencies.
  * @ignore
  */
-if(typeof window === 'undefined') {
+
+// Test if we're in Node via presence of "global" not absence of "window"
+// to support hybrid environments like Electron
+if(typeof global !== 'undefined') {
   var Buffer = require('buffer').Buffer; // TODO just use global Buffer
 }
 


### PR DESCRIPTION
Fix for #152. Hopefully makes authentication possible when using the driver within Electron.