### PR TITLE
Support isValid and new ObjectId accross different versions and instances of the bson package

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -27,7 +27,8 @@ var checkForHexRegExp = new RegExp("^[0-9a-fA-F]{24}$");
 */
 var ObjectID = function ObjectID(id) {
   if(!(this instanceof ObjectID)) return new ObjectID(id);
-  if((id instanceof ObjectID)) return id;
+  // Duck-typing to support ObjectId from different npm packages
+  if((id instanceof ObjectID) || (id && id.toHexString)) return id;
 
   this._bsontype = 'ObjectID';
   var __id = null;
@@ -253,6 +254,10 @@ ObjectID.isValid = function isValid(id) {
   }
   if(id instanceof ObjectID) {
     return true;
+  }
+  // Duck-Typing detection of ObjectId like objects
+  if(id.toHexString) {
+    return id.id.length == 12 || (id.id.length == 24 && checkForHexRegExp.test(id.id));
   }
   return false;
 };

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1735,6 +1735,19 @@ exports['Should fail to create ObjectID due to illegal hex code'] = function(tes
   test.equal(false, ObjectID.isValid("zzzzzzzzzzzzzzzzzzzzzzzz"));
   test.equal(true, ObjectID.isValid("000000000000000000000000"));
   test.equal(true, ObjectID.isValid(new ObjectID("thisis12char")));
+
+  var tmp = new ObjectID();
+  // Cloning tmp so that instanceof fails to fake import from different version/instance of the same npm package
+  var objectIdLike = {
+    id: tmp.id,
+    toHexString: function() {
+      return tmp.toHexString();
+    }
+  };
+  test.equal(true, tmp.equals(objectIdLike));
+  test.equal(true, tmp.equals(new ObjectId(objectIdLike)));
+  test.equal(true, ObjectID.isValid(objectIdLike));
+
   test.done();
 }
 


### PR DESCRIPTION
This PR uses duck-typing to better support `new ObjectID` and `isValid`. It uses logic already present in the `equals` implementation and brings it in the `constructor` and the `isValid`.

The main reason why this is needed is to support the following case:
```
var m1 = require('mongodb')
var m2 = require('./node_modules/MODULE/node_modules/mongodb')
var hash = '56facc09cb986a0051a19c10';

m1.ObjectID.isValid(new m2.ObjectID(hash)) // Returns false! Should return true!
new m1.ObjectId(new m2.ObjectId(hash)) // Throws it should just return an ObjectId
```