### PR TITLE
fix(ObjectID): isValid(new ObjectID()) returns true - Improve duck-typing in constructor

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -27,8 +27,7 @@ var checkForHexRegExp = new RegExp("^[0-9a-fA-F]{24}$");
 */
 var ObjectID = function ObjectID(id) {
   if(!(this instanceof ObjectID)) return new ObjectID(id);
-  // Duck-typing to support ObjectId from different npm packages
-  if((id instanceof ObjectID) || (id && id.toHexString)) return id;
+  if((id instanceof ObjectID)) return id;
 
   this._bsontype = 'ObjectID';
   var __id = null;
@@ -45,6 +44,9 @@ var ObjectID = function ObjectID(id) {
   } else if(id != null && id.length === 12) {
     // assume 12 byte string
     this.id = id;
+  } else if(id != null && id.toHexString) {
+    // Duck-typing to support ObjectId from different npm packages
+    return id;
   }
 
   if(ObjectID.cacheHexString) this.__id = this.toHexString();


### PR DESCRIPTION
Improving previous PR to take advantage of the validation already done in the `isValid`