### PR TITLE
ObjectID(x) where is an ObjectID-like makes a useless memory allocation

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -26,9 +26,9 @@ var checkForHexRegExp = new RegExp("^[0-9a-fA-F]{24}$");
 * @return {ObjectID} instance of ObjectID.
 */
 var ObjectID = function ObjectID(id) {
-  if(!(this instanceof ObjectID)) return new ObjectID(id);
   // Duck-typing to support ObjectId from different npm packages
   if((id instanceof ObjectID) || (id && id.toHexString)) return id;
+  if(!(this instanceof ObjectID)) return new ObjectID(id);
 
   this._bsontype = 'ObjectID';
   var __id = null;


### PR DESCRIPTION
This is a rather common scenario and perf gain is around 3x - 4x faster