### PR TITLE
Fix error - hex is not a function

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -14,7 +14,13 @@ var hasBufferType = false;
 
 // Check if buffer exists
 try {
-  if(Buffer && Buffer.from) hasBufferType = true;
+  if(Buffer && Buffer.from) {
+    // Buffer.from API parameters vary in different Node.js versions. So,
+    // existence of Buffer.from function is not enough. Check if the API we use
+    // are defined.
+    Buffer.from('1234', 'hex');
+    hasBufferType = true;
+  }
 } catch(err) {};
 
 /**

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -42,7 +42,12 @@ exports['should correctly create ObjectId from uppercase hexstring'] = function(
  * @ignore
  */
 exports['should correctly create ObjectId from Buffer'] = function(test) {
-  if(!Buffer.from) return test.done();
+  try {
+    Buffer.from('1234', 'hex');
+  } catch (err) {
+    return test.done();
+  }
+
   var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
   var b = new ObjectId(Buffer.from(a, 'hex'));
   var c = b.equals(a); // => false


### PR DESCRIPTION
Fixes issue #204.

`Buffer.from` API parameters vary in different Node.js versions. So,
existence of `Buffer.from` function is not enough. Check if the API we use
are defined.