### PR TITLE
Maintain uniqueness in a docker environment

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -137,7 +137,7 @@ ObjectID.prototype.generate = function(time) {
   }
 
   // Use pid
-  var pid = (typeof process === 'undefined' ? Math.floor(Math.random() * 100000) : process.pid) % 0xFFFF;
+  var pid = (typeof process === 'undefined' || process.pid === 1 ? Math.floor(Math.random() * 100000) : process.pid) % 0xFFFF;
   var inc = this.get_inc();
   // Buffer used
   var buffer = new Buffer(12);


### PR DESCRIPTION
Among the values to guarantee the uniqueness of ObjectID is pid.
However, in a docker environment, the pid of most processes has a value of 1.

If pid is 1, it uses random value.

https://github.com/mongodb/js-bson/issues/212