### PR TITLE
fix(serializeWithBufferAndIndex): write documents to start of intermediate buffer

### DIFF
--- a/lib/bson/bson.js
+++ b/lib/bson/bson.js
@@ -96,7 +96,7 @@ BSON.prototype.serializeWithBufferAndIndex = function(object, finalBuffer, optio
     buffer,
     object,
     checkKeys,
-    startIndex || 0,
+    0,
     0,
     serializeFunctions,
     ignoreUndefined
@@ -104,7 +104,7 @@ BSON.prototype.serializeWithBufferAndIndex = function(object, finalBuffer, optio
   buffer.copy(finalBuffer, startIndex, 0, serializationIndex);
 
   // Return the index
-  return serializationIndex - 1;
+  return startIndex + serializationIndex - 1;
 };
 
 /**

--- a/test/node/serialize_with_buffer_tests.js
+++ b/test/node/serialize_with_buffer_tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var createBSON = require('../utils'),
+let createBSON = require('../utils'),
   expect = require('chai').expect;
 
 describe('serializeWithBuffer', function() {
@@ -26,6 +26,42 @@ describe('serializeWithBuffer', function() {
     expect({ a: 1 }).to.deep.equal(doc);
     doc = bson.deserialize(b.slice(12, 24));
     expect({ a: 1 }).to.deep.equal(doc);
+    done();
+  });
+
+  it('correctly serialize 3 different docs into buffer using serializeWithBufferAndIndex', function(
+    done
+  ) {
+    const MAXSIZE = 1024 * 1024 * 17;
+    var bson = createBSON();
+    let bf = new Buffer(MAXSIZE);
+
+    const data = [
+      {
+        a: 1,
+        b: new Date('2019-01-01')
+      },
+      {
+        a: 2,
+        b: new Date('2019-01-02')
+      },
+      {
+        a: 3,
+        b: new Date('2019-01-03')
+      }
+    ];
+
+    let idx = 0;
+    data.forEach(item => {
+      idx =
+        bson.serializeWithBufferAndIndex(item, bf, {
+          index: idx
+        }) + 1;
+    });
+
+    expect(bson.deserialize(bf.slice(0, 23))).to.deep.equal(data[0]);
+    expect(bson.deserialize(bf.slice(23, 46))).to.deep.equal(data[1]);
+    expect(bson.deserialize(bf.slice(46, 69))).to.deep.equal(data[2]);
     done();
   });
 });


### PR DESCRIPTION
We first serialize the object into a buffer `buffer`, and then copy the object into `finalBuffer`. The issue here was that we serialized the object into `buffer` beginning at startIndex, but then copied into `finalBuffer` beginning at 0, meaning data previously written to `buffer` would be copied into 
`finalBuffer` rather than the desired document. 
(The existing test did not catch this because it used two identical documents.) 

This fix works by just always writes into `buffer` starting at 0. 