### PR TITLE
fix(Decimal128): update toString and fromString methods to correctly …

### DIFF
--- a/lib/bson/decimal128.js
+++ b/lib/bson/decimal128.js
@@ -325,8 +325,6 @@ Decimal128.fromString = function(string) {
     }
   }
 
-  if (significantDigits > 34) invalidErr(string, 'Too many digits to represent accurately');
-
   // Normalization of exponent
   // Correct exponent based on radix position, and shift significand as needed
   // to represent user input
@@ -392,7 +390,12 @@ Decimal128.fromString = function(string) {
     // If we have seen a radix point, 'string' is 1 longer than we have
     // documented with ndigits_read, so inc the position of the first nonzero
     // digit and the position that digits are read to.
-    if (sawRadix && exponent === EXPONENT_MIN) {
+    if (sawRadix) {
+      firstNonZero = firstNonZero + 1;
+      endOfString = endOfString + 1;
+    }
+    // if negative, we need to increment again to account for - sign at start.
+    if (isNegative) {
       firstNonZero = firstNonZero + 1;
       endOfString = endOfString + 1;
     }
@@ -431,12 +434,8 @@ Decimal128.fromString = function(string) {
               );
             }
           }
-        } else {
-          invalidErr(string, 'overflow');
         }
       }
-    } else {
-      invalidErr(string, 'overflow');
     }
   }
 
@@ -722,9 +721,19 @@ Decimal128.prototype.toString = function() {
   // has trailing zeros.  However, we *cannot* output these trailing zeros,
   // because doing so would change the precision of the value, and would
   // change stored data if the string converted number is round tripped.
-
   if (scientific_exponent >= 34 || scientific_exponent <= -7 || exponent > 0) {
     // Scientific format
+
+    // if there are too many significant digits, we should just be treating numbers
+    // as + or - 0 and using the non-scientific exponent (this is for the "invalid
+    // representation should be treated as 0/-0" spec cases in decimal128-1.json)
+    if (significand_digits > 34) {
+      string.push(0);
+      if (exponent > 0) string.push('E+' + exponent);
+      else if (exponent < 0) string.push('E' + exponent);
+      return string.join('');
+    }
+
     string.push(significand[index++]);
     significand_digits = significand_digits - 1;
 


### PR DESCRIPTION
…handle the case of too many significant digits. discovered these issues when using js-bson in mongodb-extjson. 

**for fromString**: I realized that we were incorrectly tracking firstNonZero and endOfString (not accounting for negative signs). this led to incorrect handling of [one test case](https://github.com/mongodb/specifications/blob/c6d7ac82cc48800171678b9515c92d69d5bebbcd/source/bson-corpus/tests/decima128-4.json#L71) . I also removed the check for exponent === EXPONENT_MIN because regardless of the exponent value we need to be accounting for the presence of radix and negative signs.... not sure what that was about. 
the removed errors (lines 435, 439)  I had added at some point in updating js-bson to catch some of the parseError cases. but it appears that they were falsely catching some valid string inputs, and that the parseErrors are caught elsewhere by checks I added after these ones. 

**for toString**: there are certain values that, while they can accurately be stored as Decimal128 objects, they cannot be accurately represented in the specified Decimal128 string format we use (described [here](https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst#from-string-representation)). for example, [this test](https://github.com/mongodb/js-bson/blob/0e20e4b403a235afa0fabb155a0752529739f243/test/node/specs/bson-corpus/decimal128-1.json#L53) is one such case. the added code handles these special cases and outputs strings matching those in the corpus. 



