### PR TITLE
Added an option to set the min size of the serialization buffer

### DIFF
--- a/lib/bson/bson.js
+++ b/lib/bson/bson.js
@@ -24,10 +24,12 @@ var deserialize = require('./parser/deserializer'),
  * @ignore
  * @api private
  */
-// Max Size
+// Default Max Size
 var MAXSIZE = 1024 * 1024 * 17;
-// Max Document Buffer size
+
+// Current Internal Temporary Serialization Buffer
 var buffer = new Buffer(MAXSIZE);
+var currentBufferSize = MAXSIZE;
 
 var BSON = function() {};
 
@@ -38,6 +40,7 @@ var BSON = function() {};
  * @param {Boolean} [options.checkKeys] the serializer will check if keys are valid.
  * @param {Boolean} [options.serializeFunctions=false] serialize the javascript functions **(default:false)**.
  * @param {Boolean} [options.ignoreUndefined=true] ignore undefined fields **(default:true)**.
+ * @param {Number} [options.minInternalBufferSize=1024*1024*17] minimum size of the internal temporary serialization buffer **(default:1024*1024*17)**.
  * @return {Buffer} returns the Buffer object containing the serialized object.
  * @api public
  */
@@ -49,6 +52,14 @@ BSON.prototype.serialize = function serialize(object, options) {
     typeof options.serializeFunctions === 'boolean' ? options.serializeFunctions : false;
   var ignoreUndefined =
     typeof options.ignoreUndefined === 'boolean' ? options.ignoreUndefined : true;
+  var minInternalBufferSize =
+    typeof options.minInternalBufferSize === 'number' ? options.minInternalBufferSize : MAXSIZE;
+  
+  // Resize the internal serialization buffer if needed
+  if (currentBufferSize < minInternalBufferSize) {
+    currentBufferSize = minInternalBufferSize;
+    buffer = new Buffer(currentBufferSize);
+  }
 
   // Attempt to serialize
   var serializationIndex = serializer(
@@ -93,7 +104,7 @@ BSON.prototype.serializeWithBufferAndIndex = function(object, finalBuffer, optio
 
   // Attempt to serialize
   var serializationIndex = serializer(
-    buffer,
+    finalBuffer,
     object,
     checkKeys,
     startIndex || 0,
@@ -101,7 +112,6 @@ BSON.prototype.serializeWithBufferAndIndex = function(object, finalBuffer, optio
     serializeFunctions,
     ignoreUndefined
   );
-  buffer.copy(finalBuffer, startIndex, 0, serializationIndex);
 
   // Return the index
   return serializationIndex - 1;


### PR DESCRIPTION
Added an option to set the min size of the temporary serialization buffer, plus added an optimization so a buffer is not copied after serialization when not needed.