### PR TITLE
Optimization for serializeWithBufferAndIndex

### DIFF
--- a/lib/bson/bson.js
+++ b/lib/bson/bson.js
@@ -93,7 +93,7 @@ BSON.prototype.serializeWithBufferAndIndex = function(object, finalBuffer, optio
 
   // Attempt to serialize
   var serializationIndex = serializer(
-    buffer,
+    finalBuffer,
     object,
     checkKeys,
     startIndex || 0,
@@ -101,7 +101,6 @@ BSON.prototype.serializeWithBufferAndIndex = function(object, finalBuffer, optio
     serializeFunctions,
     ignoreUndefined
   );
-  buffer.copy(finalBuffer, startIndex, 0, serializationIndex);
 
   // Return the index
   return serializationIndex - 1;


### PR DESCRIPTION
Removed an unnecessary copy to the internal buffer and then back to the final buffer when using serializeWithBufferAndIndex