### PR TITLE
use the more specific `TypeError` objects for function parameters errors.

### DIFF
--- a/alternate_parsers/bson.js
+++ b/alternate_parsers/bson.js
@@ -526,7 +526,7 @@ BSON.serializeWithBufferAndIndex = function serializeWithBufferAndIndex(
  */
 var serializeObject = function(object, checkKeys, buffer, index, serializeFunctions) {
   if (object.toBSON) {
-    if (typeof object.toBSON !== 'function') throw new Error('toBSON is not a function');
+    if (typeof object.toBSON !== 'function') throw new TypeError('toBSON is not a function');
     object = object.toBSON();
     if (object != null && typeof object !== 'object')
       throw new Error('toBSON function did not return an object');
@@ -1289,7 +1289,7 @@ var packElement = function(name, value, checkKeys, buffer, index, serializeFunct
 BSON.serialize = function(object, checkKeys, asBuffer, serializeFunctions) {
   // Throw error if we are trying serialize an illegal type
   if (object == null || typeof object !== 'object' || Array.isArray(object))
-    throw new Error('Only javascript objects supported');
+    throw new TypeError('Only javascript objects supported');
 
   // Emoty target buffer
   var buffer = null;

--- a/lib/bson/binary.js
+++ b/lib/bson/binary.js
@@ -52,7 +52,7 @@ function Binary(buffer, subType) {
       ) {
         this.buffer = writeStringToArray(buffer);
       } else {
-        throw new Error('only String, Buffer, Uint8Array or Array accepted');
+        throw new TypeError('only String, Buffer, Uint8Array or Array accepted');
       }
     } else {
       this.buffer = buffer;
@@ -80,9 +80,9 @@ function Binary(buffer, subType) {
 Binary.prototype.put = function put(byte_value) {
   // If it's a string and a has more than one character throw an error
   if (byte_value['length'] != null && typeof byte_value !== 'number' && byte_value.length !== 1)
-    throw new Error('only accepts single character String, Uint8Array or Array');
+    throw new TypeError('only accepts single character String, Uint8Array or Array');
   if ((typeof byte_value !== 'number' && byte_value < 0) || byte_value > 255)
-    throw new Error('only accepts number in a valid unsigned byte range 0-255');
+    throw new TypeError('only accepts number in a valid unsigned byte range 0-255');
 
   // Decode the byte value once
   var decoded_byte = null;

--- a/lib/bson/decimal128.js
+++ b/lib/bson/decimal128.js
@@ -142,7 +142,7 @@ var lessThan = function(left, right) {
 };
 
 var invalidErr = function(string, message) {
-  throw new Error('"${string}" not a valid Decimal128 string - ' + message);
+  throw new TypeError('"${string}" not a valid Decimal128 string - ' + message);
 };
 
 /**
@@ -210,7 +210,7 @@ Decimal128.fromString = function(string) {
   // TODO: implementing a custom parsing for this, or refactoring the regex would yield
   //       further gains.
   if (string.length >= 7000) {
-    throw new Error('' + string + ' not a valid Decimal128 string');
+    throw new TypeError('' + string + ' not a valid Decimal128 string');
   }
 
   // Results
@@ -220,7 +220,7 @@ Decimal128.fromString = function(string) {
 
   // Validate the string
   if ((!stringMatch && !infMatch && !nanMatch) || string.length === 0) {
-    throw new Error('' + string + ' not a valid Decimal128 string');
+    throw new TypeError('' + string + ' not a valid Decimal128 string');
   }
 
   if (stringMatch) {
@@ -291,7 +291,7 @@ Decimal128.fromString = function(string) {
     index = index + 1;
   }
 
-  if (sawRadix && !nDigitsRead) throw new Error('' + string + ' not a valid Decimal128 string');
+  if (sawRadix && !nDigitsRead) throw new TypeError('' + string + ' not a valid Decimal128 string');
 
   // Read exponent if exists
   if (string[index] === 'e' || string[index] === 'E') {

--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -50,7 +50,7 @@ function ObjectID(id) {
 
   // Throw an error if it's not a valid setup
   if (!valid && id != null) {
-    throw new Error(
+    throw new TypeError(
       'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
     );
   } else if (valid && typeof id === 'string' && id.length === 24 && hasBufferType) {
@@ -64,7 +64,7 @@ function ObjectID(id) {
     // Duck-typing to support ObjectId from different npm packages
     return id;
   } else {
-    throw new Error(
+    throw new TypeError(
       'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
     );
   }
@@ -92,7 +92,7 @@ ObjectID.prototype.toHexString = function() {
 
   var hexString = '';
   if (!this.id || !this.id.length) {
-    throw new Error(
+    throw new TypeError(
       'invalid ObjectId, ObjectId.id must be either a string or a Buffer, but is [' +
         JSON.stringify(this.id) +
         ']'
@@ -302,7 +302,7 @@ var convertToHex = function(bytes) {
 ObjectID.createFromHexString = function createFromHexString(string) {
   // Throw an error if it's not a valid setup
   if (typeof string === 'undefined' || (string != null && string.length !== 24)) {
-    throw new Error(
+    throw new TypeError(
       'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
     );
   }

--- a/lib/bson/parser/serializer.js
+++ b/lib/bson/parser/serializer.js
@@ -286,7 +286,7 @@ var serializeObjectId = function(buffer, key, value, index, isArray) {
   } else if (value.id && value.id.copy) {
     value.id.copy(buffer, index, 0, 12);
   } else {
-    throw new Error('object [' + JSON.stringify(value) + '] is not a valid ObjectId');
+    throw new TypeError('object [' + JSON.stringify(value) + '] is not a valid ObjectId');
   }
 
   // Ajust index
@@ -684,7 +684,7 @@ var serializeInto = function serializeInto(
 
       // Is there an override value
       if (value && value.toBSON) {
-        if (typeof value.toBSON !== 'function') throw new Error('toBSON is not a function');
+        if (typeof value.toBSON !== 'function') throw new TypeError('toBSON is not a function');
         value = value.toBSON();
       }
 
@@ -863,10 +863,10 @@ var serializeInto = function serializeInto(
   } else {
     // Did we provide a custom serialization method
     if (object.toBSON) {
-      if (typeof object.toBSON !== 'function') throw new Error('toBSON is not a function');
+      if (typeof object.toBSON !== 'function') throw new TypeError('toBSON is not a function');
       object = object.toBSON();
       if (object != null && typeof object !== 'object')
-        throw new Error('toBSON function did not return an object');
+        throw new TypeError('toBSON function did not return an object');
     }
 
     // Iterate over all the keys
@@ -874,7 +874,7 @@ var serializeInto = function serializeInto(
       value = object[key];
       // Is there an override value
       if (value && value.toBSON) {
-        if (typeof value.toBSON !== 'function') throw new Error('toBSON is not a function');
+        if (typeof value.toBSON !== 'function') throw new TypeError('toBSON is not a function');
         value = value.toBSON();
       }
 


### PR DESCRIPTION
[this PR is a rebase (and update) of PR #157]

When constructing a new `ObjectId` object, the passed id value is validated for conversion to an hex string.
This is just fine, however a generic Error object is thrown when this validation fails.
Tracking the error then becomes unconvenient.
From official [Joyent's design patterns for errors](https://www.joyent.com/developers/node/design/errors), it is suggested that:

> 3. Use the Error's name property to distinguish errors programmatically.
>    When you need to figure out what kind of error this is, use the name property.
>    Built-in JavaScript names you may want to reuse include "RangeError"
>    (an argument is outside of its valid range) and "TypeError" (an argument has the wrong type).
>    For HTTP errors, it's common to use the RFC-given status text to name the error, like
>    "BadRequestError" or "ServiceUnavailableError".

This PR uses the [`TypeError` class](https://nodejs.org/api/errors.html#errors_class_typeerror) instead of the generic `Error` object.
Because `TypeError` is a subclass of `Error`, all existing code should continue to work flawlessly and new code can more easily track an invalid argument error.
