### PR TITLE
fix(bson): fix custom inspect property

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -1,3 +1,6 @@
+// Custom inspect property name / symbol.
+var inspect = 'inspect';
+
 /**
  * Machine id.
  *
@@ -13,7 +16,10 @@ var checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
 
 // Check if buffer exists
 try {
-  if (Buffer && Buffer.from) var hasBufferType = true;
+  if (Buffer && Buffer.from) {
+    var hasBufferType = true;
+    inspect = require('util').inspect.custom || 'inspect';
+  }
 } catch (err) {
   hasBufferType = false;
 }
@@ -196,7 +202,7 @@ ObjectID.prototype.toString = function(format) {
 * @return {String} return the 24 byte hex string representation.
 * @ignore
 */
-ObjectID.prototype.inspect = ObjectID.prototype.toString;
+ObjectID.prototype[inspect] = ObjectID.prototype.toString;
 
 /**
 * Converts to its JSON representation.

--- a/lib/bson/symbol.js
+++ b/lib/bson/symbol.js
@@ -1,3 +1,6 @@
+// Custom inspect property name / symbol.
+var inspect = Buffer ? require('util').inspect.custom || 'inspect' : 'inspect';
+
 /**
  * A class representation of the BSON Symbol type.
  *
@@ -32,7 +35,7 @@ Symbol.prototype.toString = function() {
 /**
  * @ignore
  */
-Symbol.prototype.inspect = function() {
+Symbol.prototype[inspect] = function() {
   return this.value;
 };
 


### PR DESCRIPTION
The currently used custom inspect way is deprecated and was removed
in Node.js 11.0.0-pre. This should fix that.