### PR TITLE
Deserializing to custom targets (classes)

### DIFF
--- a/lib/bson/parser/deserializer.js
+++ b/lib/bson/parser/deserializer.js
@@ -38,7 +38,7 @@ var deserialize = function(buffer, options, isArray) {
   return deserializeObject(buffer, index, options, isArray);
 };
 
-var deserializeObject = function(buffer, index, options, isArray) {
+var deserializeObject = function(buffer, index, options, isArray, target) {
   var evalFunctions = options['evalFunctions'] == null ? false : options['evalFunctions'];
   var cacheFunctions = options['cacheFunctions'] == null ? false : options['cacheFunctions'];
   var cacheFunctionsCrc32 =
@@ -73,11 +73,13 @@ var deserializeObject = function(buffer, index, options, isArray) {
   if (size < 5 || size > buffer.length) throw new Error('corrupt bson message');
 
   // Create holding object
-  var object = isArray ? [] : {};
+  var object = (target instanceof Function) ? new target() : (isArray ? [] : {});
   // Used for arrays to skip having to perform utf8 decoding
   var arrayIndex = 0;
 
   var done = false;
+
+  if (isArray && target) target = target['$'];
 
   // While we have more left data left keep parsing
   // while (buffer[index + 1] !== 0) {
@@ -97,6 +99,9 @@ var deserializeObject = function(buffer, index, options, isArray) {
     // If are at the end of the buffer there is a problem with the document
     if (i >= buffer.length) throw new Error('Bad BSON Document: illegal CString');
     var name = isArray ? arrayIndex++ : buffer.toString('utf8', index, i);
+
+	  if (name === 'firstBatch' || name === 'nextBatch') target = {$: options.target};
+	  else if (!isArray && target) target = target['$' + name];
 
     index = i + 1;
 
@@ -164,7 +169,7 @@ var deserializeObject = function(buffer, index, options, isArray) {
       if (raw) {
         object[name] = buffer.slice(index, index + objectSize);
       } else {
-        object[name] = deserializeObject(buffer, _index, options, false);
+        object[name] = deserializeObject(buffer, _index, options, false, target);
       }
 
       index = index + objectSize;
@@ -187,7 +192,7 @@ var deserializeObject = function(buffer, index, options, isArray) {
         arrayOptions['raw'] = true;
       }
 
-      object[name] = deserializeObject(buffer, _index, arrayOptions, true);
+      object[name] = deserializeObject(buffer, _index, arrayOptions, true, target);
       index = index + objectSize;
 
       if (buffer[index - 1] !== 0) throw new Error('invalid array terminator byte');

--- a/lib/bson/parser/deserializer.js
+++ b/lib/bson/parser/deserializer.js
@@ -78,8 +78,9 @@ var deserializeObject = function(buffer, index, options, isArray, target) {
   var arrayIndex = 0;
 
   var done = false;
+  var newTarget = null;
 
-  if (isArray && target) target = target['$'];
+  if (isArray && target) newTarget = target['$'];
 
   // While we have more left data left keep parsing
   // while (buffer[index + 1] !== 0) {
@@ -100,8 +101,8 @@ var deserializeObject = function(buffer, index, options, isArray, target) {
     if (i >= buffer.length) throw new Error('Bad BSON Document: illegal CString');
     var name = isArray ? arrayIndex++ : buffer.toString('utf8', index, i);
 
-	  if (name === 'firstBatch' || name === 'nextBatch') target = {$: options.target};
-	  else if (!isArray && target) target = target['$' + name];
+	  if (name === 'firstBatch' || name === 'nextBatch') newTarget = {$: options.target};
+	  else if (!isArray && target) newTarget = target['$' + name];
 
     index = i + 1;
 
@@ -169,7 +170,7 @@ var deserializeObject = function(buffer, index, options, isArray, target) {
       if (raw) {
         object[name] = buffer.slice(index, index + objectSize);
       } else {
-        object[name] = deserializeObject(buffer, _index, options, false, target);
+        object[name] = deserializeObject(buffer, _index, options, false, newTarget);
       }
 
       index = index + objectSize;
@@ -192,7 +193,7 @@ var deserializeObject = function(buffer, index, options, isArray, target) {
         arrayOptions['raw'] = true;
       }
 
-      object[name] = deserializeObject(buffer, _index, arrayOptions, true, target);
+      object[name] = deserializeObject(buffer, _index, arrayOptions, true, newTarget);
       index = index + objectSize;
 
       if (buffer[index - 1] !== 0) throw new Error('invalid array terminator byte');


### PR DESCRIPTION
This pull request tries to cover this feature request https://github.com/mongodb/js-bson/issues/211

I thought of two options for nested targeting:

1- one (which current code is based on) is **using static props of the top target**, for example consider following document in mongodb:

```
{
    _id: 1,
    comments: [
          {_id: 1, content: ""},
          {_id: 2, content: ""}
    ]
}
```

Assigning the top document to an Article object:
```
class Article {}
articles.find({}, {target: Article});
```

Assigning articles to an extended Array:
```
class Article {
     static $comments = class Comments extends Array {}
} 
articles.find({}, {target: Article});
```

assigning articles items to a Comment class:
```
class Article {
     static $comments = class Comments extends Array {
            static $ = class Comment {}
     }
} 
articles.find({}, {target: Article});
```

I used $ at the begging of field names to prevent confusion with Class self properties, and used $ for array items.

2- **Using a custom data structure** like this:
`articles.find({}, {targets: {root: Article, Comments: {root: Comments, item: Comment}}});`

I believe first one is nicer but it's more confusing and the whole hierarchy of data must be defines.
If the maintainers accepts the general idea then it can be discussed.

For now I used **firstBatch** and **nextBatch** to detect documents parsing,  until someone suggest a better approach.

if you want to test this code please use my modified mongodb core driver (I've added necessary code to commands.js).