### PR TITLE
fix(bson): normalizedFunctionString handles named functions

### DIFF
--- a/lib/bson/parser/utils.js
+++ b/lib/bson/parser/utils.js
@@ -5,7 +5,7 @@
  * @param {Function} fn The function to stringify
  */
 function normalizedFunctionString(fn) {
-  return fn.toString().replace('function(', 'function (');
+  return fn.toString().replace(/function(.*)\(/, 'function (');
 }
 
 module.exports = {

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -22,6 +22,7 @@ var Buffer = require('buffer').Buffer,
   vm = require('vm');
 
 var createBSON = require('../utils');
+const normalizedFunctionString = require('../../lib/bson/parser/utils').normalizedFunctionString;
 
 // for tests
 BSON.BSON_BINARY_SUBTYPE_DEFAULT = 0;
@@ -2345,5 +2346,18 @@ describe('BSON', function() {
     const uint8ArrayRaw = Array.prototype.slice.call(uint8Array, 0);
 
     expect(bufferRaw).to.deep.equal(uint8ArrayRaw);
+  });
+
+  it('Should normalize variations of the same function to the same string', function() {
+    const testObj = { test: function() {}, test2: function test2() {} };
+    const testFuncs = [
+      function() {},
+      function func() {},
+      function fUnCtIoN() {},
+      testObj['test'],
+      testObj['test2']
+    ];
+    const expectedString = 'function () {}';
+    testFuncs.forEach(fn => expect(normalizedFunctionString(fn)).to.equal(expectedString));
   });
 });


### PR DESCRIPTION
Update normalizedFunctionString to correctly normalize the string
representation of named functions.

Fixes NODE-1552