### PR TITLE
feat(ext-json): merge extended JSON into js-bson

### DIFF
--- a/lib/binary.js
+++ b/lib/binary.js
@@ -274,6 +274,32 @@ class Binary {
   toString(format) {
     return this.buffer != null ? this.buffer.slice(0, this.position).toString(format) : '';
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    const base64String = Buffer.isBuffer(this.buffer)
+      ? this.buffer.toString('base64')
+      : Buffer.from(this.buffer).toString('base64');
+
+    const subType = Number(this.sub_type).toString(16);
+    return {
+      $binary: {
+        base64: base64String,
+        subType: subType.length === 1 ? '0' + subType : subType
+      }
+    };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc) {
+    const type = doc.$binary.subType ? parseInt(doc.$binary.subType, 16) : 0;
+    const data = new Buffer(doc.$binary.base64, 'base64');
+    return new Binary(data, type);
+  }
 }
 
 /**

--- a/lib/bson.js
+++ b/lib/bson.js
@@ -16,6 +16,7 @@ const MaxKey = require('./max_key');
 const DBRef = require('./db_ref');
 const Binary = require('./binary');
 const constants = require('./constants');
+const EJSON = require('./extended_json');
 
 // Parts of the parser
 const internalDeserialize = require('./parser/deserializer');
@@ -234,5 +235,8 @@ module.exports = Object.assign({}, constants, {
   setInternalBufferSize,
 
   // legacy support
-  ObjectID: ObjectId
+  ObjectID: ObjectId,
+
+  // Extended JSON
+  EJSON
 });

--- a/lib/code.js
+++ b/lib/code.js
@@ -22,6 +22,24 @@ class Code {
   toJSON() {
     return { scope: this.scope, code: this.code };
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    if (this.scope) {
+      return { $code: this.code, $scope: this.scope };
+    }
+
+    return { $code: this.code };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc) {
+    return new Code(doc.$code, doc.$scope);
+  }
 }
 
 Object.defineProperty(Code.prototype, '_bsontype', { value: 'Code' });

--- a/lib/db_ref.js
+++ b/lib/db_ref.js
@@ -42,6 +42,29 @@ class DBRef {
     if (this.db != null) o.$db = this.db;
     return o;
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    let o = {
+      $ref: this.collection,
+      $id: this.oid
+    };
+
+    if (this.db) o.$db = this.db;
+    o = Object.assign(o, this.fields);
+    return o;
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc) {
+    var copy = Object.assign({}, doc);
+    ['$ref', '$id', '$db'].forEach(k => delete copy[k]);
+    return new DBRef(doc.$ref, doc.$id, doc.$db, copy);
+  }
 }
 
 Object.defineProperty(DBRef.prototype, '_bsontype', { value: 'DBRef' });

--- a/lib/decimal128.js
+++ b/lib/decimal128.js
@@ -788,5 +788,19 @@ Decimal128.prototype.toJSON = function() {
   return { $numberDecimal: this.toString() };
 };
 
+/**
+ * @ignore
+ */
+Decimal128.prototype.toExtendedJSON = function() {
+  return { $numberDecimal: this.toString() };
+};
+
+/**
+ * @ignore
+ */
+Decimal128.fromExtendedJSON = function(doc) {
+  return Decimal128.fromString(doc.$numberDecimal);
+};
+
 Object.defineProperty(Decimal128.prototype, '_bsontype', { value: 'Decimal128' });
 module.exports = Decimal128;

--- a/lib/double.js
+++ b/lib/double.js
@@ -29,6 +29,23 @@ class Double {
   toJSON() {
     return this.value;
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON(options) {
+    if (options && options.relaxed && isFinite(this.value)) return this.value;
+    return { $numberDouble: this.value.toString() };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc, options) {
+    return options && options.relaxed
+      ? parseFloat(doc.$numberDouble)
+      : new Double(parseFloat(doc.$numberDouble));
+  }
 }
 
 Object.defineProperty(Double.prototype, '_bsontype', { value: 'Double' });

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -1,0 +1,297 @@
+'use strict';
+
+// const Buffer = require('buffer').Buffer;
+// const Map = require('./map');
+const Long = require('./long');
+const Double = require('./double');
+const Timestamp = require('./timestamp');
+const ObjectId = require('./objectid');
+const BSONRegExp = require('./regexp');
+const Symbol = require('./symbol');
+const Int32 = require('./int_32');
+const Code = require('./code');
+const Decimal128 = require('./decimal128');
+const MinKey = require('./min_key');
+const MaxKey = require('./max_key');
+const DBRef = require('./db_ref');
+const Binary = require('./binary');
+
+// all the types where we don't need to do any special processing and can just pass the EJSON
+//straight to type.fromExtendedJSON
+const keysToCodecs = {
+  $oid: ObjectId,
+  $binary: Binary,
+  $symbol: Symbol,
+  $numberInt: Int32,
+  $numberDecimal: Decimal128,
+  $numberDouble: Double,
+  $numberLong: Long,
+  $minKey: MinKey,
+  $maxKey: MaxKey,
+  $regularExpression: BSONRegExp,
+  $timestamp: Timestamp
+};
+
+// const BSONTypes = Object.keys(BSON);
+
+function deserializeValue(self, key, value, options) {
+  if (typeof value === 'number') {
+    // if it's an integer, should interpret as smallest BSON integer
+    // that can represent it exactly. (if out of range, interpret as double.)
+    if (Math.floor(value) === value) {
+      let int32Range = value >= BSON_INT32_MIN && value <= BSON_INT32_MAX,
+        int64Range = value >= BSON_INT64_MIN && value <= BSON_INT64_MAX;
+
+      if (int32Range) return options.strict ? new Int32(value) : value;
+      if (int64Range) return options.strict ? new Long.fromNumber(value) : value;
+    }
+    // If the number is a non-integer or out of integer range, should interpret as BSON Double.
+    return new Double(value);
+  }
+
+  // from here on out we're looking for bson types, so bail if its not an object
+  if (value == null || typeof value !== 'object') return value;
+
+  // upgrade deprecated undefined to null
+  if (value.$undefined) return null;
+
+  const keys = Object.keys(value).filter(k => k.startsWith('$') && value[k] != null);
+  for (let i = 0; i < keys.length; i++) {
+    let c = keysToCodecs[keys[i]];
+    if (c) return c.fromExtendedJSON(value, options);
+  }
+
+  if (value.$date != null) {
+    const d = value.$date;
+    const date = new Date();
+
+    if (typeof d === 'string') date.setTime(Date.parse(d));
+    else if (d instanceof Long) date.setTime(d.toNumber());
+    else if (typeof d === 'number' && options.relaxed) date.setTime(d);
+    return date;
+  }
+
+  if (value.$code != null) {
+    let copy = Object.assign({}, value);
+    if (value.$scope) {
+      copy.$scope = deserializeValue(self, null, value.$scope);
+    }
+
+    return Code.fromExtendedJSON(value);
+  }
+
+  if (value.$ref != null || value.$dbPointer != null) {
+    let v = value.$ref ? value : value.$dbPointer;
+
+    // we run into this in a "degenerate EJSON" case (with $id and $ref order flipped)
+    // because of the order JSON.parse goes through the document
+    if (v instanceof DBRef) return v;
+
+    const dollarKeys = Object.keys(v).filter(k => k.startsWith('$'));
+    let valid = true;
+    dollarKeys.forEach(k => {
+      if (['$ref', '$id', '$db'].indexOf(k) === -1) valid = false;
+    });
+
+    // only make DBRef if $ keys are all valid
+    if (valid) return DBRef.fromExtendedJSON(v);
+  }
+
+  return value;
+}
+
+/**
+ * Parse an Extended JSON string, constructing the JavaScript value or object described by that
+ * string.
+ *
+ * @param {string} text
+ * @param {object} [options] Optional settings
+ * @param {boolean} [options.relaxed=true] Attempt to return native JS types where possible, rather than BSON types (if true)
+ * @return {object}
+ *
+ * @example
+ * const EJSON = require('mongodb-extjson');
+ * const text = '{ "int32": { "$numberInt": "10" } }';
+ *
+ * // prints { int32: { [String: '10'] _bsontype: 'Int32', value: '10' } }
+ * console.log(EJSON.parse(text, { relaxed: false }));
+ *
+ * // prints { int32: 10 }
+ * console.log(EJSON.parse(text));
+ */
+function parse(text, options) {
+  options = Object.assign({}, { relaxed: true }, options);
+
+  // relaxed implies not strict
+  if (typeof options.relaxed === 'boolean') options.strict = !options.relaxed;
+  if (typeof options.strict === 'boolean') options.relaxed = !options.strict;
+
+  return JSON.parse(text, (key, value) => deserializeValue(this, key, value, options));
+}
+
+//
+// Serializer
+//
+
+// MAX INT32 boundaries
+const BSON_INT32_MAX = 0x7fffffff,
+  BSON_INT32_MIN = -0x80000000,
+  BSON_INT64_MAX = 0x7fffffffffffffff,
+  BSON_INT64_MIN = -0x8000000000000000;
+
+/**
+ * Converts a BSON document to an Extended JSON string, optionally replacing values if a replacer
+ * function is specified or optionally including only the specified properties if a replacer array
+ * is specified.
+ *
+ * @param {object} value The value to convert to extended JSON
+ * @param {function|array} [replacer] A function that alters the behavior of the stringification process, or an array of String and Number objects that serve as a whitelist for selecting/filtering the properties of the value object to be included in the JSON string. If this value is null or not provided, all properties of the object are included in the resulting JSON string
+ * @param {string|number} [space] A String or Number object that's used to insert white space into the output JSON string for readability purposes.
+ * @param {object} [options] Optional settings
+ * @param {boolean} [options.relaxed=true] Enabled Extended JSON's `relaxed` mode
+ * @returns {string}
+ *
+ * @example
+ * const EJSON = require('mongodb-extjson');
+ * const Int32 = require('mongodb').Int32;
+ * const doc = { int32: new Int32(10) };
+ *
+ * // prints '{"int32":{"$numberInt":"10"}}'
+ * console.log(EJSON.stringify(doc, { relaxed: false }));
+ *
+ * // prints '{"int32":10}'
+ * console.log(EJSON.stringify(doc));
+ */
+function stringify(value, replacer, space, options) {
+  if (space != null && typeof space === 'object') (options = space), (space = 0);
+  if (replacer != null && typeof replacer === 'object')
+    (options = replacer), (replacer = null), (space = 0);
+  options = Object.assign({}, { relaxed: true }, options);
+
+  const doc = Array.isArray(value)
+    ? serializeArray(value, options)
+    : serializeDocument(value, options);
+
+  return JSON.stringify(doc, replacer, space);
+}
+
+/**
+ * Serializes an object to an Extended JSON string, and reparse it as a JavaScript object.
+ *
+ * @param {object} bson The object to serialize
+ * @param {object} [options] Optional settings passed to the `stringify` function
+ * @return {object}
+ */
+function serialize(bson, options) {
+  options = options || {};
+  return JSON.parse(stringify(bson, options));
+}
+
+/**
+ * Deserializes an Extended JSON object into a plain JavaScript object with native/BSON types
+ *
+ * @param {object} ejson The Extended JSON object to deserialize
+ * @param {object} [options] Optional settings passed to the parse method
+ * @return {object}
+ */
+function deserialize(ejson, options) {
+  options = options || {};
+  return parse(JSON.stringify(ejson), options);
+}
+
+function serializeArray(array, options) {
+  return array.map(v => serializeValue(v, options));
+}
+
+function getISOString(date) {
+  const isoStr = date.toISOString();
+  // we should only show milliseconds in timestamp if they're non-zero
+  return date.getUTCMilliseconds() !== 0 ? isoStr : isoStr.slice(0, -5) + 'Z';
+}
+
+function serializeValue(value, options) {
+  if (Array.isArray(value)) return serializeArray(value, options);
+
+  if (value === undefined) return null;
+
+  if (value instanceof Date) {
+    let dateNum = value.getTime(),
+      // is it in year range 1970-9999?
+      inRange = dateNum > -1 && dateNum < 253402318800000;
+
+    return options.relaxed && inRange
+      ? { $date: getISOString(value) }
+      : { $date: { $numberLong: value.getTime().toString() } };
+  }
+
+  if (typeof value === 'number' && !options.relaxed) {
+    // it's an integer
+    if (Math.floor(value) === value) {
+      let int32Range = value >= BSON_INT32_MIN && value <= BSON_INT32_MAX,
+        int64Range = value >= BSON_INT64_MIN && value <= BSON_INT64_MAX;
+
+      // interpret as being of the smallest BSON integer type that can represent the number exactly
+      if (int32Range) return { $numberInt: value.toString() };
+      if (int64Range) return { $numberLong: value.toString() };
+    }
+    return { $numberDouble: value.toString() };
+  }
+
+  if (value != null && typeof value === 'object') return serializeDocument(value, options);
+  return value;
+}
+
+function serializeDocument(doc, options) {
+  if (doc == null || typeof doc !== 'object') throw new Error('not an object instance');
+
+  // the document itself is a BSON type
+  if (doc._bsontype && typeof doc.toExtendedJSON === 'function') {
+    if (doc._bsontype === 'Code' && doc.scope) {
+      doc.scope = serializeDocument(doc.scope, options);
+    } else if (doc._bsontype === 'DBRef' && doc.oid) {
+      doc.oid = serializeDocument(doc.oid, options);
+    }
+
+    return doc.toExtendedJSON(options);
+  }
+
+  // the document is an object with nested BSON types
+  const _doc = {};
+  for (let name in doc) {
+    let val = doc[name];
+    if (Array.isArray(val)) {
+      _doc[name] = serializeArray(val, options);
+    } else if (val != null && typeof val.toExtendedJSON === 'function') {
+      if (val._bsontype === 'Code' && val.scope) {
+        val.scope = serializeDocument(val.scope, options);
+      } else if (val._bsontype === 'DBRef' && val.oid) {
+        val.oid = serializeDocument(val.oid, options);
+      }
+
+      _doc[name] = val.toExtendedJSON(options);
+    } else if (val instanceof Date) {
+      _doc[name] = serializeValue(val, options);
+    } else if (val != null && typeof val === 'object') {
+      _doc[name] = serializeDocument(val, options);
+    }
+    _doc[name] = serializeValue(val, options);
+    if (val instanceof RegExp) {
+      let flags = val.flags;
+      if (flags === undefined) {
+        flags = val.toString().match(/[gimuy]*$/)[0];
+      }
+
+      const rx = new BSONRegExp(val.source, flags);
+      _doc[name] = rx.toExtendedJSON();
+    }
+  }
+
+  return _doc;
+}
+
+module.exports = {
+  parse,
+  deserialize,
+  serialize,
+  stringify
+};

--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -29,6 +29,21 @@ class Int32 {
   toJSON() {
     return this.value;
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON(options) {
+    if (options && options.relaxed) return this.value;
+    return { $numberInt: this.value.toString() };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc, options) {
+    return options && options.relaxed ? parseInt(doc.$numberInt, 10) : new Int32(doc.$numberInt);
+  }
 }
 
 Object.defineProperty(Int32.prototype, '_bsontype', { value: 'Int32' });

--- a/lib/long.js
+++ b/lib/long.js
@@ -1,5 +1,21 @@
 'use strict';
 const Long = require('long');
 
+/**
+ * @ignore
+ */
+Long.prototype.toExtendedJSON = function(options) {
+  if (options && options.relaxed) return this.toNumber();
+  return { $numberLong: this.toString() };
+};
+
+/**
+ * @ignore
+ */
+Long.fromExtendedJSON = function(doc, options) {
+  const result = Long.fromString(doc.$numberLong);
+  return options && options.relaxed ? result.toNumber() : result;
+};
+
 Object.defineProperty(Long.prototype, '_bsontype', { value: 'Long' });
 module.exports = Long;

--- a/lib/max_key.js
+++ b/lib/max_key.js
@@ -9,6 +9,20 @@ class MaxKey {
    * @return {MaxKey} A MaxKey instance
    */
   constructor() {}
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    return { $maxKey: 1 };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON() {
+    return new MaxKey();
+  }
 }
 
 Object.defineProperty(MaxKey.prototype, '_bsontype', { value: 'MaxKey' });

--- a/lib/min_key.js
+++ b/lib/min_key.js
@@ -9,6 +9,20 @@ class MinKey {
    * @return {MinKey} A MinKey instance
    */
   constructor() {}
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    return { $minKey: 1 };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON() {
+    return new MinKey();
+  }
 }
 
 Object.defineProperty(MinKey.prototype, '_bsontype', { value: 'MinKey' });

--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -351,6 +351,21 @@ class ObjectId {
 
     return false;
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    if (this.toHexString) return { $oid: this.toHexString() };
+    return { $oid: this.toString('hex') };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc) {
+    return new ObjectId(doc.$oid);
+  }
 }
 
 /**

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -38,6 +38,26 @@ class BSONRegExp {
       }
     }
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    return { $regularExpression: { pattern: this.pattern, options: this.options } };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc) {
+    return new BSONRegExp(
+      doc.$regularExpression.pattern,
+      doc.$regularExpression.options
+        .split('')
+        .sort()
+        .join('')
+    );
+  }
 }
 
 Object.defineProperty(BSONRegExp.prototype, '_bsontype', { value: 'BSONRegExp' });

--- a/lib/symbol.js
+++ b/lib/symbol.js
@@ -42,6 +42,20 @@ class Symbol {
   toJSON() {
     return this.value;
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    return { $symbol: this.value };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc) {
+    return new Symbol(doc.$symbol);
+  }
 }
 
 Object.defineProperty(Symbol.prototype, '_bsontype', { value: 'Symbol' });

--- a/lib/timestamp.js
+++ b/lib/timestamp.js
@@ -74,6 +74,20 @@ class Timestamp extends Long {
   static fromString(str, opt_radix) {
     return new Timestamp(Long.fromString(str, opt_radix));
   }
+
+  /**
+   * @ignore
+   */
+  toExtendedJSON() {
+    return { $timestamp: { t: this.high, i: this.low } };
+  }
+
+  /**
+   * @ignore
+   */
+  static fromExtendedJSON(doc) {
+    return new Timestamp(doc.$timestamp.i, doc.$timestamp.t);
+  }
 }
 
 Object.defineProperty(Timestamp.prototype, '_bsontype', { value: 'Timestamp' });

--- a/test/node/bson_corpus_tests.js
+++ b/test/node/bson_corpus_tests.js
@@ -4,6 +4,7 @@ const Buffer = require('buffer').Buffer;
 const BSON = require('../../lib/bson');
 const Decimal128 = BSON.Decimal128;
 const expect = require('chai').expect;
+const EJSON = require('../../lib/extended_json');
 
 var deserializeOptions = {
   bsonRegExp: true,
@@ -15,43 +16,187 @@ var serializeOptions = {
   ignoreUndefined: false
 };
 
-// tests from the corpus that we need to skip, and explanations why
+function nativeToBson(native) {
+  const serializeOptions = {
+    ignoreUndefined: false
+  };
 
-var skip = {
+  return BSON.serialize(native, serializeOptions);
+}
+
+function bsonToNative(bson) {
+  var deserializeOptions = {
+    bsonRegExp: true,
+    promoteLongs: true,
+    promoteValues: false
+  };
+
+  return BSON.deserialize(bson, deserializeOptions);
+}
+
+function jsonToNative(json) {
+  return EJSON.parse(json, { relaxed: false });
+}
+
+function nativeToCEJSON(native) {
+  return EJSON.stringify(native, { relaxed: false });
+}
+
+function nativeToREJSON(native) {
+  return EJSON.stringify(native, { relaxed: true });
+}
+
+function normalize(cEJ) {
+  return JSON.stringify(JSON.parse(cEJ));
+}
+
+// tests from the corpus that we need to skip, and explanations why
+const skipBSON = {
   'NaN with payload':
     'passing this would require building a custom type to store the NaN payload data.'
 };
 
-const corpus = require('./tools/bson_corpus_test_loader');
+const skipExtendedJSON = {
+  'Timestamp with high-order bit set on both seconds and increment':
+    'Current BSON implementation of timestamp/long cannot hold these values - 1 too large.'
+};
 
+// test modifications for JavaScript
+const modifiedDoubles = {
+  '+1.0': { canonical_extjson: '{"d":{"$numberDouble":"1"}}' },
+  '-1.0': { canonical_extjson: '{"d":{"$numberDouble":"-1"}}' },
+  '1.23456789012345677E+18': { canonical_extjson: '{"d":{"$numberDouble":"1234567890123456800"}}' },
+  '-1.23456789012345677E+18': {
+    canonical_extjson: '{"d":{"$numberDouble":"-1234567890123456800"}}'
+  },
+  '0.0': { canonical_extjson: '{"d":{"$numberDouble":"0"}}' },
+  '-0.0': {
+    canonical_extjson: '{"d":{"$numberDouble":"0"}}',
+    canonical_bson: '10000000016400000000000000000000'
+  }
+};
+
+const modifiedMultitype = {
+  'All BSON types': {
+    canonical_extjson:
+      '{"_id":{"$oid":"57e193d7a9cc81b4027498b5"},"Symbol":"symbol","String":"string","Int32":{"$numberInt":"42"},"Int64":{"$numberLong":"42"},"Double":{"$numberDouble":"-1"},"Binary":{"$binary":{"base64":"o0w498Or7cijeBSpkquNtg==","subType":"03"}},"BinaryUserDefined":{"$binary":{"base64":"AQIDBAU=","subType":"80"}},"Code":{"$code":"function() {}"},"CodeWithScope":{"$code":"function() {}","$scope":{}},"Subdocument":{"foo":"bar"},"Array":[{"$numberInt":"1"},{"$numberInt":"2"},{"$numberInt":"3"},{"$numberInt":"4"},{"$numberInt":"5"}],"Timestamp":{"$timestamp":{"t":42,"i":1}},"Regex":{"$regularExpression":{"pattern":"pattern","options":""}},"DatetimeEpoch":{"$date":{"$numberLong":"0"}},"DatetimePositive":{"$date":{"$numberLong":"2147483647"}},"DatetimeNegative":{"$date":{"$numberLong":"-2147483648"}},"True":true,"False":false,"DBPointer":{"$ref":"collection","$id":{"$oid":"57e193d7a9cc81b4027498b1"}},"DBRef":{"$ref":"collection","$id":{"$oid":"57fd71e96e32ab4225b723fb"},"$db":"database"},"Minkey":{"$minKey":1},"Maxkey":{"$maxKey":1},"Null":null,"Undefined":null}',
+    canonical_bson:
+      '48020000075f69640057e193d7a9cc81b4027498b50253796d626f6c000700000073796d626f6c0002537472696e670007000000737472696e670010496e743332002a00000012496e743634002a0000000000000001446f75626c6500000000000000f0bf0542696e617279001000000003a34c38f7c3abedc8a37814a992ab8db60542696e61727955736572446566696e656400050000008001020304050d436f6465000e00000066756e6374696f6e2829207b7d000f436f64655769746853636f7065001b0000000e00000066756e6374696f6e2829207b7d00050000000003537562646f63756d656e74001200000002666f6f0004000000626172000004417272617900280000001030000100000010310002000000103200030000001033000400000010340005000000001154696d657374616d7000010000002a0000000b5265676578007061747465726e0000094461746574696d6545706f6368000000000000000000094461746574696d65506f73697469766500ffffff7f00000000094461746574696d654e656761746976650000000080ffffffff085472756500010846616c73650000034442506f696e746572002b0000000224726566000b000000636f6c6c656374696f6e00072469640057e193d7a9cc81b4027498b100034442526566003d0000000224726566000b000000636f6c6c656374696f6e00072469640057fd71e96e32ab4225b723fb02246462000900000064617461626173650000ff4d696e6b6579007f4d61786b6579000a4e756c6c000a556e646566696e65640000',
+    converted_extjson:
+      '{"_id":{"$oid":"57e193d7a9cc81b4027498b5"},"Symbol":"symbol","String":"string","Int32":{"$numberInt":"42"},"Int64":{"$numberLong":"42"},"Double":{"$numberDouble":"-1"},"Binary":{"$binary":{"base64":"o0w498Or7cijeBSpkquNtg==","subType":"03"}},"BinaryUserDefined":{"$binary":{"base64":"AQIDBAU=","subType":"80"}},"Code":{"$code":"function() {}"},"CodeWithScope":{"$code":"function() {}","$scope":{}},"Subdocument":{"foo":"bar"},"Array":[{"$numberInt":"1"},{"$numberInt":"2"},{"$numberInt":"3"},{"$numberInt":"4"},{"$numberInt":"5"}],"Timestamp":{"$timestamp":{"t":42,"i":1}},"Regex":{"$regularExpression":{"pattern":"pattern","options":""}},"DatetimeEpoch":{"$date":{"$numberLong":"0"}},"DatetimePositive":{"$date":{"$numberLong":"2147483647"}},"DatetimeNegative":{"$date":{"$numberLong":"-2147483648"}},"True":true,"False":false,"DBPointer":{"$ref":"collection","$id":{"$oid":"57e193d7a9cc81b4027498b1"}},"DBRef":{"$ref":"collection","$id":{"$oid":"57fd71e96e32ab4225b723fb"},"$db":"database"},"Minkey":{"$minKey":1},"Maxkey":{"$maxKey":1},"Null":null,"Undefined":null}',
+    converted_bson:
+      '48020000075f69640057e193d7a9cc81b4027498b50253796d626f6c000700000073796d626f6c0002537472696e670007000000737472696e670010496e743332002a00000012496e743634002a0000000000000001446f75626c6500000000000000f0bf0542696e617279001000000003a34c38f7c3abedc8a37814a992ab8db60542696e61727955736572446566696e656400050000008001020304050d436f6465000e00000066756e6374696f6e2829207b7d000f436f64655769746853636f7065001b0000000e00000066756e6374696f6e2829207b7d00050000000003537562646f63756d656e74001200000002666f6f0004000000626172000004417272617900280000001030000100000010310002000000103200030000001033000400000010340005000000001154696d657374616d7000010000002a0000000b5265676578007061747465726e0000094461746574696d6545706f6368000000000000000000094461746574696d65506f73697469766500ffffff7f00000000094461746574696d654e656761746976650000000080ffffffff085472756500010846616c73650000034442506f696e746572002b0000000224726566000b000000636f6c6c656374696f6e00072469640057e193d7a9cc81b4027498b100034442526566003d0000000224726566000b000000636f6c6c656374696f6e00072469640057fd71e96e32ab4225b723fb02246462000900000064617461626173650000ff4d696e6b6579007f4d61786b6579000a4e756c6c000a556e646566696e65640000'
+  }
+};
+
+const corpus = require('./tools/bson_corpus_test_loader');
 describe('BSON Corpus', function() {
   corpus.forEach(scenario => {
-    describe(scenario.description, function() {
-      if (scenario.valid) {
-        describe('valid', function() {
-          scenario.valid.forEach(v => {
-            if (skip.hasOwnProperty(v.description)) {
+    const deprecated = scenario.deprecated;
+    const description = scenario.description;
+    const valid = scenario.valid || [];
+
+    // since doubles are formatted differently in JS than in corpus, overwrite expected results
+    if (description === 'Double type') {
+      valid.forEach(v => {
+        if (modifiedDoubles[v.description]) {
+          Object.assign(v, modifiedDoubles[v.description]);
+        }
+      });
+      // multitype test has a double nested in object, so change those expected values too
+    } else if (description === 'Multiple types within the same document') {
+      valid.forEach(v => {
+        if (modifiedMultitype[v.description]) {
+          Object.assign(v, modifiedMultitype[v.description]);
+        }
+      });
+    }
+
+    describe(description, function() {
+      if (valid) {
+        describe('valid-bson', function() {
+          valid.forEach(v => {
+            if (skipBSON.hasOwnProperty(v.description)) {
               it.skip(v.description, () => {});
               return;
             }
 
             it(v.description, function() {
-              var cB = Buffer.from(v.canonical_bson, 'hex');
-              if (v.degenerate_bson) var dB = Buffer.from(v.degenerate_bson, 'hex');
-              if (v.converted_bson) var convB = Buffer.from(v.converted_bson, 'hex');
+              const cB = Buffer.from(v.canonical_bson, 'hex');
+              let dB, convB;
+              if (v.degenerate_bson) dB = Buffer.from(v.degenerate_bson, 'hex');
+              if (v.converted_bson) convB = Buffer.from(v.converted_bson, 'hex');
 
-              var roundTripped = BSON.serialize(
+              const roundTripped = BSON.serialize(
                 BSON.deserialize(cB, deserializeOptions),
                 serializeOptions
               );
 
-              if (scenario.deprecated) expect(convB).to.deep.equal(roundTripped);
+              if (deprecated) expect(convB).to.deep.equal(roundTripped);
               else expect(cB).to.deep.equal(roundTripped);
 
               if (dB) {
                 expect(cB).to.deep.equal(
                   BSON.serialize(BSON.deserialize(dB, deserializeOptions), serializeOptions)
                 );
+              }
+            });
+          });
+        });
+
+        describe('valid-extjson', function() {
+          valid.forEach(v => {
+            if (skipExtendedJSON.hasOwnProperty(v.description)) {
+              it.skip(v.description, () => {});
+              return;
+            }
+
+            it(v.description, function() {
+              // read in test case data. if this scenario is for a deprecated
+              // type, we want to use the "converted" BSON and EJSON, which
+              // use the upgraded version of the deprecated type. otherwise,
+              // just use canonical.
+              let cB, cEJ;
+              if (deprecated) {
+                cB = new Buffer(v.converted_bson, 'hex');
+                cEJ = normalize(v.converted_extjson);
+              } else {
+                cB = new Buffer(v.canonical_bson, 'hex');
+                cEJ = normalize(v.canonical_extjson);
+              }
+
+              // convert inputs to native Javascript objects
+              const nativeFromCB = bsonToNative(cB);
+
+              // round tripped EJSON should match the original
+              expect(nativeToCEJSON(jsonToNative(cEJ))).to.equal(cEJ);
+
+              // invalid, but still parseable, EJSON. if provided, make sure that we
+              // properly convert it to canonical EJSON and BSON.
+              if (v.degenerate_extjson) {
+                const dEJ = normalize(v.degenerate_extjson);
+                const roundTrippedDEJ = nativeToCEJSON(jsonToNative(dEJ));
+                expect(roundTrippedDEJ).to.equal(cEJ);
+                if (!v.lossy) {
+                  expect(nativeToBson(jsonToNative(dEJ))).to.deep.equal(cB);
+                }
+              }
+
+              // as long as conversion isn't lossy (i.e. BSON can represent everything in
+              // the EJSON), make sure EJSON -> native -> BSON matches canonical BSON.
+              if (!v.lossy) {
+                expect(nativeToBson(jsonToNative(cEJ))).to.deep.equal(cB);
+              }
+
+              // the reverse direction, BSON -> native -> EJSON, should match canonical EJSON.
+              expect(nativeToCEJSON(nativeFromCB)).to.equal(cEJ);
+
+              if (v.relaxed_extjson) {
+                let rEJ = normalize(v.relaxed_extjson);
+                // BSON -> native -> relaxed EJSON matches provided
+                expect(nativeToREJSON(nativeFromCB)).to.equal(rEJ);
+                // relaxed EJSON -> native -> relaxed EJSON unchanged
+                expect(nativeToREJSON(jsonToNative(rEJ))).to.equal(rEJ);
               }
             });
           });

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -1,0 +1,250 @@
+'use strict';
+
+const assert = require('assert');
+const expect = require('chai').expect;
+const BSON = require('../../lib/bson');
+const EJSON = BSON.EJSON;
+
+// BSON types
+const Binary = BSON.Binary;
+const Code = BSON.Code;
+const DBRef = BSON.DBRef;
+const Decimal128 = BSON.Decimal128;
+const Double = BSON.Double;
+const Int32 = BSON.Int32;
+const Long = BSON.Long;
+const MaxKey = BSON.MaxKey;
+const MinKey = BSON.MinKey;
+const ObjectID = BSON.ObjectID;
+const BSONRegExp = BSON.BSONRegExp;
+const Symbol = BSON.Symbol;
+const Timestamp = BSON.Timestamp;
+
+describe('Extended JSON', function() {
+  let doc = {};
+
+  before(function() {
+    const buffer = new Buffer(64);
+    for (var i = 0; i < buffer.length; i++) buffer[i] = i;
+    const date = new Date();
+    date.setTime(1488372056737);
+    doc = {
+      _id: new Int32(100),
+      gh: new Int32(1),
+      binary: new Binary(buffer),
+      date: date,
+      code: new Code('function() {}', { a: new Int32(1) }),
+      dbRef: new DBRef('tests', new Int32(1), 'test'),
+      decimal: Decimal128.fromString('100'),
+      double: new Double(10.1),
+      int32: new Int32(10),
+      long: Long.fromNumber(200),
+      maxKey: new MaxKey(),
+      minKey: new MinKey(),
+      objectId: ObjectID.createFromHexString('111111111111111111111111'),
+      regexp: new BSONRegExp('hello world', 'i'),
+      symbol: new Symbol('symbol'),
+      timestamp: Timestamp.fromNumber(1000),
+      int32Number: 300,
+      doubleNumber: 200.2,
+      longNumberIntFit: 0x19000000000000,
+      doubleNumberIntFit: 19007199250000000.12
+    };
+  });
+
+  it('should correctly extend an existing mongodb module', function() {
+    // Serialize the document
+    var json =
+      '{"_id":{"$numberInt":"100"},"gh":{"$numberInt":"1"},"binary":{"$binary":{"base64":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==","subType":"00"}},"date":{"$date":{"$numberLong":"1488372056737"}},"code":{"$code":"function() {}","$scope":{"a":{"$numberInt":"1"}}},"dbRef":{"$ref":"tests","$id":{"$numberInt":"1"},"$db":"test"},"decimal":{"$numberDecimal":"100"},"double":{"$numberDouble":"10.1"},"int32":{"$numberInt":"10"},"long":{"$numberLong":"200"},"maxKey":{"$maxKey":1},"minKey":{"$minKey":1},"objectId":{"$oid":"111111111111111111111111"},"regexp":{"$regularExpression":{"pattern":"hello world","options":"i"}},"symbol":{"$symbol":"symbol"},"timestamp":{"$timestamp":{"t":0,"i":1000}},"int32Number":{"$numberInt":"300"},"doubleNumber":{"$numberDouble":"200.2"},"longNumberIntFit":{"$numberLong":"7036874417766400"},"doubleNumberIntFit":{"$numberLong":"19007199250000000"}}';
+
+    assert.equal(json, EJSON.stringify(doc, null, 0, { relaxed: false }));
+  });
+
+  it('should correctly deserialize using the default relaxed mode', function() {
+    // Deserialize the document using non strict mode
+    var doc1 = EJSON.parse(EJSON.stringify(doc, null, 0));
+
+    // Validate the values
+    assert.equal(300, doc1.int32Number);
+    assert.equal(200.2, doc1.doubleNumber);
+    assert.equal(0x19000000000000, doc1.longNumberIntFit);
+    assert.equal(19007199250000000.12, doc1.doubleNumberIntFit);
+
+    // Deserialize the document using strict mode
+    doc1 = EJSON.parse(EJSON.stringify(doc, null, 0), { relaxed: false });
+
+    // Validate the values
+    expect(doc1.int32Number._bsontype).to.equal('Int32');
+    expect(doc1.doubleNumber._bsontype).to.equal('Double');
+    expect(doc1.longNumberIntFit._bsontype).to.equal('Long');
+    expect(doc1.doubleNumberIntFit._bsontype).to.equal('Long');
+  });
+
+  it('should correctly serialize, and deserialize using built-in BSON', function() {
+    // Create a doc
+    var doc1 = {
+      int32: new Int32(10)
+    };
+
+    // Serialize the document
+    var text = EJSON.stringify(doc1, null, 0, { relaxed: false });
+    expect(text).to.equal('{"int32":{"$numberInt":"10"}}');
+
+    // Deserialize the json in strict and non strict mode
+    var doc2 = EJSON.parse(text, { relaxed: false });
+    expect(doc2.int32._bsontype).to.equal('Int32');
+    doc2 = EJSON.parse(text);
+    expect(doc2.int32).to.equal(10);
+  });
+
+  it('should correctly serialize bson types when they are values', function() {
+    var serialized = EJSON.stringify(new ObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
+    expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
+    serialized = EJSON.stringify(new Int32(42), { relaxed: false });
+    expect(serialized).to.equal('{"$numberInt":"42"}');
+    serialized = EJSON.stringify(
+      {
+        _id: { $nin: [new ObjectID('591801a468f9e7024b6235ea')] }
+      },
+      { relaxed: false }
+    );
+    expect(serialized).to.equal('{"_id":{"$nin":[{"$oid":"591801a468f9e7024b6235ea"}]}}');
+
+    serialized = EJSON.stringify(new Binary(new Uint8Array([1, 2, 3, 4, 5])), { relaxed: false });
+    expect(serialized).to.equal('{"$binary":{"base64":"AQIDBAU=","subType":"00"}}');
+  });
+
+  it('should correctly parse null values', function() {
+    expect(EJSON.parse('null')).to.be.null;
+    expect(EJSON.parse('[null]')[0]).to.be.null;
+
+    var input = '{"result":[{"_id":{"$oid":"591801a468f9e7024b623939"},"emptyField":null}]}';
+    var parsed = EJSON.parse(input);
+
+    expect(parsed).to.deep.equal({
+      result: [{ _id: new ObjectID('591801a468f9e7024b623939'), emptyField: null }]
+    });
+  });
+
+  it('should correctly throw when passed a non-string to parse', function() {
+    expect(() => {
+      EJSON.parse({});
+    }).to.throw;
+  });
+
+  it('should allow relaxed parsing by default', function() {
+    const dt = new Date(1452124800000);
+    const inputObject = {
+      int: { $numberInt: '500' },
+      long: { $numberLong: '42' },
+      double: { $numberDouble: '24' },
+      date: { $date: { $numberLong: '1452124800000' } }
+    };
+
+    const parsed = EJSON.parse(JSON.stringify(inputObject));
+    expect(parsed).to.eql({
+      int: 500,
+      long: 42,
+      double: 24,
+      date: dt
+    });
+  });
+
+  it('should allow regexp', function() {
+    const parsedRegExp = EJSON.stringify({ test: /some-regex/i });
+    const parsedBSONRegExp = EJSON.stringify(
+      { test: new BSONRegExp('some-regex', 'i') },
+      { relaxed: true }
+    );
+    expect(parsedRegExp).to.eql(parsedBSONRegExp);
+  });
+
+  it('should serialize from BSON object to EJSON object', function() {
+    const doc = {
+      binary: new Binary(''),
+      code: new Code('function() {}'),
+      dbRef: new DBRef('tests', new Int32(1), 'test'),
+      decimal128: new Decimal128(128),
+      double: new Double(10.1),
+      int32: new Int32(10),
+      long: new Long(234),
+      maxKey: new MaxKey(),
+      minKey: new MinKey(),
+      objectID: ObjectID.createFromHexString('111111111111111111111111'),
+      bsonRegExp: new BSONRegExp('hello world', 'i'),
+      symbol: new Symbol('symbol'),
+      timestamp: new Timestamp()
+    };
+
+    const result = EJSON.serialize(doc, { relaxed: false });
+    expect(result).to.deep.equal({
+      binary: { $binary: { base64: '', subType: '00' } },
+      code: { $code: 'function() {}' },
+      dbRef: { $ref: 'tests', $id: { $numberInt: '1' }, $db: 'test' },
+      decimal128: { $numberDecimal: '0E-6176' },
+      double: { $numberDouble: '10.1' },
+      int32: { $numberInt: '10' },
+      long: { $numberLong: '234' },
+      maxKey: { $maxKey: 1 },
+      minKey: { $minKey: 1 },
+      objectID: { $oid: '111111111111111111111111' },
+      bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
+      symbol: { $symbol: 'symbol' },
+      timestamp: { $timestamp: { t: 0, i: 0 } }
+    });
+  });
+
+  it('should deserialize from EJSON object to BSON object', function() {
+    const doc = {
+      binary: { $binary: { base64: '', subType: '00' } },
+      code: { $code: 'function() {}' },
+      dbRef: { $ref: 'tests', $id: { $numberInt: '1' }, $db: 'test' },
+      decimal128: { $numberDecimal: '0E-6176' },
+      double: { $numberDouble: '10.1' },
+      int32: { $numberInt: '10' },
+      long: { $numberLong: '234' },
+      maxKey: { $maxKey: 1 },
+      minKey: { $minKey: 1 },
+      objectID: { $oid: '111111111111111111111111' },
+      bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
+      symbol: { $symbol: 'symbol' },
+      timestamp: { $timestamp: { t: 0, i: 0 } }
+    };
+
+    const result = EJSON.deserialize(doc, { relaxed: false });
+
+    // binary
+    expect(result.binary).to.be.an.instanceOf(BSON.Binary);
+    // code
+    expect(result.code).to.be.an.instanceOf(BSON.Code);
+    expect(result.code.code).to.equal('function() {}');
+    // dbRef
+    expect(result.dbRef).to.be.an.instanceOf(BSON.DBRef);
+    expect(result.dbRef.collection).to.equal('tests');
+    expect(result.dbRef.db).to.equal('test');
+    // decimal128
+    expect(result.decimal128).to.be.an.instanceOf(BSON.Decimal128);
+    // double
+    expect(result.double).to.be.an.instanceOf(BSON.Double);
+    expect(result.double.value).to.equal(10.1);
+    // int32
+    expect(result.int32).to.be.an.instanceOf(BSON.Int32);
+    expect(result.int32.value).to.equal('10');
+    //long
+    expect(result.long).to.be.an.instanceOf(BSON.Long);
+    // maxKey
+    expect(result.maxKey).to.be.an.instanceOf(BSON.MaxKey);
+    // minKey
+    expect(result.minKey).to.be.an.instanceOf(BSON.MinKey);
+    // objectID
+    expect(result.objectID.toString()).to.equal('111111111111111111111111');
+    //bsonRegExp
+    expect(result.bsonRegExp).to.be.an.instanceOf(BSON.BSONRegExp);
+    expect(result.bsonRegExp.pattern).to.equal('hello world');
+    expect(result.bsonRegExp.options).to.equal('i');
+    // symbol
+    expect(result.symbol.toString()).to.equal('symbol');
+    // timestamp
+    expect(result.timestamp).to.be.an.instanceOf(BSON.Timestamp);
+  });
+});


### PR DESCRIPTION
This is a big code merge, but I believe it would dramatically reduce our maintenance load and we are already making a major version bump here. Generally the code changes would go from:
```
const EJSON = require('mongodb-extjson');
EJSON.stringify(...);
EJSON.parse(...);
```
to
```
const { EJSON } = require('bson');
EJSON.stringify(...);
EJSON.parse(...);
```