### PR TITLE
ObjectId.isValid should check buffter length

### DIFF
--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -328,7 +328,7 @@ class ObjectId {
       return true;
     }
 
-    if (id instanceof _Buffer) {
+    if (id instanceof _Buffer && id.length === 12) {
       return true;
     }
 

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -80,4 +80,18 @@ describe('ObjectId', function() {
 
     done();
   });
+
+  /**
+   * @ignore
+   */
+  it('should isValid check input Buffer length', function(done) {
+    var buffTooShort = new Buffer ([]);
+    var buffTooLong = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    var buff12Bytes = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+    expect(ObjectId.isValid(buffTooShort)).to.be.false;
+    expect(ObjectId.isValid(buffTooLong)).to.be.false;
+    expect(ObjectId.isValid(buff12Bytes)).to.be.true;
+    done();
+  });
 });


### PR DESCRIPTION
```
const buff = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])

// returns true
ObjectId.isValid(buff) 
// TypeError: Argument passed in must be a single String of 12 bytes or a string of 24 hex characters
new ObjectId(buff)
```

