### PR TITLE
fix(ObjectId): will now throw if an invalid character is passed

### DIFF
--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -34,6 +34,15 @@ function convertToHex(bytes) {
   return bytes.toString('hex');
 }
 
+function makeObjectIdError(invalidString, index) {
+  const invalidCharacter = invalidString[index];
+  return new TypeError(
+    `ObjectId string "${invalidString}" contains invalid character "${invalidCharacter}" with character code (${invalidString.charCodeAt(
+      index
+    )}). All character codes for a non-hex string must be less than 256.`
+  );
+}
+
 /**
  * A class representation of the BSON ObjectId type.
  */
@@ -111,7 +120,11 @@ class ObjectId {
     }
 
     for (let i = 0; i < this.id.length; i++) {
-      hexString += hexTable[this.id.charCodeAt(i)];
+      const hexChar = hexTable[this.id.charCodeAt(i)];
+      if (typeof hexChar !== 'string') {
+        throw makeObjectIdError(this.id, i);
+      }
+      hexString += hexChar;
     }
 
     if (ObjectId.cacheHexString) this.__id = hexString;

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -94,4 +94,9 @@ describe('ObjectId', function() {
     expect(ObjectId.isValid(buff12Bytes)).to.be.true;
     done();
   });
+
+  it('should throw if a 12-char string is passed in with character codes greater than 256', function() {
+    expect(() => new ObjectId('abcdefghijkl').toHexString()).to.not.throw();
+    expect(() => new ObjectId('abcdefŽhijkl').toHexString()).to.throw(TypeError);
+  });
 });


### PR DESCRIPTION
If a non-hex string of length 12 is passed into the ObjectId
constructor, we generate a hexString based off of the character
codes of the passed in id. This requires that the passed id consist
entirely of characters with values < 256 in utf-16. Previously,
we let this silently fail and generated invalid hex string. Now,
we throw a TypeError

Fixes NODE-1737

BREAKING CHANGE:
Where code was previously silently erroring, users may now
experience TypeErrors