### PR TITLE
Use Buffer equals when comparing ObjectId

### DIFF
--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -224,7 +224,7 @@ class ObjectId {
    */
   equals(otherId) {
     if (otherId instanceof ObjectId) {
-      return this.toString() === otherId.toString();
+      return this.id.equals(otherId.id);
     }
 
     if (

--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -224,7 +224,7 @@ class ObjectId {
    */
   equals(otherId) {
     if (otherId instanceof ObjectId) {
-      return this.id.equals(otherId.id);
+      return this.id[11] === otherId.id[11] && this.id.equals(otherId.id);
     }
 
     if (


### PR DESCRIPTION
This PR updates ObjectId #equals to use internal Node.js buffer #equals function when comparing two ObjectId objects.

While tracing performance issue in our MongoDB based app, I found #equals was calling toString() when comparing two ObjectId, which turns out to be quite inefficient. In our own testing this change appears to be much, much faster when comparing two ObjectIds.