### PR TITLE
fix(object-id): correct serialization of old ObjectID types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
     "Promise": true,
     "Uint8Array" : true,
     "ArrayBuffer" : true,
-    "Set": true
+    "Set": true,
+    "Map": true
   },
   "parserOptions": {
     "ecmaVersion": 2017

--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -138,6 +138,13 @@ class ObjectId {
    * @return {number} returns next index value.
    * @ignore
    */
+  static get_inc() {
+    return (ObjectId.index = (ObjectId.index + 1) % 0xffffff);
+  }
+
+  /**
+   * @deprecated Please use the static form instead
+   */
   get_inc() {
     return (ObjectId.index = (ObjectId.index + 1) % 0xffffff);
   }
@@ -148,6 +155,13 @@ class ObjectId {
    * @method
    * @return {number} returns next index value.
    * @ignore
+   */
+  static getInc() {
+    return ObjectId.get_inc();
+  }
+
+  /**
+   * @deprecated Please use the static form instead
    */
   getInc() {
     return this.get_inc();
@@ -160,7 +174,7 @@ class ObjectId {
    * @param {number} [time] optional parameter allowing to pass in a second based timestamp.
    * @return {Buffer} return the 12 byte id buffer string.
    */
-  generate(time) {
+  static generate(time) {
     if ('number' !== typeof time) {
       time = ~~(Date.now() / 1000);
     }
@@ -187,6 +201,13 @@ class ObjectId {
     buffer[9] = (inc >> 16) & 0xff;
 
     return buffer;
+  }
+
+  /**
+   * @deprecated Please use the static form instead
+   */
+  generate(time) {
+    return ObjectId.generate(time);
   }
 
   /**

--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -2,6 +2,7 @@
 
 const Buffer = require('buffer').Buffer;
 let randomBytes = require('./parser/utils').randomBytes;
+const deprecate = require('util').deprecate;
 
 // constants
 const PROCESS_UNIQUE = randomBytes(5);
@@ -61,7 +62,7 @@ class ObjectId {
     // The most common usecase (blank id, new objectId instance)
     if (id == null || typeof id === 'number') {
       // Generate a new id
-      this.id = this.generate(id);
+      this.id = ObjectId.generate(id);
       // If we are caching the hex string
       if (ObjectId.cacheHexString) this.__id = this.toString('hex');
       // Return the object
@@ -138,33 +139,8 @@ class ObjectId {
    * @return {number} returns next index value.
    * @ignore
    */
-  static get_inc() {
-    return (ObjectId.index = (ObjectId.index + 1) % 0xffffff);
-  }
-
-  /**
-   * @deprecated Please use the static form instead
-   */
-  get_inc() {
-    return (ObjectId.index = (ObjectId.index + 1) % 0xffffff);
-  }
-
-  /**
-   * Update the ObjectId index used in generating new ObjectId's on the driver
-   *
-   * @method
-   * @return {number} returns next index value.
-   * @ignore
-   */
   static getInc() {
-    return ObjectId.get_inc();
-  }
-
-  /**
-   * @deprecated Please use the static form instead
-   */
-  getInc() {
-    return this.get_inc();
+    return (ObjectId.index = (ObjectId.index + 1) % 0xffffff);
   }
 
   /**
@@ -179,7 +155,7 @@ class ObjectId {
       time = ~~(Date.now() / 1000);
     }
 
-    const inc = this.get_inc();
+    const inc = ObjectId.getInc();
     const buffer = Buffer.alloc(12);
 
     // 4-byte timestamp
@@ -201,13 +177,6 @@ class ObjectId {
     buffer[9] = (inc >> 16) & 0xff;
 
     return buffer;
-  }
-
-  /**
-   * @deprecated Please use the static form instead
-   */
-  generate(time) {
-    return ObjectId.generate(time);
   }
 
   /**
@@ -389,6 +358,27 @@ class ObjectId {
     return new ObjectId(doc.$oid);
   }
 }
+
+// Deprecated methods
+ObjectId.get_inc = deprecate(
+  () => ObjectId.getInc(),
+  'Please use the static `ObjectId.getInc()` instead'
+);
+
+ObjectId.prototype.get_inc = deprecate(
+  () => ObjectId.getInc(),
+  'Please use the static `ObjectId.getInc()` instead'
+);
+
+ObjectId.prototype.getInc = deprecate(
+  () => ObjectId.getInc(),
+  'Please use the static `ObjectId.getInc()` instead'
+);
+
+ObjectId.prototype.generate = deprecate(
+  time => ObjectId.generate(time),
+  'Please use the static `ObjectId.generate(time)` instead'
+);
 
 /**
  * @ignore

--- a/lib/parser/serializer.js
+++ b/lib/parser/serializer.js
@@ -251,12 +251,6 @@ function serializeBSONRegExp(buffer, key, value, index, isArray) {
 }
 
 function serializeMinMax(buffer, key, value, index, isArray) {
-  console.log({
-    value,
-    MinKey,
-    isMinKey: value instanceof MinKey
-  });
-
   // Write the type of either min or max key
   if (value === null) {
     buffer[index++] = constants.BSON_DATA_NULL;

--- a/lib/parser/serializer.js
+++ b/lib/parser/serializer.js
@@ -711,7 +711,7 @@ function serializeInto(
         index = serializeNull(buffer, key, value, index, true);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index, true);
-      } else if (value['_bsontype'] === 'ObjectId') {
+      } else if (value['_bsontype'] === 'ObjectId' || value['_bsontype'] === 'ObjectID') {
         index = serializeObjectId(buffer, key, value, index, true);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index, true);
@@ -818,7 +818,7 @@ function serializeInto(
         index = serializeDate(buffer, key, value, index);
       } else if (value === null || (value === undefined && ignoreUndefined === false)) {
         index = serializeNull(buffer, key, value, index);
-      } else if (value['_bsontype'] === 'ObjectId') {
+      } else if (value['_bsontype'] === 'ObjectId' || value['_bsontype'] === 'ObjectID') {
         index = serializeObjectId(buffer, key, value, index);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index);
@@ -920,7 +920,7 @@ function serializeInto(
         if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index);
-      } else if (value['_bsontype'] === 'ObjectId') {
+      } else if (value['_bsontype'] === 'ObjectId' || value['_bsontype'] === 'ObjectID') {
         index = serializeObjectId(buffer, key, value, index);
       } else if (Buffer.isBuffer(value)) {
         index = serializeBuffer(buffer, key, value, index);


### PR DESCRIPTION
`ObjectId` in previous versions of the library had a `bsontype` of `ObjectID` (note the capital lettering at the end). The new library needs to be updated to reflect this. 