### PR TITLE
Fix: deprecation warnings for buffers and util.inspect

### DIFF
--- a/lib/binary.js
+++ b/lib/binary.js
@@ -297,7 +297,7 @@ class Binary {
    */
   static fromExtendedJSON(doc) {
     const type = doc.$binary.subType ? parseInt(doc.$binary.subType, 16) : 0;
-    const data = new Buffer(doc.$binary.base64, 'base64');
+    const data = Buffer.from(doc.$binary.base64, 'base64');
     return new Binary(data, type);
   }
 }

--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -2,7 +2,8 @@
 
 const Buffer = require('buffer').Buffer;
 let randomBytes = require('./parser/utils').randomBytes;
-const deprecate = require('util').deprecate;
+const util = require('util');
+const deprecate = util.deprecate;
 
 // constants
 const PROCESS_UNIQUE = randomBytes(5);
@@ -403,7 +404,7 @@ Object.defineProperty(ObjectId.prototype, 'generationTime', {
  * @return {String} return the 24 byte hex string representation.
  * @ignore
  */
-ObjectId.prototype.inspect = ObjectId.prototype.toString;
+ObjectId.prototype[util.inspect.custom || 'inspect'] = ObjectId.prototype.toString;
 
 /**
  * @ignore

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "docs": "jsdoc2md --heading-depth 3 --template tools/README.hbs --plugin dmd-clear --files lib/bson.js lib/extended_json.js > README.md",
     "test": "npm run-script lint && npm run-script test-node && npm run-script test-browser",
     "test-node": "node --throw-deprecation node_modules/.bin/_mocha ./test/node",
-    "test-browser": "npm run-script build && node --throw-deprecation karma start",
+    "test-browser": "npm run-script build && node --throw-deprecation node_modules/.bin/karma start",
     "build": "rollup -c",
     "lint": "eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "scripts": {
     "docs": "jsdoc2md --heading-depth 3 --template tools/README.hbs --plugin dmd-clear --files lib/bson.js lib/extended_json.js > README.md",
     "test": "npm run-script lint && npm run-script test-node && npm run-script test-browser",
-    "test-node": "mocha ./test/node",
-    "test-browser": "npm run-script build && karma start",
+    "test-node": "node --throw-deprecation node_modules/.bin/_mocha ./test/node",
+    "test-browser": "npm run-script build && node --throw-deprecation karma start",
     "build": "rollup -c",
     "lint": "eslint lib test",
     "format": "prettier --print-width 100 --tab-width 2 --single-quote --write 'test/**/*.js' 'lib/**/*.js'",

--- a/test/node/bson_corpus_tests.js
+++ b/test/node/bson_corpus_tests.js
@@ -158,10 +158,10 @@ describe('BSON Corpus', function() {
               // just use canonical.
               let cB, cEJ;
               if (deprecated) {
-                cB = new Buffer(v.converted_bson, 'hex');
+                cB = Buffer.from(v.converted_bson, 'hex');
                 cEJ = normalize(v.converted_extjson);
               } else {
-                cB = new Buffer(v.canonical_bson, 'hex');
+                cB = Buffer.from(v.canonical_bson, 'hex');
                 cEJ = normalize(v.canonical_extjson);
               }
 

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -24,7 +24,7 @@ describe('Extended JSON', function() {
   let doc = {};
 
   before(function() {
-    const buffer = new Buffer(64);
+    const buffer = Buffer.alloc(64);
     for (var i = 0; i < buffer.length; i++) buffer[i] = i;
     const date = new Date();
     date.setTime(1488372056737);

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -85,9 +85,9 @@ describe('ObjectId', function() {
    * @ignore
    */
   it('should isValid check input Buffer length', function(done) {
-    var buffTooShort = new Buffer([]);
-    var buffTooLong = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-    var buff12Bytes = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    var buffTooShort = Buffer.from([]);
+    var buffTooLong = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    var buff12Bytes = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
     expect(ObjectId.isValid(buffTooShort)).to.be.false;
     expect(ObjectId.isValid(buffTooLong)).to.be.false;


### PR DESCRIPTION
Node has deprecated the `inspect` property on objects for use in `util.inspect()`. Doing so on an ObjectID on Node v10 prints a deprecation warning:

```
(node:16945) [DEP0079] DeprecationWarning: Custom inspection function on Objects via .inspect() is deprecated
```

This fixes it to use the new symbol that is exposed by `util.inspect` instead - and fallback to the string property for old node versions.