### PR TITLE
Fix EJSON.stringify if replacer is array (not function)

### DIFF
--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -251,16 +251,6 @@ function serializeValue(value, options) {
     return { $numberDouble: value.toString() };
   }
 
-  if (value instanceof RegExp) {
-    let flags = value.flags;
-    if (flags === undefined) {
-      flags = value.toString().match(/[gimuy]*$/)[0];
-    }
-
-    const rx = new BSONRegExp(value.source, flags);
-    return rx.toExtendedJSON();
-  }
-
   if (value != null && typeof value === 'object') return serializeDocument(value, options);
   return value;
 }
@@ -268,33 +258,46 @@ function serializeValue(value, options) {
 function serializeDocument(doc, options) {
   if (doc == null || typeof doc !== 'object') throw new Error('not an object instance');
 
-  // the "document" is a BSON type
-  if (doc._bsontype) {
-    if (doc._bsontype === 'ObjectID') {
-      // Deprecated ObjectID class with capital "D" is still used (e.g. by 'mongodb' package). It has
-      // no "toExtendedJSON" method, so convert to new ObjectId (lowercase "d") class before serializing
-      doc = ObjectId.createFromHexString(doc.toString());
+  // the document itself is a BSON type
+  if (doc._bsontype && typeof doc.toExtendedJSON === 'function') {
+    if (doc._bsontype === 'Code' && doc.scope) {
+      doc.scope = serializeDocument(doc.scope, options);
+    } else if (doc._bsontype === 'DBRef' && doc.oid) {
+      doc.oid = serializeDocument(doc.oid, options);
     }
-    if (typeof doc.toExtendedJSON === 'function') {
-      // TODO: the two cases below mutate the original document! Bad.  I don't know
-      // enough about these two BSON types to know how to safely clone these objects, but
-      // someone who knows MongoDB better should fix this to clone instead of mutating input objects.
-      if (doc._bsontype === 'Code' && doc.scope) {
-        doc.scope = serializeDocument(doc.scope, options);
-      } else if (doc._bsontype === 'DBRef' && doc.oid) {
-        doc.oid = serializeDocument(doc.oid, options);
-      }
 
-      return doc.toExtendedJSON(options);
-    }
-    // TODO: should we throw an exception if there's a BSON type that has no toExtendedJSON method?
-  } 
+    return doc.toExtendedJSON(options);
+  }
 
-  // Recursively serialize this document's property values. 
+  // the document is an object with nested BSON types
   const _doc = {};
   for (let name in doc) {
-    const val = doc[name];
+    let val = doc[name];
+    if (Array.isArray(val)) {
+      _doc[name] = serializeArray(val, options);
+    } else if (val != null && typeof val.toExtendedJSON === 'function') {
+      if (val._bsontype === 'Code' && val.scope) {
+        val.scope = serializeDocument(val.scope, options);
+      } else if (val._bsontype === 'DBRef' && val.oid) {
+        val.oid = serializeDocument(val.oid, options);
+      }
+
+      _doc[name] = val.toExtendedJSON(options);
+    } else if (val instanceof Date) {
+      _doc[name] = serializeValue(val, options);
+    } else if (val != null && typeof val === 'object') {
+      _doc[name] = serializeDocument(val, options);
+    }
     _doc[name] = serializeValue(val, options);
+    if (val instanceof RegExp) {
+      let flags = val.flags;
+      if (flags === undefined) {
+        flags = val.toString().match(/[gimuy]*$/)[0];
+      }
+
+      const rx = new BSONRegExp(val.source, flags);
+      _doc[name] = rx.toExtendedJSON();
+    }
   }
 
   return _doc;

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -251,6 +251,16 @@ function serializeValue(value, options) {
     return { $numberDouble: value.toString() };
   }
 
+  if (value instanceof RegExp) {
+    let flags = value.flags;
+    if (flags === undefined) {
+      flags = value.toString().match(/[gimuy]*$/)[0];
+    }
+
+    const rx = new BSONRegExp(value.source, flags);
+    return rx.toExtendedJSON();
+  }
+
   if (value != null && typeof value === 'object') return serializeDocument(value, options);
   return value;
 }
@@ -258,46 +268,33 @@ function serializeValue(value, options) {
 function serializeDocument(doc, options) {
   if (doc == null || typeof doc !== 'object') throw new Error('not an object instance');
 
-  // the document itself is a BSON type
-  if (doc._bsontype && typeof doc.toExtendedJSON === 'function') {
-    if (doc._bsontype === 'Code' && doc.scope) {
-      doc.scope = serializeDocument(doc.scope, options);
-    } else if (doc._bsontype === 'DBRef' && doc.oid) {
-      doc.oid = serializeDocument(doc.oid, options);
+  // the "document" is a BSON type
+  if (doc._bsontype) {
+    if (doc._bsontype === 'ObjectID') {
+      // Deprecated ObjectID class with capital "D" is still used (e.g. by 'mongodb' package). It has
+      // no "toExtendedJSON" method, so convert to new ObjectId (lowercase "d") class before serializing
+      doc = ObjectId.createFromHexString(doc.toString());
     }
+    if (typeof doc.toExtendedJSON === 'function') {
+      // TODO: the two cases below mutate the original document! Bad.  I don't know
+      // enough about these two BSON types to know how to safely clone these objects, but
+      // someone who knows MongoDB better should fix this to clone instead of mutating input objects.
+      if (doc._bsontype === 'Code' && doc.scope) {
+        doc.scope = serializeDocument(doc.scope, options);
+      } else if (doc._bsontype === 'DBRef' && doc.oid) {
+        doc.oid = serializeDocument(doc.oid, options);
+      }
 
-    return doc.toExtendedJSON(options);
-  }
+      return doc.toExtendedJSON(options);
+    }
+    // TODO: should we throw an exception if there's a BSON type that has no toExtendedJSON method?
+  } 
 
-  // the document is an object with nested BSON types
+  // Recursively serialize this document's property values. 
   const _doc = {};
   for (let name in doc) {
-    let val = doc[name];
-    if (Array.isArray(val)) {
-      _doc[name] = serializeArray(val, options);
-    } else if (val != null && typeof val.toExtendedJSON === 'function') {
-      if (val._bsontype === 'Code' && val.scope) {
-        val.scope = serializeDocument(val.scope, options);
-      } else if (val._bsontype === 'DBRef' && val.oid) {
-        val.oid = serializeDocument(val.oid, options);
-      }
-
-      _doc[name] = val.toExtendedJSON(options);
-    } else if (val instanceof Date) {
-      _doc[name] = serializeValue(val, options);
-    } else if (val != null && typeof val === 'object') {
-      _doc[name] = serializeDocument(val, options);
-    }
+    const val = doc[name];
     _doc[name] = serializeValue(val, options);
-    if (val instanceof RegExp) {
-      let flags = val.flags;
-      if (flags === undefined) {
-        flags = val.toString().match(/[gimuy]*$/)[0];
-      }
-
-      const rx = new BSONRegExp(val.source, flags);
-      _doc[name] = rx.toExtendedJSON();
-    }
   }
 
   return _doc;

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -169,9 +169,15 @@ const BSON_INT32_MAX = 0x7fffffff,
  * console.log(EJSON.stringify(doc));
  */
 function stringify(value, replacer, space, options) {
-  if (space != null && typeof space === 'object') (options = space), (space = 0);
-  if (replacer != null && typeof replacer === 'object')
-    (options = replacer), (replacer = null), (space = 0);
+  if (space != null && typeof space === 'object') {
+    options = space;
+    space = 0;
+  }
+  if (replacer != null && typeof replacer === 'object' && !Array.isArray(replacer)) {
+    options = replacer;
+    replacer = null;
+    space = 0;
+  }
   options = Object.assign({}, { relaxed: true }, options);
 
   const doc = Array.isArray(value)

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -253,23 +253,22 @@ describe('Extended JSON', function() {
     expect(result.test).to.equal(34.12);
     expect(result.test).to.be.a('number');
   });
-  
-  it('should work for function-valued and array-valued replacer parameters', function() {
+
+  it('should work for function-valued and array-valued replacer parameters', async function() {
     const doc = { a: new Int32(10), b: new Int32(10) };
 
-    var replacerArray = ['a'];
+    var replacerArray = ['a', '$numberInt'];
     var serialized = EJSON.stringify(doc, replacerArray, 0, { relaxed: false });
     expect(serialized).to.equal('{"a":{"$numberInt":"10"}}');
 
     serialized = EJSON.stringify(doc, replacerArray);
     expect(serialized).to.equal('{"a":10}');
 
-    var replacerFunc = function (key) { return key === 'a' ? '5' : undefined; }
+    var replacerFunc = function (key, value) { return key === 'b' ? undefined : value; }
     serialized = EJSON.stringify(doc, replacerFunc, 0, { relaxed: false });
-    expect(serialized).to.equal('{"a":{"$numberInt":"5"}}');
+    expect(serialized).to.equal('{"a":{"$numberInt":"10"}}');
 
     serialized = EJSON.stringify(doc, replacerFunc);
-    expect(serialized).to.equal('{"a":5}');
+    expect(serialized).to.equal('{"a":10}');
   });
-
 });

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -254,7 +254,7 @@ describe('Extended JSON', function() {
     expect(result.test).to.be.a('number');
   });
 
-  it('should work for function-valued and array-valued replacer parameters', async function() {
+  it('should work for function-valued and array-valued replacer parameters', function() {
     const doc = { a: new Int32(10), b: new Int32(10) };
 
     var replacerArray = ['a', '$numberInt'];

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -15,7 +15,9 @@ const Int32 = BSON.Int32;
 const Long = BSON.Long;
 const MaxKey = BSON.MaxKey;
 const MinKey = BSON.MinKey;
+const OldObjectID = require('mongodb').ObjectID; // use old ObjectID class because MongoDB drivers still return it
 const ObjectID = BSON.ObjectID;
+const ObjectId = BSON.ObjectId;
 const BSONRegExp = BSON.BSONRegExp;
 const BSONSymbol = BSON.BSONSymbol;
 const Timestamp = BSON.Timestamp;
@@ -41,7 +43,9 @@ describe('Extended JSON', function() {
       long: Long.fromNumber(200),
       maxKey: new MaxKey(),
       minKey: new MinKey(),
-      objectId: ObjectID.createFromHexString('111111111111111111111111'),
+      objectId: ObjectId.createFromHexString('111111111111111111111111'),
+      objectID: ObjectID.createFromHexString('111111111111111111111111'),
+      oldObjectID: OldObjectID.createFromHexString('111111111111111111111111'),
       regexp: new BSONRegExp('hello world', 'i'),
       symbol: new BSONSymbol('symbol'),
       timestamp: Timestamp.fromNumber(1000),
@@ -55,7 +59,7 @@ describe('Extended JSON', function() {
   it('should correctly extend an existing mongodb module', function() {
     // Serialize the document
     var json =
-      '{"_id":{"$numberInt":"100"},"gh":{"$numberInt":"1"},"binary":{"$binary":{"base64":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==","subType":"00"}},"date":{"$date":{"$numberLong":"1488372056737"}},"code":{"$code":"function() {}","$scope":{"a":{"$numberInt":"1"}}},"dbRef":{"$ref":"tests","$id":{"$numberInt":"1"},"$db":"test"},"decimal":{"$numberDecimal":"100"},"double":{"$numberDouble":"10.1"},"int32":{"$numberInt":"10"},"long":{"$numberLong":"200"},"maxKey":{"$maxKey":1},"minKey":{"$minKey":1},"objectId":{"$oid":"111111111111111111111111"},"regexp":{"$regularExpression":{"pattern":"hello world","options":"i"}},"symbol":{"$symbol":"symbol"},"timestamp":{"$timestamp":{"t":0,"i":1000}},"int32Number":{"$numberInt":"300"},"doubleNumber":{"$numberDouble":"200.2"},"longNumberIntFit":{"$numberLong":"7036874417766400"},"doubleNumberIntFit":{"$numberLong":"19007199250000000"}}';
+      '{"_id":{"$numberInt":"100"},"gh":{"$numberInt":"1"},"binary":{"$binary":{"base64":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==","subType":"00"}},"date":{"$date":{"$numberLong":"1488372056737"}},"code":{"$code":"function() {}","$scope":{"a":{"$numberInt":"1"}}},"dbRef":{"$ref":"tests","$id":{"$numberInt":"1"},"$db":"test"},"decimal":{"$numberDecimal":"100"},"double":{"$numberDouble":"10.1"},"int32":{"$numberInt":"10"},"long":{"$numberLong":"200"},"maxKey":{"$maxKey":1},"minKey":{"$minKey":1},"objectId":{"$oid":"111111111111111111111111"},"objectID":{"$oid":"111111111111111111111111"},"oldObjectID":{"$oid":"111111111111111111111111"},"regexp":{"$regularExpression":{"pattern":"hello world","options":"i"}},"symbol":{"$symbol":"symbol"},"timestamp":{"$timestamp":{"t":0,"i":1000}},"int32Number":{"$numberInt":"300"},"doubleNumber":{"$numberDouble":"200.2"},"longNumberIntFit":{"$numberLong":"7036874417766400"},"doubleNumberIntFit":{"$numberLong":"19007199250000000"}}';
 
     assert.equal(json, EJSON.stringify(doc, null, 0, { relaxed: false }));
   });
@@ -98,13 +102,32 @@ describe('Extended JSON', function() {
   });
 
   it('should correctly serialize bson types when they are values', function() {
-    var serialized = EJSON.stringify(new ObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
+    var serialized = EJSON.stringify(new ObjectId('591801a468f9e7024b6235ea'), { relaxed: false });
     expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
+    serialized = EJSON.stringify(new ObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
+    expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
+    serialized = EJSON.stringify(new OldObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
+    expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
+
     serialized = EJSON.stringify(new Int32(42), { relaxed: false });
     expect(serialized).to.equal('{"$numberInt":"42"}');
     serialized = EJSON.stringify(
       {
+        _id: { $nin: [new ObjectId('591801a468f9e7024b6235ea')] }
+      },
+      { relaxed: false }
+    );
+    expect(serialized).to.equal('{"_id":{"$nin":[{"$oid":"591801a468f9e7024b6235ea"}]}}');
+    serialized = EJSON.stringify(
+      {
         _id: { $nin: [new ObjectID('591801a468f9e7024b6235ea')] }
+      },
+      { relaxed: false }
+    );
+    expect(serialized).to.equal('{"_id":{"$nin":[{"$oid":"591801a468f9e7024b6235ea"}]}}');
+    serialized = EJSON.stringify(
+      {
+        _id: { $nin: [new OldObjectID('591801a468f9e7024b6235ea')] }
       },
       { relaxed: false }
     );
@@ -122,7 +145,7 @@ describe('Extended JSON', function() {
     var parsed = EJSON.parse(input);
 
     expect(parsed).to.deep.equal({
-      result: [{ _id: new ObjectID('591801a468f9e7024b623939'), emptyField: null }]
+      result: [{ _id: new ObjectId('591801a468f9e7024b623939'), emptyField: null }]
     });
   });
 
@@ -170,7 +193,9 @@ describe('Extended JSON', function() {
       long: new Long(234),
       maxKey: new MaxKey(),
       minKey: new MinKey(),
+      objectId: ObjectId.createFromHexString('111111111111111111111111'),
       objectID: ObjectID.createFromHexString('111111111111111111111111'),
+      oldObjectID: OldObjectID.createFromHexString('111111111111111111111111'),
       bsonRegExp: new BSONRegExp('hello world', 'i'),
       symbol: new BSONSymbol('symbol'),
       timestamp: new Timestamp()
@@ -187,7 +212,9 @@ describe('Extended JSON', function() {
       long: { $numberLong: '234' },
       maxKey: { $maxKey: 1 },
       minKey: { $minKey: 1 },
+      objectId: { $oid: '111111111111111111111111' },
       objectID: { $oid: '111111111111111111111111' },
+      oldObjectID: { $oid: '111111111111111111111111' },
       bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
       symbol: { $symbol: 'symbol' },
       timestamp: { $timestamp: { t: 0, i: 0 } }
@@ -205,7 +232,9 @@ describe('Extended JSON', function() {
       long: { $numberLong: '234' },
       maxKey: { $maxKey: 1 },
       minKey: { $minKey: 1 },
+      objectId: { $oid: '111111111111111111111111' },
       objectID: { $oid: '111111111111111111111111' },
+      oldObjectID: { $oid: '111111111111111111111111' },
       bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
       symbol: { $symbol: 'symbol' },
       timestamp: { $timestamp: { t: 0, i: 0 } }
@@ -237,7 +266,9 @@ describe('Extended JSON', function() {
     // minKey
     expect(result.minKey).to.be.an.instanceOf(BSON.MinKey);
     // objectID
+    expect(result.objectId.toString()).to.equal('111111111111111111111111');
     expect(result.objectID.toString()).to.equal('111111111111111111111111');
+    expect(result.oldObjectID.toString()).to.equal('111111111111111111111111');
     //bsonRegExp
     expect(result.bsonRegExp).to.be.an.instanceOf(BSON.BSONRegExp);
     expect(result.bsonRegExp.pattern).to.equal('hello world');

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -15,12 +15,21 @@ const Int32 = BSON.Int32;
 const Long = BSON.Long;
 const MaxKey = BSON.MaxKey;
 const MinKey = BSON.MinKey;
-const OldObjectID = require('mongodb').ObjectID; // use old ObjectID class because MongoDB drivers still return it
 const ObjectID = BSON.ObjectID;
 const ObjectId = BSON.ObjectId;
 const BSONRegExp = BSON.BSONRegExp;
 const BSONSymbol = BSON.BSONSymbol;
 const Timestamp = BSON.Timestamp;
+
+// support old ObjectID class because MongoDB drivers still return it
+const OldObjectID = (function() {
+  try {
+    return require('mongodb').ObjectID;
+  }
+  catch {
+    return ObjectId; // if mongo is unavailable, e.g. browsers, just re-use BSON's
+  }
+})();
 
 describe('Extended JSON', function() {
   let doc = {};

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -253,4 +253,23 @@ describe('Extended JSON', function() {
     expect(result.test).to.equal(34.12);
     expect(result.test).to.be.a('number');
   });
+  
+  it('should work for function-valued and array-valued replacer parameters', function() {
+    const doc = { a: new Int32(10), b: new Int32(10) };
+
+    var replacerArray = ['a'];
+    var serialized = EJSON.stringify(doc, replacerArray, 0, { relaxed: false });
+    expect(serialized).to.equal('{"a":{"$numberInt":"10"}}');
+
+    serialized = EJSON.stringify(doc, replacerArray);
+    expect(serialized).to.equal('{"a":10}');
+
+    var replacerFunc = function (key) { return key === 'a' ? '5' : undefined; }
+    serialized = EJSON.stringify(doc, replacerFunc, 0, { relaxed: false });
+    expect(serialized).to.equal('{"a":{"$numberInt":"5"}}');
+
+    serialized = EJSON.stringify(doc, replacerFunc);
+    expect(serialized).to.equal('{"a":5}');
+  });
+
 });

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -26,7 +26,7 @@ const OldObjectID = (function() {
   try {
     return require('mongodb').ObjectID;
   }
-  catch {
+  catch (e) {
     return ObjectId; // if mongo is unavailable, e.g. browsers, just re-use BSON's
   }
 })();

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -16,24 +16,9 @@ const Long = BSON.Long;
 const MaxKey = BSON.MaxKey;
 const MinKey = BSON.MinKey;
 const ObjectID = BSON.ObjectID;
-const ObjectId = BSON.ObjectId;
 const BSONRegExp = BSON.BSONRegExp;
 const BSONSymbol = BSON.BSONSymbol;
 const Timestamp = BSON.Timestamp;
-
-// test the old ObjectID class because MongoDB drivers still return it
-// fall back to BSON's ObjectId in browser tests
-function getOldObjectID() {
-  try {
-    const file = require.resolve('mongodb'); // apparently this will fail faster in browser tests
-    return require(file).ObjectID;
-  }
-  catch (e) {
-    return ObjectId; // if mongo is unavailable, e.g. browsers, just re-use BSON's
-  }
-}
-
-const OldObjectID = getOldObjectID();
 
 describe('Extended JSON', function() {
   let doc = {};
@@ -56,9 +41,7 @@ describe('Extended JSON', function() {
       long: Long.fromNumber(200),
       maxKey: new MaxKey(),
       minKey: new MinKey(),
-      objectId: ObjectId.createFromHexString('111111111111111111111111'),
-      objectID: ObjectID.createFromHexString('111111111111111111111111'),
-      oldObjectID: OldObjectID.createFromHexString('111111111111111111111111'),
+      objectId: ObjectID.createFromHexString('111111111111111111111111'),
       regexp: new BSONRegExp('hello world', 'i'),
       symbol: new BSONSymbol('symbol'),
       timestamp: Timestamp.fromNumber(1000),
@@ -72,7 +55,7 @@ describe('Extended JSON', function() {
   it('should correctly extend an existing mongodb module', function() {
     // Serialize the document
     var json =
-      '{"_id":{"$numberInt":"100"},"gh":{"$numberInt":"1"},"binary":{"$binary":{"base64":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==","subType":"00"}},"date":{"$date":{"$numberLong":"1488372056737"}},"code":{"$code":"function() {}","$scope":{"a":{"$numberInt":"1"}}},"dbRef":{"$ref":"tests","$id":{"$numberInt":"1"},"$db":"test"},"decimal":{"$numberDecimal":"100"},"double":{"$numberDouble":"10.1"},"int32":{"$numberInt":"10"},"long":{"$numberLong":"200"},"maxKey":{"$maxKey":1},"minKey":{"$minKey":1},"objectId":{"$oid":"111111111111111111111111"},"objectID":{"$oid":"111111111111111111111111"},"oldObjectID":{"$oid":"111111111111111111111111"},"regexp":{"$regularExpression":{"pattern":"hello world","options":"i"}},"symbol":{"$symbol":"symbol"},"timestamp":{"$timestamp":{"t":0,"i":1000}},"int32Number":{"$numberInt":"300"},"doubleNumber":{"$numberDouble":"200.2"},"longNumberIntFit":{"$numberLong":"7036874417766400"},"doubleNumberIntFit":{"$numberLong":"19007199250000000"}}';
+      '{"_id":{"$numberInt":"100"},"gh":{"$numberInt":"1"},"binary":{"$binary":{"base64":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==","subType":"00"}},"date":{"$date":{"$numberLong":"1488372056737"}},"code":{"$code":"function() {}","$scope":{"a":{"$numberInt":"1"}}},"dbRef":{"$ref":"tests","$id":{"$numberInt":"1"},"$db":"test"},"decimal":{"$numberDecimal":"100"},"double":{"$numberDouble":"10.1"},"int32":{"$numberInt":"10"},"long":{"$numberLong":"200"},"maxKey":{"$maxKey":1},"minKey":{"$minKey":1},"objectId":{"$oid":"111111111111111111111111"},"regexp":{"$regularExpression":{"pattern":"hello world","options":"i"}},"symbol":{"$symbol":"symbol"},"timestamp":{"$timestamp":{"t":0,"i":1000}},"int32Number":{"$numberInt":"300"},"doubleNumber":{"$numberDouble":"200.2"},"longNumberIntFit":{"$numberLong":"7036874417766400"},"doubleNumberIntFit":{"$numberLong":"19007199250000000"}}';
 
     assert.equal(json, EJSON.stringify(doc, null, 0, { relaxed: false }));
   });
@@ -115,32 +98,13 @@ describe('Extended JSON', function() {
   });
 
   it('should correctly serialize bson types when they are values', function() {
-    var serialized = EJSON.stringify(new ObjectId('591801a468f9e7024b6235ea'), { relaxed: false });
+    var serialized = EJSON.stringify(new ObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
     expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
-    serialized = EJSON.stringify(new ObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
-    expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
-    serialized = EJSON.stringify(new OldObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
-    expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
-
     serialized = EJSON.stringify(new Int32(42), { relaxed: false });
     expect(serialized).to.equal('{"$numberInt":"42"}');
     serialized = EJSON.stringify(
       {
-        _id: { $nin: [new ObjectId('591801a468f9e7024b6235ea')] }
-      },
-      { relaxed: false }
-    );
-    expect(serialized).to.equal('{"_id":{"$nin":[{"$oid":"591801a468f9e7024b6235ea"}]}}');
-    serialized = EJSON.stringify(
-      {
         _id: { $nin: [new ObjectID('591801a468f9e7024b6235ea')] }
-      },
-      { relaxed: false }
-    );
-    expect(serialized).to.equal('{"_id":{"$nin":[{"$oid":"591801a468f9e7024b6235ea"}]}}');
-    serialized = EJSON.stringify(
-      {
-        _id: { $nin: [new OldObjectID('591801a468f9e7024b6235ea')] }
       },
       { relaxed: false }
     );
@@ -158,7 +122,7 @@ describe('Extended JSON', function() {
     var parsed = EJSON.parse(input);
 
     expect(parsed).to.deep.equal({
-      result: [{ _id: new ObjectId('591801a468f9e7024b623939'), emptyField: null }]
+      result: [{ _id: new ObjectID('591801a468f9e7024b623939'), emptyField: null }]
     });
   });
 
@@ -206,9 +170,7 @@ describe('Extended JSON', function() {
       long: new Long(234),
       maxKey: new MaxKey(),
       minKey: new MinKey(),
-      objectId: ObjectId.createFromHexString('111111111111111111111111'),
       objectID: ObjectID.createFromHexString('111111111111111111111111'),
-      oldObjectID: OldObjectID.createFromHexString('111111111111111111111111'),
       bsonRegExp: new BSONRegExp('hello world', 'i'),
       symbol: new BSONSymbol('symbol'),
       timestamp: new Timestamp()
@@ -225,9 +187,7 @@ describe('Extended JSON', function() {
       long: { $numberLong: '234' },
       maxKey: { $maxKey: 1 },
       minKey: { $minKey: 1 },
-      objectId: { $oid: '111111111111111111111111' },
       objectID: { $oid: '111111111111111111111111' },
-      oldObjectID: { $oid: '111111111111111111111111' },
       bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
       symbol: { $symbol: 'symbol' },
       timestamp: { $timestamp: { t: 0, i: 0 } }
@@ -245,9 +205,7 @@ describe('Extended JSON', function() {
       long: { $numberLong: '234' },
       maxKey: { $maxKey: 1 },
       minKey: { $minKey: 1 },
-      objectId: { $oid: '111111111111111111111111' },
       objectID: { $oid: '111111111111111111111111' },
-      oldObjectID: { $oid: '111111111111111111111111' },
       bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
       symbol: { $symbol: 'symbol' },
       timestamp: { $timestamp: { t: 0, i: 0 } }
@@ -279,9 +237,7 @@ describe('Extended JSON', function() {
     // minKey
     expect(result.minKey).to.be.an.instanceOf(BSON.MinKey);
     // objectID
-    expect(result.objectId.toString()).to.equal('111111111111111111111111');
     expect(result.objectID.toString()).to.equal('111111111111111111111111');
-    expect(result.oldObjectID.toString()).to.equal('111111111111111111111111');
     //bsonRegExp
     expect(result.bsonRegExp).to.be.an.instanceOf(BSON.BSONRegExp);
     expect(result.bsonRegExp.pattern).to.equal('hello world');

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -21,15 +21,19 @@ const BSONRegExp = BSON.BSONRegExp;
 const BSONSymbol = BSON.BSONSymbol;
 const Timestamp = BSON.Timestamp;
 
-// support old ObjectID class because MongoDB drivers still return it
-const OldObjectID = (function() {
+// test the old ObjectID class because MongoDB drivers still return it
+// fall back to BSON's ObjectId in browser tests
+function getOldObjectID() {
   try {
-    return require('mongodb').ObjectID;
+    const file = require.resolve('mongodb'); // apparently this will fail faster in browser tests
+    return require(file).ObjectID;
   }
   catch (e) {
     return ObjectId; // if mongo is unavailable, e.g. browsers, just re-use BSON's
   }
-})();
+}
+
+const OldObjectID = getOldObjectID();
 
 describe('Extended JSON', function() {
   let doc = {};


### PR DESCRIPTION
Currently, passing an array form of the `replacer` parameter of `EJSON.stringify` will not work, despite the documentation saying that it should work.  The cause is that the current implementation checks whether `replacer` is of type `object`, and if it is then it assumes that the `replacer` parameter is really the `options` parameter (meaning that `replacer` and `space` have been omitted by the user).  This logic breaks when `replacer` is an array (which is an `object` too). 

To fix this problem I added a check using `Array.isArray` so the replacement above will only happen if `replacer` is an object that's not an array. 

While I was editing this method, I also changed the weird (and eslint-defying) use of assignment expressions like this: 
`if (space != null && typeof space === 'object') (options = space), (space = 0);` 
to a more conventional statement form of assignment.

This PR doesn't conflict or overlap with two other PRs I filed today: #304 and #305.