### PR TITLE
Stop running Extended JSON serializer twice for each nested document

### DIFF
--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -282,8 +282,7 @@ function serializeDocument(doc, options) {
   // Recursively serialize this document's property values. 
   const _doc = {};
   for (let name in doc) {
-    const val = doc[name];
-    _doc[name] = serializeValue(val, options);
+    _doc[name] = serializeValue(doc[name], options);
   }
 
   return _doc;

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -245,6 +245,16 @@ function serializeValue(value, options) {
     return { $numberDouble: value.toString() };
   }
 
+  if (value instanceof RegExp) {
+    let flags = value.flags;
+    if (flags === undefined) {
+      flags = value.toString().match(/[gimuy]*$/)[0];
+    }
+
+    const rx = new BSONRegExp(value.source, flags);
+    return rx.toExtendedJSON();
+  }
+
   if (value != null && typeof value === 'object') return serializeDocument(value, options);
   return value;
 }
@@ -252,46 +262,28 @@ function serializeValue(value, options) {
 function serializeDocument(doc, options) {
   if (doc == null || typeof doc !== 'object') throw new Error('not an object instance');
 
-  // the document itself is a BSON type
-  if (doc._bsontype && typeof doc.toExtendedJSON === 'function') {
-    if (doc._bsontype === 'Code' && doc.scope) {
-      doc.scope = serializeDocument(doc.scope, options);
-    } else if (doc._bsontype === 'DBRef' && doc.oid) {
-      doc.oid = serializeDocument(doc.oid, options);
+  // the "document" is a BSON type
+  if (doc._bsontype) {
+    if (typeof doc.toExtendedJSON === 'function') {
+      // TODO: the two cases below mutate the original document! Bad.  I don't know
+      // enough about these two BSON types to know how to safely clone these objects, but
+      // someone who knows MongoDB better should fix this to clone instead of mutating input objects.
+      if (doc._bsontype === 'Code' && doc.scope) {
+        doc.scope = serializeDocument(doc.scope, options);
+      } else if (doc._bsontype === 'DBRef' && doc.oid) {
+        doc.oid = serializeDocument(doc.oid, options);
+      }
+
+      return doc.toExtendedJSON(options);
     }
+    // TODO: should we throw an exception if there's a BSON type that has no toExtendedJSON method?
+  } 
 
-    return doc.toExtendedJSON(options);
-  }
-
-  // the document is an object with nested BSON types
+  // Recursively serialize this document's property values. 
   const _doc = {};
   for (let name in doc) {
-    let val = doc[name];
-    if (Array.isArray(val)) {
-      _doc[name] = serializeArray(val, options);
-    } else if (val != null && typeof val.toExtendedJSON === 'function') {
-      if (val._bsontype === 'Code' && val.scope) {
-        val.scope = serializeDocument(val.scope, options);
-      } else if (val._bsontype === 'DBRef' && val.oid) {
-        val.oid = serializeDocument(val.oid, options);
-      }
-
-      _doc[name] = val.toExtendedJSON(options);
-    } else if (val instanceof Date) {
-      _doc[name] = serializeValue(val, options);
-    } else if (val != null && typeof val === 'object') {
-      _doc[name] = serializeDocument(val, options);
-    }
+    const val = doc[name];
     _doc[name] = serializeValue(val, options);
-    if (val instanceof RegExp) {
-      let flags = val.flags;
-      if (flags === undefined) {
-        flags = val.toString().match(/[gimuy]*$/)[0];
-      }
-
-      const rx = new BSONRegExp(val.source, flags);
-      _doc[name] = rx.toExtendedJSON();
-    }
   }
 
   return _doc;

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -16,20 +16,9 @@ const Long = BSON.Long;
 const MaxKey = BSON.MaxKey;
 const MinKey = BSON.MinKey;
 const ObjectID = BSON.ObjectID;
-const ObjectId = BSON.ObjectId;
 const BSONRegExp = BSON.BSONRegExp;
 const BSONSymbol = BSON.BSONSymbol;
 const Timestamp = BSON.Timestamp;
-
-// support old ObjectID class because MongoDB drivers still return it
-const OldObjectID = (function() {
-  try {
-    return require('mongodb').ObjectID;
-  }
-  catch {
-    return ObjectId; // if mongo is unavailable, e.g. browsers, just re-use BSON's
-  }
-})();
 
 describe('Extended JSON', function() {
   let doc = {};
@@ -52,9 +41,7 @@ describe('Extended JSON', function() {
       long: Long.fromNumber(200),
       maxKey: new MaxKey(),
       minKey: new MinKey(),
-      objectId: ObjectId.createFromHexString('111111111111111111111111'),
-      objectID: ObjectID.createFromHexString('111111111111111111111111'),
-      oldObjectID: OldObjectID.createFromHexString('111111111111111111111111'),
+      objectId: ObjectID.createFromHexString('111111111111111111111111'),
       regexp: new BSONRegExp('hello world', 'i'),
       symbol: new BSONSymbol('symbol'),
       timestamp: Timestamp.fromNumber(1000),
@@ -68,7 +55,7 @@ describe('Extended JSON', function() {
   it('should correctly extend an existing mongodb module', function() {
     // Serialize the document
     var json =
-      '{"_id":{"$numberInt":"100"},"gh":{"$numberInt":"1"},"binary":{"$binary":{"base64":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==","subType":"00"}},"date":{"$date":{"$numberLong":"1488372056737"}},"code":{"$code":"function() {}","$scope":{"a":{"$numberInt":"1"}}},"dbRef":{"$ref":"tests","$id":{"$numberInt":"1"},"$db":"test"},"decimal":{"$numberDecimal":"100"},"double":{"$numberDouble":"10.1"},"int32":{"$numberInt":"10"},"long":{"$numberLong":"200"},"maxKey":{"$maxKey":1},"minKey":{"$minKey":1},"objectId":{"$oid":"111111111111111111111111"},"objectID":{"$oid":"111111111111111111111111"},"oldObjectID":{"$oid":"111111111111111111111111"},"regexp":{"$regularExpression":{"pattern":"hello world","options":"i"}},"symbol":{"$symbol":"symbol"},"timestamp":{"$timestamp":{"t":0,"i":1000}},"int32Number":{"$numberInt":"300"},"doubleNumber":{"$numberDouble":"200.2"},"longNumberIntFit":{"$numberLong":"7036874417766400"},"doubleNumberIntFit":{"$numberLong":"19007199250000000"}}';
+      '{"_id":{"$numberInt":"100"},"gh":{"$numberInt":"1"},"binary":{"$binary":{"base64":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==","subType":"00"}},"date":{"$date":{"$numberLong":"1488372056737"}},"code":{"$code":"function() {}","$scope":{"a":{"$numberInt":"1"}}},"dbRef":{"$ref":"tests","$id":{"$numberInt":"1"},"$db":"test"},"decimal":{"$numberDecimal":"100"},"double":{"$numberDouble":"10.1"},"int32":{"$numberInt":"10"},"long":{"$numberLong":"200"},"maxKey":{"$maxKey":1},"minKey":{"$minKey":1},"objectId":{"$oid":"111111111111111111111111"},"regexp":{"$regularExpression":{"pattern":"hello world","options":"i"}},"symbol":{"$symbol":"symbol"},"timestamp":{"$timestamp":{"t":0,"i":1000}},"int32Number":{"$numberInt":"300"},"doubleNumber":{"$numberDouble":"200.2"},"longNumberIntFit":{"$numberLong":"7036874417766400"},"doubleNumberIntFit":{"$numberLong":"19007199250000000"}}';
 
     assert.equal(json, EJSON.stringify(doc, null, 0, { relaxed: false }));
   });
@@ -111,32 +98,13 @@ describe('Extended JSON', function() {
   });
 
   it('should correctly serialize bson types when they are values', function() {
-    var serialized = EJSON.stringify(new ObjectId('591801a468f9e7024b6235ea'), { relaxed: false });
+    var serialized = EJSON.stringify(new ObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
     expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
-    serialized = EJSON.stringify(new ObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
-    expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
-    serialized = EJSON.stringify(new OldObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
-    expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
-
     serialized = EJSON.stringify(new Int32(42), { relaxed: false });
     expect(serialized).to.equal('{"$numberInt":"42"}');
     serialized = EJSON.stringify(
       {
-        _id: { $nin: [new ObjectId('591801a468f9e7024b6235ea')] }
-      },
-      { relaxed: false }
-    );
-    expect(serialized).to.equal('{"_id":{"$nin":[{"$oid":"591801a468f9e7024b6235ea"}]}}');
-    serialized = EJSON.stringify(
-      {
         _id: { $nin: [new ObjectID('591801a468f9e7024b6235ea')] }
-      },
-      { relaxed: false }
-    );
-    expect(serialized).to.equal('{"_id":{"$nin":[{"$oid":"591801a468f9e7024b6235ea"}]}}');
-    serialized = EJSON.stringify(
-      {
-        _id: { $nin: [new OldObjectID('591801a468f9e7024b6235ea')] }
       },
       { relaxed: false }
     );
@@ -154,7 +122,7 @@ describe('Extended JSON', function() {
     var parsed = EJSON.parse(input);
 
     expect(parsed).to.deep.equal({
-      result: [{ _id: new ObjectId('591801a468f9e7024b623939'), emptyField: null }]
+      result: [{ _id: new ObjectID('591801a468f9e7024b623939'), emptyField: null }]
     });
   });
 
@@ -202,9 +170,7 @@ describe('Extended JSON', function() {
       long: new Long(234),
       maxKey: new MaxKey(),
       minKey: new MinKey(),
-      objectId: ObjectId.createFromHexString('111111111111111111111111'),
       objectID: ObjectID.createFromHexString('111111111111111111111111'),
-      oldObjectID: OldObjectID.createFromHexString('111111111111111111111111'),
       bsonRegExp: new BSONRegExp('hello world', 'i'),
       symbol: new BSONSymbol('symbol'),
       timestamp: new Timestamp()
@@ -221,9 +187,7 @@ describe('Extended JSON', function() {
       long: { $numberLong: '234' },
       maxKey: { $maxKey: 1 },
       minKey: { $minKey: 1 },
-      objectId: { $oid: '111111111111111111111111' },
       objectID: { $oid: '111111111111111111111111' },
-      oldObjectID: { $oid: '111111111111111111111111' },
       bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
       symbol: { $symbol: 'symbol' },
       timestamp: { $timestamp: { t: 0, i: 0 } }
@@ -241,9 +205,7 @@ describe('Extended JSON', function() {
       long: { $numberLong: '234' },
       maxKey: { $maxKey: 1 },
       minKey: { $minKey: 1 },
-      objectId: { $oid: '111111111111111111111111' },
       objectID: { $oid: '111111111111111111111111' },
-      oldObjectID: { $oid: '111111111111111111111111' },
       bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
       symbol: { $symbol: 'symbol' },
       timestamp: { $timestamp: { t: 0, i: 0 } }
@@ -275,9 +237,7 @@ describe('Extended JSON', function() {
     // minKey
     expect(result.minKey).to.be.an.instanceOf(BSON.MinKey);
     // objectID
-    expect(result.objectId.toString()).to.equal('111111111111111111111111');
     expect(result.objectID.toString()).to.equal('111111111111111111111111');
-    expect(result.oldObjectID.toString()).to.equal('111111111111111111111111');
     //bsonRegExp
     expect(result.bsonRegExp).to.be.an.instanceOf(BSON.BSONRegExp);
     expect(result.bsonRegExp.pattern).to.equal('hello world');
@@ -292,23 +252,5 @@ describe('Extended JSON', function() {
     const result = EJSON.deserialize({ test: 34.12 }, { relaxed: true });
     expect(result.test).to.equal(34.12);
     expect(result.test).to.be.a('number');
-  });
-
-  it('should work for function-valued and array-valued replacer parameters', function() {
-    const doc = { a: new Int32(10), b: new Int32(10) };
-
-    var replacerArray = ['a', '$numberInt'];
-    var serialized = EJSON.stringify(doc, replacerArray, 0, { relaxed: false });
-    expect(serialized).to.equal('{"a":{"$numberInt":"10"}}');
-
-    serialized = EJSON.stringify(doc, replacerArray);
-    expect(serialized).to.equal('{"a":10}');
-
-    var replacerFunc = function (key, value) { return key === 'b' ? undefined : value; }
-    serialized = EJSON.stringify(doc, replacerFunc, 0, { relaxed: false });
-    expect(serialized).to.equal('{"a":{"$numberInt":"10"}}');
-
-    serialized = EJSON.stringify(doc, replacerFunc);
-    expect(serialized).to.equal('{"a":10}');
   });
 });


### PR DESCRIPTION
This PR fixes #302 (Extended JSON serializer runs twice for every nested document) by refactoring EJSON serialization to remove the ignored first serialization and to remove the duplicated code that was producing the ignored first serialization.

Although all existing tests still pass, I didn't add any new tests because the only externally-visible change from this PR should be faster serialization-- the library itself should work the same.

I also noticed two other potential problems that I didn't know how to fix, so I added TODO comments that can be addressed in later PRs.

This PR's code changes overlap with #304, but the overlapping lines are the same in both--and neither PR is dependent on the other--so they should merge together or individually without conflicts.