### PR TITLE
Fix getTimestamp for times beyond 2038

### DIFF
--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -254,7 +254,7 @@ class ObjectId {
     // 2038) we must be careful to avoid creating a negative time. To do that,
     // use only the high 31 bits of the 32 bit timestamp, then add the least
     // significant bit after converting to a number:
-    const time = 2 * ((this.id[3] >>> 1) | (this.id[2] << 7) | (this.id[1] << 15) | (this.id[0] << 23)) + (this.id[3] & 1);
+    const time = this.id.readUInt32BE(0);
     timestamp.setTime(Math.floor(time) * 1000);
     return timestamp;
   }

--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -249,7 +249,12 @@ class ObjectId {
    */
   getTimestamp() {
     const timestamp = new Date();
-    const time = this.id[3] | (this.id[2] << 8) | (this.id[1] << 16) | (this.id[0] << 24);
+    // javascript performs bitwise operations as if the values are signed 32
+    // bit integers - so if the highest bit of this.id[0] is set (times beyond
+    // 2038) we must be careful to avoid creating a negative time. To do that,
+    // use only the high 31 bits of the 32 bit timestamp, then add the least
+    // significant bit after converting to a number:
+    const time = 2 * ((this.id[3] >>> 1) | (this.id[2] << 7) | (this.id[1] << 15) | (this.id[0] << 23)) + (this.id[3] & 1);
     timestamp.setTime(Math.floor(time) * 1000);
     return timestamp;
   }

--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -249,11 +249,6 @@ class ObjectId {
    */
   getTimestamp() {
     const timestamp = new Date();
-    // javascript performs bitwise operations as if the values are signed 32
-    // bit integers - so if the highest bit of this.id[0] is set (times beyond
-    // 2038) we must be careful to avoid creating a negative time. To do that,
-    // use only the high 31 bits of the 32 bit timestamp, then add the least
-    // significant bit after converting to a number:
     const time = this.id.readUInt32BE(0);
     timestamp.setTime(Math.floor(time) * 1000);
     return timestamp;

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -99,4 +99,9 @@ describe('ObjectId', function() {
     expect(() => new ObjectId('abcdefghijkl').toHexString()).to.not.throw();
     expect(() => new ObjectId('abcdefŽhijkl').toHexString()).to.throw(TypeError);
   });
+
+  it('should correctly interpret timestamps beyond 2038', function() {
+    var farFuture = new Date('2040-01-01T00:00:00.000Z').getTime();
+    expect(new BSON.ObjectId(BSON.ObjectId.generate(farFuture/1000)).getTimestamp().getTime()).to.equal(farFuture);
+  });
 });


### PR DESCRIPTION
Avoid treating timestamps with the most significant bit set as negative. The mongodb documentation describe the timetsamp portion of objectids as 'seconds since the unix epoch', so this seems to be the correct behaviour, although I cannot find a formal specification for it.

However this is technically a breaking change if people were relying on timestamp values before 1970.