### PR TITLE
fix(Timestamp): make sure timestamp is always unsigned

### DIFF
--- a/lib/timestamp.js
+++ b/lib/timestamp.js
@@ -11,9 +11,9 @@ const Long = require('./long');
 class Timestamp extends Long {
   constructor(low, high) {
     if (Long.isLong(low)) {
-      super(low.low, low.high);
+      super(low.low, low.high, true);
     } else {
-      super(low, high);
+      super(low, high, true);
     }
   }
 
@@ -37,7 +37,7 @@ class Timestamp extends Long {
    * @return {Timestamp} the timestamp.
    */
   static fromInt(value) {
-    return new Timestamp(Long.fromInt(value));
+    return new Timestamp(Long.fromInt(value, true));
   }
 
   /**
@@ -48,7 +48,7 @@ class Timestamp extends Long {
    * @return {Timestamp} the timestamp.
    */
   static fromNumber(value) {
-    return new Timestamp(Long.fromNumber(value));
+    return new Timestamp(Long.fromNumber(value, true));
   }
 
   /**
@@ -72,14 +72,14 @@ class Timestamp extends Long {
    * @return {Timestamp} the timestamp.
    */
   static fromString(str, opt_radix) {
-    return new Timestamp(Long.fromString(str, opt_radix));
+    return new Timestamp(Long.fromString(str, opt_radix, true));
   }
 
   /**
    * @ignore
    */
   toExtendedJSON() {
-    return { $timestamp: { t: this.high, i: this.low } };
+    return { $timestamp: { t: this.high >>> 0, i: this.low >>> 0 } };
   }
 
   /**
@@ -91,4 +91,7 @@ class Timestamp extends Long {
 }
 
 Object.defineProperty(Timestamp.prototype, '_bsontype', { value: 'Timestamp' });
+
+Timestamp.MAX_VALUE = Timestamp.MAX_UNSIGNED_VALUE;
+
 module.exports = Timestamp;

--- a/test/node/timestamp_tests.js
+++ b/test/node/timestamp_tests.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const BSON = require('../../lib/bson');
+const expect = require('chai').expect;
+
+describe('Timestamp', function() {
+  it('should have a MAX_VALUE equal to Long.MAX_UNSIGNED_VALUE', function() {
+    expect(BSON.Timestamp.MAX_VALUE).to.equal(BSON.Long.MAX_UNSIGNED_VALUE);
+  });
+
+  it('should always be an unsigned value', function() {
+    [
+      new BSON.Timestamp(),
+      new BSON.Timestamp(0xff, 0xffffffff),
+      new BSON.Timestamp(0xffffffff, 0xffffffff),
+      new BSON.Timestamp(-1, -1),
+      new BSON.Timestamp(new BSON.Timestamp(0xffffffff, 0xffffffff)),
+      new BSON.Timestamp(new BSON.Long(0xffffffff, 0xfffffffff, false)),
+      new BSON.Timestamp(new BSON.Long(0xffffffff, 0xfffffffff, true))
+    ].forEach(timestamp => {
+      expect(timestamp).to.have.property('unsigned', true);
+    });
+  });
+
+  it('should print out an unsigned number', function() {
+    const timestamp = new BSON.Timestamp(0xffffffff, 0xffffffff);
+    expect(timestamp.toString()).to.equal('18446744073709551615');
+    expect(timestamp.toJSON()).to.deep.equal({ $timestamp: '18446744073709551615' });
+    expect(timestamp.toExtendedJSON()).to.deep.equal({
+      $timestamp: { t: 4294967295, i: 4294967295 }
+    });
+  });
+});


### PR DESCRIPTION
Fixes NODE-1939