### PR TITLE
fix(Decimal128): throw error when passing a string to Decimal128 constructor

### DIFF
--- a/lib/decimal128.js
+++ b/lib/decimal128.js
@@ -154,6 +154,9 @@ function invalidErr(string, message) {
  * @return {Double}
  */
 function Decimal128(bytes) {
+  if (typeof bytes === 'string') {
+    throw new Error('Decimal128 constructor expects a Buffer parameter. Use `Decimal128.fromString()` to load a Decimal128 from a string'); 
+  }
   this.bytes = bytes;
 }
 


### PR DESCRIPTION
You can get some nasty surprises when you pass a string to the Decimal128 constructor:

```javascript
const bson = require('bson');

const v = new bson.Decimal128('14.92');

// {"$numberDecimal":"8.740930561E-6167"}
console.log(JSON.stringify(v));
```

Would be handy to at least throw an error. Although is there some reason why we can't just do `fromString()` if the user passes a string instead of a buffer to the `Decimal128` constructor?