### PR TITLE
src(objectid): cleanup and simplification, perf improvement

### DIFF
--- a/lib/objectid.js
+++ b/lib/objectid.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Buffer = require('buffer').Buffer;
-let randomBytes = require('./parser/utils').randomBytes;
+const randomBytes = require('./parser/utils').randomBytes;
 const util = require('util');
 const deprecate = util.deprecate;
 
@@ -10,30 +10,11 @@ const PROCESS_UNIQUE = randomBytes(5);
 
 // Regular expression that checks for hex value
 const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
-let hasBufferType = false;
-
-// Check if buffer exists
-try {
-  if (Buffer && Buffer.from) hasBufferType = true;
-} catch (err) {
-  hasBufferType = false;
-}
 
 // Precomputed hex table enables speedy hex string conversion
 const hexTable = [];
 for (let i = 0; i < 256; i++) {
   hexTable[i] = (i <= 15 ? '0' : '') + i.toString(16);
-}
-
-// Lookup tables
-const decodeLookup = [];
-let i = 0;
-while (i < 10) decodeLookup[0x30 + i] = i++;
-while (i < 16) decodeLookup[0x41 - 10 + i] = decodeLookup[0x61 - 10 + i] = i++;
-
-const _Buffer = Buffer;
-function convertToHex(bytes) {
-  return bytes.toString('hex');
 }
 
 function makeObjectIdError(invalidString, index) {
@@ -52,49 +33,40 @@ class ObjectId {
   /**
    * Create an ObjectId type
    *
-   * @param {(string|Buffer|number)} id Can be a 24 byte hex string, 12 byte binary Buffer, or a Number.
+   * @param {(string|Buffer|number)} id Can be a 24 character hex string, 12 byte string, 12 byte Buffer, or a Number.
    * @property {number} generationTime The generation time of this ObjectId instance
    * @return {ObjectId} instance of ObjectId.
    */
   constructor(id) {
-    // Duck-typing to support ObjectId from different npm packages
     if (id instanceof ObjectId) return id;
 
-    // The most common usecase (blank id, new objectId instance)
     if (id == null || typeof id === 'number') {
-      // Generate a new id
       this.id = ObjectId.generate(id);
-      // If we are caching the hex string
-      if (ObjectId.cacheHexString) this.__id = this.toString('hex');
-      // Return the object
-      return;
-    }
-
-    // Check if the passed in id is valid
-    const valid = ObjectId.isValid(id);
-
-    // Throw an error if it's not a valid setup
-    if (!valid && id != null) {
-      throw new TypeError(
-        'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
-      );
-    } else if (valid && typeof id === 'string' && id.length === 24 && hasBufferType) {
-      return new ObjectId(Buffer.from(id, 'hex'));
-    } else if (valid && typeof id === 'string' && id.length === 24) {
-      return ObjectId.createFromHexString(id);
-    } else if (id != null && id.length === 12) {
-      // assume 12 byte string
+    } else if (typeof id === 'string') {
+      if (id.length === 24 && checkForHexRegExp.test(id)) {
+        this.id = Buffer.from(id, 'hex');
+        this.__id = id;
+      } else if (id.length === 12) {
+        // TODO convert to buffer now? Would allow cleaning up 'equals' method
+        // and fix the bug in 'getTimestamp'.
+        this.id = id;
+      }
+    } else if (id instanceof Buffer && id.length === 12) {
       this.id = id;
-    } else if (id != null && id.toHexString) {
+    } else if (id.toHexString) {
       // Duck-typing to support ObjectId from different npm packages
-      return ObjectId.createFromHexString(id.toHexString());
-    } else {
+      this.id = Buffer.from(id.toHexString(), 'hex');
+    }
+
+    if (!this.id) {
       throw new TypeError(
         'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
       );
     }
 
-    if (ObjectId.cacheHexString) this.__id = this.toString('hex');
+    if (ObjectId.cacheHexString && !this.__id) {
+      this.__id = this.toString('hex');
+    }
   }
 
   /**
@@ -106,7 +78,6 @@ class ObjectId {
   toHexString() {
     if (ObjectId.cacheHexString && this.__id) return this.__id;
 
-    let hexString = '';
     if (!this.id || !this.id.length) {
       throw new TypeError(
         'invalid ObjectId, ObjectId.id must be either a string or a Buffer, but is [' +
@@ -115,12 +86,13 @@ class ObjectId {
       );
     }
 
-    if (this.id instanceof _Buffer) {
-      hexString = convertToHex(this.id);
+    if (this.id instanceof Buffer) {
+      const hexString = this.id.toString('hex');
       if (ObjectId.cacheHexString) this.__id = hexString;
       return hexString;
     }
 
+    let hexString = '';
     for (let i = 0; i < this.id.length; i++) {
       const hexChar = hexTable[this.id.charCodeAt(i)];
       if (typeof hexChar !== 'string') {
@@ -189,7 +161,7 @@ class ObjectId {
    */
   toString(format) {
     // Is the id a buffer then use the buffer toString method to return the format
-    if (this.id && this.id.copy) {
+    if (this.id && this.id instanceof Buffer) {
       return this.id.toString(typeof format === 'string' ? format : 'hex');
     }
 
@@ -218,24 +190,16 @@ class ObjectId {
       return this.toString() === otherId.toString();
     }
 
-    if (
-      typeof otherId === 'string' &&
-      ObjectId.isValid(otherId) &&
-      otherId.length === 12 &&
-      this.id instanceof _Buffer
-    ) {
-      return otherId === this.id.toString('binary');
-    }
-
-    if (typeof otherId === 'string' && ObjectId.isValid(otherId) && otherId.length === 24) {
+    if (typeof otherId === 'string' && otherId.length === 24) {
       return otherId.toLowerCase() === this.toHexString();
     }
 
-    if (typeof otherId === 'string' && ObjectId.isValid(otherId) && otherId.length === 12) {
-      return otherId === this.id;
+    if (typeof otherId === 'string' && otherId.length === 12) {
+      const rhs = this.id instanceof Buffer ? this.id.toString('binary') : this.id;
+      return otherId === rhs;
     }
 
-    if (otherId != null && (otherId instanceof ObjectId || otherId.toHexString)) {
+    if (otherId != null && otherId.toHexString) {
       return otherId.toHexString() === this.toHexString();
     }
 
@@ -250,6 +214,7 @@ class ObjectId {
    */
   getTimestamp() {
     const timestamp = new Date();
+    // TODO this will break if 'id' is a 12-char string
     const time = this.id.readUInt32BE(0);
     timestamp.setTime(Math.floor(time) * 1000);
     return timestamp;
@@ -289,26 +254,13 @@ class ObjectId {
    */
   static createFromHexString(string) {
     // Throw an error if it's not a valid setup
-    if (typeof string === 'undefined' || (string != null && string.length !== 24)) {
+    if (typeof string !== 'string' || !checkForHexRegExp.test(string)) {
       throw new TypeError(
         'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
       );
     }
 
-    // Use Buffer.from method if available
-    if (hasBufferType) return new ObjectId(Buffer.from(string, 'hex'));
-
-    // Calculate lengths
-    const array = new _Buffer(12);
-
-    let n = 0;
-    let i = 0;
-    while (i < 24) {
-      array[n++] =
-        (decodeLookup[string.charCodeAt(i++)] << 4) | decodeLookup[string.charCodeAt(i++)];
-    }
-
-    return new ObjectId(array);
+    return new ObjectId(string);
   }
 
   /**
@@ -333,12 +285,12 @@ class ObjectId {
       return true;
     }
 
-    if (id instanceof _Buffer && id.length === 12) {
+    if (id instanceof Buffer && id.length === 12) {
       return true;
     }
 
     // Duck-Typing detection of ObjectId like objects
-    if (id.toHexString) {
+    if (id.toHexString && id.id) {
       return id.id.length === 12 || (id.id.length === 24 && checkForHexRegExp.test(id.id));
     }
 


### PR DESCRIPTION
I have another PR prepared that trivially speeds up the `equals` method a ton, but wanted to clean the surrounding code up first.

---

* Since Node.js v6.9.0 is the minimum version, `Buffer.from` is always available. Allows removing `decodeLookup` stuff, poor duck-typing of 'id' (`this.id.copy` was used as a test for it being a buffer).

* Indicate that 12-byte string is allowed as constructor arg.

* Simplify logic in constructor. Performance improvement from not having to call `isValid` in as many cases and reordering of branches. **Creating an ObjectId from a hex string is now ~19% faster.**

* Remove a hidden Buffer constructor usage (aliased as `new _Buffer`)

* Add a TODO regarding an existing bug in `getTimestamp`. (I want to convert 12-char strings to Buffers in the ctor to fix this and clean other code up, but that would be a breaking change because it would make the constructor throw instead of `toHexString`. Throwing in the ctor seems preferable...)

* Simplify `createFromHexString`. (This is the same as the constructor but requires the input be a hex string.)

* Simplify logic (remove redundant and unnecessary code) in `equals` method.