### PR TITLE
NODE-2253: Support for v1 Extended JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ console.log(EJSON.parse(text));
 | [space] | <code>string</code> \| <code>number</code> |  | A String or Number object that's used to insert white space into the output JSON string for readability purposes. |
 | [options] | <code>object</code> |  | Optional settings |
 | [options.relaxed] | <code>boolean</code> | <code>true</code> | Enabled Extended JSON's `relaxed` mode |
+| [options.legacy] | <code>boolean</code> | <code>true</code> | Output in Extended JSON v1 |
 
 Converts a BSON document to an Extended JSON string, optionally replacing values if a replacer
 function is specified or optionally including only the specified properties if a replacer array

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -303,9 +303,15 @@ class Binary {
   /**
    * @ignore
    */
-  static fromExtendedJSON(doc) {
-    const type = doc.$binary.subType ? parseInt(doc.$binary.subType, 16) : 0;
-    const data = Buffer.from(doc.$binary.base64, 'base64');
+  static fromExtendedJSON(doc, options) {
+    let data, type;
+    if (options.legacy) {
+      type = doc.$type ? parseInt(doc.$type, 16) : 0;
+      data = Buffer.from(doc.$binary, 'base64');
+    } else {
+      type = doc.$binary.subType ? parseInt(doc.$binary.subType, 16) : 0;
+      data = Buffer.from(doc.$binary.base64, 'base64');
+    }
     return new Binary(data, type);
   }
 }

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -280,12 +280,18 @@ class Binary {
   /**
    * @ignore
    */
-  toExtendedJSON() {
+  toExtendedJSON(options) {
     const base64String = Buffer.isBuffer(this.buffer)
       ? this.buffer.toString('base64')
       : Buffer.from(this.buffer).toString('base64');
 
     const subType = Number(this.sub_type).toString(16);
+    if (options.legacy) {
+      return {
+        $binary: base64String,
+        $type: subType.length === 1 ? '0' + subType : subType
+      };
+    }
     return {
       $binary: {
         base64: base64String,

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -305,6 +305,7 @@ class Binary {
    * @ignore
    */
   static fromExtendedJSON(doc, options) {
+    options = options || {};
     let data, type;
     if (options.legacy) {
       type = doc.$type ? parseInt(doc.$type, 16) : 0;

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -281,6 +281,7 @@ class Binary {
    * @ignore
    */
   toExtendedJSON(options) {
+    options = options || {};
     const base64String = Buffer.isBuffer(this.buffer)
       ? this.buffer.toString('base64')
       : Buffer.from(this.buffer).toString('base64');

--- a/lib/db_ref.js
+++ b/lib/db_ref.js
@@ -46,11 +46,15 @@ class DBRef {
   /**
    * @ignore
    */
-  toExtendedJSON() {
+  toExtendedJSON(options) {
     let o = {
       $ref: this.collection,
       $id: this.oid
     };
+
+    if (options.legacy) {
+      return o;
+    }
 
     if (this.db) o.$db = this.db;
     o = Object.assign(o, this.fields);

--- a/lib/db_ref.js
+++ b/lib/db_ref.js
@@ -47,6 +47,7 @@ class DBRef {
    * @ignore
    */
   toExtendedJSON(options) {
+    options = options || {};
     let o = {
       $ref: this.collection,
       $id: this.oid

--- a/lib/db_ref.js
+++ b/lib/db_ref.js
@@ -65,6 +65,7 @@ class DBRef {
    * @ignore
    */
   static fromExtendedJSON(doc) {
+    console.log('.fromExtendedJSON', doc);
     var copy = Object.assign({}, doc);
     ['$ref', '$id', '$db'].forEach(k => delete copy[k]);
     return new DBRef(doc.$ref, doc.$id, doc.$db, copy);

--- a/lib/db_ref.js
+++ b/lib/db_ref.js
@@ -65,7 +65,6 @@ class DBRef {
    * @ignore
    */
   static fromExtendedJSON(doc) {
-    console.log('.fromExtendedJSON', doc);
     var copy = Object.assign({}, doc);
     ['$ref', '$id', '$db'].forEach(k => delete copy[k]);
     return new DBRef(doc.$ref, doc.$id, doc.$db, copy);

--- a/lib/double.js
+++ b/lib/double.js
@@ -34,7 +34,9 @@ class Double {
    * @ignore
    */
   toExtendedJSON(options) {
-    if (options && options.relaxed && isFinite(this.value)) return this.value;
+    if (options && (options.legacy || (options.relaxed && isFinite(this.value)))) {
+      return this.value;
+    }
     return { $numberDouble: this.value.toString() };
   }
 

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -32,6 +32,7 @@ const keysToCodecs = {
   $numberLong: Long,
   $minKey: MinKey,
   $maxKey: MaxKey,
+  $regex: BSONRegExp,
   $regularExpression: BSONRegExp,
   $timestamp: Timestamp
 };

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -38,7 +38,7 @@ const keysToCodecs = {
 
 function deserializeValue(self, key, value, options) {
   if (typeof value === 'number') {
-    if (options.relaxed) {
+    if (options.relaxed || options.legacy) {
       return value;
     }
 
@@ -69,9 +69,14 @@ function deserializeValue(self, key, value, options) {
     const d = value.$date;
     const date = new Date();
 
-    if (typeof d === 'string') date.setTime(Date.parse(d));
-    else if (Long.isLong(d)) date.setTime(d.toNumber());
-    else if (typeof d === 'number' && options.relaxed) date.setTime(d);
+    if (options.legacy) {
+      if (typeof d === 'number') date.setTime(d);
+      else if (typeof d === 'string') date.setTime(Date.parse(d));
+    } else {
+      if (typeof d === 'string') date.setTime(Date.parse(d));
+      else if (Long.isLong(d)) date.setTime(d.toNumber());
+      else if (typeof d === 'number' && options.relaxed) date.setTime(d);
+    }
     return date;
   }
 
@@ -235,7 +240,7 @@ function serializeValue(value, options) {
 
     if (options.legacy) {
       return options.relaxed && inRange
-        ? { $date: value.getTime().toString() }
+        ? { $date: value.getTime() }
         : { $date: getISOString(value) };
     }
     return options.relaxed && inRange

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -233,6 +233,11 @@ function serializeValue(value, options) {
       // is it in year range 1970-9999?
       inRange = dateNum > -1 && dateNum < 253402318800000;
 
+    if (options.legacy) {
+      return options.relaxed && inRange
+        ? { $date: value.getTime().toString() }
+        : { $date: getISOString(value) };
+    }
     return options.relaxed && inRange
       ? { $date: getISOString(value) }
       : { $date: { $numberLong: value.getTime().toString() } };
@@ -258,7 +263,7 @@ function serializeValue(value, options) {
     }
 
     const rx = new BSONRegExp(value.source, flags);
-    return rx.toExtendedJSON();
+    return rx.toExtendedJSON(options);
   }
 
   if (value != null && typeof value === 'object') return serializeDocument(value, options);

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -131,7 +131,7 @@ function deserializeValue(self, key, value, options) {
  * console.log(EJSON.parse(text));
  */
 function parse(text, options) {
-  options = Object.assign({}, { relaxed: true }, options);
+  options = Object.assign({}, { relaxed: true, legacy: false }, options);
 
   // relaxed implies not strict
   if (typeof options.relaxed === 'boolean') options.strict = !options.relaxed;
@@ -161,6 +161,7 @@ const BSON_INT32_MAX = 0x7fffffff,
  * @param {string|number} [space] A String or Number object that's used to insert white space into the output JSON string for readability purposes.
  * @param {object} [options] Optional settings
  * @param {boolean} [options.relaxed=true] Enabled Extended JSON's `relaxed` mode
+ * @param {boolean} [options.legacy=false] Output using the Extended JSON v1 spec
  * @returns {string}
  *
  * @example
@@ -184,7 +185,7 @@ function stringify(value, replacer, space, options) {
     replacer = null;
     space = 0;
   }
-  options = Object.assign({}, { relaxed: true }, options);
+  options = Object.assign({}, { relaxed: true, legacy: false }, options);
 
   const doc = Array.isArray(value)
     ? serializeArray(value, options)

--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -34,7 +34,7 @@ class Int32 {
    * @ignore
    */
   toExtendedJSON(options) {
-    if (options && options.relaxed) return this.value;
+    if (options && (options.relaxed || options.legacy)) return this.value;
     return { $numberInt: this.value.toString() };
   }
 

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -39,6 +39,15 @@ class BSONRegExp {
     }
   }
 
+  static parseOptions(options) {
+    return options
+      ? options
+          .split('')
+          .sort()
+          .join('')
+      : '';
+  }
+
   /**
    * @ignore
    */
@@ -53,12 +62,16 @@ class BSONRegExp {
    * @ignore
    */
   static fromExtendedJSON(doc) {
+    if (doc.$regex) {
+      // This is for $regex query operators that have extended json values.
+      if (doc.$regex._bsontype === 'BSONRegExp') {
+        return doc;
+      }
+      return new BSONRegExp(doc.$regex, BSONRegExp.parseOptions(doc.$options));
+    }
     return new BSONRegExp(
       doc.$regularExpression.pattern,
-      doc.$regularExpression.options
-        .split('')
-        .sort()
-        .join('')
+      BSONRegExp.parseOptions(doc.$regularExpression.options)
     );
   }
 }

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -42,7 +42,10 @@ class BSONRegExp {
   /**
    * @ignore
    */
-  toExtendedJSON() {
+  toExtendedJSON(options) {
+    if (options.legacy) {
+      return { $regex: this.pattern, $options: this.options };
+    }
     return { $regularExpression: { pattern: this.pattern, options: this.options } };
   }
 

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -52,6 +52,7 @@ class BSONRegExp {
    * @ignore
    */
   toExtendedJSON(options) {
+    options = options || {};
     if (options.legacy) {
       return { $regex: this.pattern, $options: this.options };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3276,7 +3276,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3297,12 +3298,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3317,17 +3320,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3444,7 +3450,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3456,6 +3463,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3470,6 +3478,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3477,12 +3486,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3501,6 +3512,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3581,7 +3593,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3593,6 +3606,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3678,7 +3692,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3714,6 +3729,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3733,6 +3749,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3776,12 +3793,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -615,7 +615,7 @@ describe('Extended JSON', function() {
       });
 
       context('when deserializing regex', function() {
-        it.skip('parses $regex and $options', function() {
+        it('parses $regex and $options', function() {
           const regexp = new BSONRegExp('hello world', 'i');
           const doc = { field: regexp };
           const bson = EJSON.parse('{"field":{"$regex":"hello world","$options":"i"}}', {
@@ -626,8 +626,8 @@ describe('Extended JSON', function() {
       });
 
       context('when deserializing dbref', function() {
-        it.skip('parses $ref and $id', function() {
-          const dbRef = new DBRef('tests', new Int32(1));
+        it('parses $ref and $id', function() {
+          const dbRef = new DBRef('tests', 1);
           const doc = { field: dbRef };
           const bson = EJSON.parse('{"field":{"$ref":"tests","$id":1}}', {
             legacy: true

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -525,7 +525,7 @@ describe('Extended JSON', function() {
             const date = new Date(1452124800000);
             const doc = { field: date };
             const json = EJSON.stringify(doc, { legacy: true, relaxed: true });
-            expect(json).to.equal('{"field":{"$date":"1452124800000"}}');
+            expect(json).to.equal('{"field":{"$date":1452124800000}}');
           });
         });
       });
@@ -572,6 +572,83 @@ describe('Extended JSON', function() {
           const doc = { field: doub };
           const json = EJSON.stringify(doc, { legacy: true });
           expect(json).to.equal('{"field":1.1}');
+        });
+      });
+    });
+
+    describe('.parse', function() {
+      context('when deserializing binary', function() {
+        it('parses $binary and $type', function() {
+          const binary = new Binary(new Uint8Array([1, 2, 3, 4, 5]));
+          const doc = { field: binary };
+          const bson = EJSON.parse('{"field":{"$binary":"AQIDBAU=","$type":"00"}}', {
+            legacy: true
+          });
+          expect(bson).to.deep.equal(doc);
+        });
+      });
+
+      context('when deserializing date', function() {
+        context('when using strict mode', function() {
+          it('parses $date with with ISO-8601 string', function() {
+            const date = new Date(1452124800000);
+            const doc = { field: date };
+            const bson = EJSON.parse('{"field":{"$date":"2016-01-07T00:00:00Z"}}', {
+              legacy: true,
+              relaxed: false
+            });
+            expect(bson).to.deep.equal(doc);
+          });
+        });
+
+        context('when using relaxed mode', function() {
+          it('parses $date number with millis since epoch', function() {
+            const date = new Date(1452124800000);
+            const doc = { field: date };
+            const bson = EJSON.parse('{"field":{"$date":1452124800000}}', {
+              legacy: true,
+              relaxed: true
+            });
+            expect(bson).to.deep.equal(doc);
+          });
+        });
+      });
+
+      context('when deserializing regex', function() {
+        it.skip('parses $regex and $options', function() {
+          const regexp = new BSONRegExp('hello world', 'i');
+          const doc = { field: regexp };
+          const bson = EJSON.parse('{"field":{"$regex":"hello world","$options":"i"}}', {
+            legacy: true
+          });
+          expect(bson).to.deep.equal(doc);
+        });
+      });
+
+      context('when deserializing dbref', function() {
+        it.skip('parses $ref and $id', function() {
+          const dbRef = new DBRef('tests', new Int32(1));
+          const doc = { field: dbRef };
+          const bson = EJSON.parse('{"field":{"$ref":"tests","$id":1}}', {
+            legacy: true
+          });
+          expect(bson).to.deep.equal(doc);
+        });
+      });
+
+      context('when deserializing int32', function() {
+        it('parses the number', function() {
+          const doc = { field: 1 };
+          const bson = EJSON.parse('{"field":1}', { legacy: true });
+          expect(bson).to.deep.equal(doc);
+        });
+      });
+
+      context('when deserializing double', function() {
+        it('parses the number', function() {
+          const doc = { field: 1.1 };
+          const bson = EJSON.parse('{"field":1.1}', { legacy: true });
+          expect(bson).to.deep.equal(doc);
         });
       });
     });

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -498,4 +498,82 @@ describe('Extended JSON', function() {
     expect(() => EJSON.serialize(badArray)).to.throw();
     // expect(() => EJSON.serialize(badMap)).to.throw(); // uncomment when EJSON supports ES6 Map
   });
+
+  context('when dealing with legacy extended json', function() {
+    describe('.stringify', function() {
+      context('when serializing binary', function() {
+        it('stringifies $binary and $type', function() {
+          const binary = new Binary(new Uint8Array([1, 2, 3, 4, 5]));
+          const doc = { field: binary };
+          const json = EJSON.stringify(doc, { legacy: true });
+          expect(json).to.equal('{"field":{"$binary":"AQIDBAU=","$type":"00"}}');
+        });
+      });
+
+      context('when serializing date', function() {
+        context('when using strict mode', function() {
+          it('stringifies $date with with ISO-8601 string', function() {
+            const date = new Date(1452124800000);
+            const doc = { field: date };
+            const json = EJSON.stringify(doc, { legacy: true, relaxed: false });
+            expect(json).to.equal('{"field":{"$date":"2016-01-07T00:00:00Z"}}');
+          });
+        });
+
+        context('when using relaxed mode', function() {
+          it('stringifies $date with with millis since epoch', function() {
+            const date = new Date(1452124800000);
+            const doc = { field: date };
+            const json = EJSON.stringify(doc, { legacy: true, relaxed: true });
+            expect(json).to.equal('{"field":{"$date":"1452124800000"}}');
+          });
+        });
+      });
+
+      context('when serializing regex', function() {
+        it('stringifies $regex and $options', function() {
+          const regexp = new BSONRegExp('hello world', 'i');
+          const doc = { field: regexp };
+          const json = EJSON.stringify(doc, { legacy: true });
+          expect(json).to.equal('{"field":{"$regex":"hello world","$options":"i"}}');
+        });
+      });
+
+      context('when serializing dbref', function() {
+        it('stringifies $ref and $id', function() {
+          const dbRef = new DBRef('tests', new Int32(1));
+          const doc = { field: dbRef };
+          const json = EJSON.stringify(doc, { legacy: true });
+          expect(json).to.equal('{"field":{"$ref":"tests","$id":1}}');
+        });
+      });
+
+      context('when serializing dbref', function() {
+        it('stringifies $ref and $id', function() {
+          const dbRef = new DBRef('tests', new Int32(1));
+          const doc = { field: dbRef };
+          const json = EJSON.stringify(doc, { legacy: true });
+          expect(json).to.equal('{"field":{"$ref":"tests","$id":1}}');
+        });
+      });
+
+      context('when serializing int32', function() {
+        it('stringifies the number', function() {
+          const int32 = new Int32(1);
+          const doc = { field: int32 };
+          const json = EJSON.stringify(doc, { legacy: true });
+          expect(json).to.equal('{"field":1}');
+        });
+      });
+
+      context('when serializing double', function() {
+        it('stringifies the number', function() {
+          const doub = new Double(1.1);
+          const doc = { field: doub };
+          const json = EJSON.stringify(doc, { legacy: true });
+          expect(json).to.equal('{"field":1.1}');
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Adds a `legacy: true` option to `serialize`, `deserialize`, `parse`, and `stringify`.
- Adds tests for cases where v1 and v2 extjson differ.