### PR TITLE
fix: Support Number object in Int32 and Double constructors

### DIFF
--- a/lib/double.js
+++ b/lib/double.js
@@ -6,10 +6,14 @@ class Double {
   /**
    * Create a Double type
    *
-   * @param {number} value the number we want to represent as a double.
+   * @param {number|Number} value the number we want to represent as a double.
    * @return {Double}
    */
   constructor(value) {
+    if (value instanceof Number) {
+      value = value.valueOf();
+    }
+
     this.value = value;
   }
 

--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -6,10 +6,14 @@ class Int32 {
   /**
    * Create an Int32 type
    *
-   * @param {number} value the number we want to represent as an int32.
+   * @param {number|Number} value the number we want to represent as an int32.
    * @return {Int32}
    */
   constructor(value) {
+    if (value instanceof Number) {
+      value = value.valueOf();
+    }
+
     this.value = value;
   }
 

--- a/test/node/double_tests.js
+++ b/test/node/double_tests.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BSON = require('../../lib/bson');
+const Double = BSON.Double;
+const expect = require('chai').expect;
+
+describe('Double', function() {
+  describe('Constructor', function() {
+    var value = 42.3456;
+
+    it('Primitive number', function(done) {
+      expect(new Double(value).valueOf()).to.equal(value);
+      done();
+    });
+
+    it('Number object', function(done) {
+      expect(new Double(new Number(value)).valueOf()).to.equal(value);
+      done();
+    });
+  });
+});

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const BSON = require('../../lib/bson');
+const Int32 = BSON.Int32;
+const expect = require('chai').expect;
+
+describe('Int32', function() {
+  describe('Constructor', function() {
+    var value = 42;
+
+    it('Primitive number', function(done) {
+      expect(new Int32(value).valueOf()).to.equal(value);
+      done();
+    });
+
+    it('Number object', function(done) {
+      expect(new Int32(new Number(value)).valueOf()).to.equal(value);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Numbers objects deserve the same love and support as their primitive
counterparts. So handle them appropriately without introducing
regressions into behaviors of other types that may be passed in as
values

Fixes NODE-2384