### PR TITLE
fix(ejson): legacy mode now matches all compass test cases

### DIFF
--- a/lib/binary.js
+++ b/lib/binary.js
@@ -290,7 +290,7 @@ class Binary {
     if (options.legacy) {
       return {
         $binary: base64String,
-        $type: subType.length === 1 ? '0' + subType : subType
+        $type: subType
       };
     }
     return {

--- a/lib/db_ref.js
+++ b/lib/db_ref.js
@@ -53,7 +53,7 @@ class DBRef {
       $id: this.oid
     };
 
-    if (options.legacy) {
+    if (options.legacy && this.db) {
       o.$ref = [this.db, this.collection].join('.');
       return o;
     }
@@ -66,9 +66,13 @@ class DBRef {
   /**
    * @ignore
    */
-  static fromExtendedJSON(doc) {
+  static fromExtendedJSON(doc, options) {
+    options = options || {};
     var copy = Object.assign({}, doc);
     ['$ref', '$id', '$db'].forEach(k => delete copy[k]);
+    if (options.legacy && doc.$ref && typeof doc.$ref === 'string') {
+      doc.$db = doc.$ref.split('.').unshift();
+    }
     return new DBRef(doc.$ref, doc.$id, doc.$db, copy);
   }
 }

--- a/lib/db_ref.js
+++ b/lib/db_ref.js
@@ -54,6 +54,7 @@ class DBRef {
     };
 
     if (options.legacy) {
+      o.$ref = [this.db, this.collection].join('.');
       return o;
     }
 

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -242,9 +242,9 @@ function serializeValue(value, options) {
       inRange = dateNum > -1 && dateNum < 253402318800000;
 
     if (options.legacy) {
-      return options.relaxed && inRange
-        ? { $date: value.getTime() }
-        : { $date: getISOString(value) };
+      return inRange
+        ? { $date: getISOString(value) }
+      : { $date: { $numberLong: value.getTime().toString() } };
     }
     return options.relaxed && inRange
       ? { $date: getISOString(value) }

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -174,7 +174,7 @@ function serialize(value, options) {
 
   if (Object.prototype.toString.call(value) === '[object Object]') {
     return serializeDocument(value, options);
-  } 
+  }
   return serializeValue(value, options);
 }
 
@@ -258,7 +258,7 @@ function serializeValue(value, options) {
     if (options.legacy) {
       return inRange
         ? { $date: getISOString(value) }
-      : { $date: { $numberLong: value.getTime().toString() } };
+        : { $date: { $numberLong: value.getTime().toString() } };
     }
     return options.relaxed && inRange
       ? { $date: getISOString(value) }

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -171,6 +171,10 @@ function serialize(value, options) {
   if (Array.isArray(value)) {
     return serializeArray(value, options);
   }
+
+  if (Object.prototype.toString.call(value) === '[object Object]') {
+    return serializeDocument(value, options);
+  } 
   return serializeValue(value, options);
 }
 

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -58,7 +58,12 @@ function deserializeValue(self, key, value, options) {
   if (value == null || typeof value !== 'object') return value;
 
   // upgrade deprecated undefined to null
-  if (value.$undefined) return null;
+  if (value.$undefined) {
+    if (options.legacy) {
+      return undefined;
+    }
+    return null;
+  }
 
   const keys = Object.keys(value).filter(k => k.startsWith('$') && value[k] != null);
   for (let i = 0; i < keys.length; i++) {
@@ -234,7 +239,12 @@ function getISOString(date) {
 function serializeValue(value, options) {
   if (Array.isArray(value)) return serializeArray(value, options);
 
-  if (value === undefined) return null;
+  if (value === undefined) {
+    if (options.legacy) {
+      return { $undefined: true };
+    }
+    return null;
+  }
 
   if (value instanceof Date) {
     let dateNum = value.getTime(),

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -163,10 +163,10 @@ const BSON_INT32_MAX = 0x7fffffff,
 function serialize(value, options) {
   options = Object.assign({}, { relaxed: true, legacy: false }, options);
 
-  const doc = Array.isArray(value)
-    ? serializeArray(value, options)
-    : serializeDocument(value, options);
-  return doc;
+  if (Array.isArray(value)) {
+    return serializeArray(value, options);
+  }
+  return serializeValue(value, options);
 }
 
 /**

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -151,6 +151,25 @@ const BSON_INT32_MAX = 0x7fffffff,
   BSON_INT64_MIN = -0x8000000000000000;
 
 /**
+ * Serializes an object to an Extended JSON string, and reparse it as a JavaScript object.
+ *
+ * @memberof EJSON
+ * @param {object} value The object to serialize
+ * @param {object} [options] Optional settings
+ * @param {boolean} [options.relaxed=true] Enabled Extended JSON's `relaxed` mode
+ * @param {boolean} [options.legacy=false] Output using the Extended JSON v1 spec
+ * @return {object}
+ */
+function serialize(value, options) {
+  options = Object.assign({}, { relaxed: true, legacy: false }, options);
+
+  const doc = Array.isArray(value)
+    ? serializeArray(value, options)
+    : serializeDocument(value, options);
+  return doc;
+}
+
+/**
  * Converts a BSON document to an Extended JSON string, optionally replacing values if a replacer
  * function is specified or optionally including only the specified properties if a replacer array
  * is specified.
@@ -185,26 +204,8 @@ function stringify(value, replacer, space, options) {
     replacer = null;
     space = 0;
   }
-  options = Object.assign({}, { relaxed: true, legacy: false }, options);
-
-  const doc = Array.isArray(value)
-    ? serializeArray(value, options)
-    : serializeDocument(value, options);
-
+  const doc = serialize(value, options);
   return JSON.stringify(doc, replacer, space);
-}
-
-/**
- * Serializes an object to an Extended JSON string, and reparse it as a JavaScript object.
- *
- * @memberof EJSON
- * @param {object} bson The object to serialize
- * @param {object} [options] Optional settings passed to the `stringify` function
- * @return {object}
- */
-function serialize(bson, options) {
-  options = options || {};
-  return JSON.parse(stringify(bson, options));
 }
 
 /**

--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -255,7 +255,7 @@ function serializeValue(value, options) {
       // is it in year range 1970-9999?
       inRange = dateNum > -1 && dateNum < 253402318800000;
 
-    if (options.legacy) {
+    if (!options.relaxed && options.legacy) {
       return inRange
         ? { $date: getISOString(value) }
         : { $date: { $numberLong: value.getTime().toString() } };

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -62,18 +62,26 @@ class BSONRegExp {
   /**
    * @ignore
    */
-  static fromExtendedJSON(doc) {
+  static fromExtendedJSON(doc, options) {
+    options = options || {};
+    let expr;
     if (doc.$regex) {
       // This is for $regex query operators that have extended json values.
       if (doc.$regex._bsontype === 'BSONRegExp') {
-        return doc;
+        expr = doc;
+      } else {
+        expr = new BSONRegExp(doc.$regex, BSONRegExp.parseOptions(doc.$options));
       }
-      return new BSONRegExp(doc.$regex, BSONRegExp.parseOptions(doc.$options));
+    } else {
+      expr = new BSONRegExp(
+        doc.$regularExpression.pattern,
+        BSONRegExp.parseOptions(doc.$regularExpression.options)
+      );
     }
-    return new BSONRegExp(
-      doc.$regularExpression.pattern,
-      BSONRegExp.parseOptions(doc.$regularExpression.options)
-    );
+    if (options.legacy) {
+      return new RegExp(expr.pattern, expr.options);
+    }
+    return expr;
   }
 }
 

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -2367,7 +2367,11 @@ describe('BSON', function() {
     const badBsonType = Object.assign({}, oid, { _bsontype: 'bogus' });
     const badDoc = { bad: badBsonType };
     const badArray = [oid, badDoc];
-    const badMap = new Map([['a', badBsonType], ['b', badDoc], ['c', badArray]]);
+    const badMap = new Map([
+      ['a', badBsonType],
+      ['b', badDoc],
+      ['c', badArray]
+    ]);
     expect(() => BSON.serialize(badDoc)).to.throw();
     expect(() => BSON.serialize(badArray)).to.throw();
     expect(() => BSON.serialize(badMap)).to.throw();

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -506,7 +506,7 @@ describe('Extended JSON', function() {
           const binary = new Binary(new Uint8Array([1, 2, 3, 4, 5]));
           const doc = { field: binary };
           const json = EJSON.stringify(doc, { legacy: true });
-          expect(json).to.equal('{"field":{"$binary":"AQIDBAU=","$type":"00"}}');
+          expect(json).to.equal('{"field":{"$binary":"AQIDBAU=","$type":"0"}}');
         });
       });
 

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -519,15 +519,6 @@ describe('Extended JSON', function() {
             expect(json).to.equal('{"field":{"$date":"2016-01-07T00:00:00Z"}}');
           });
         });
-
-        context('when using relaxed mode', function() {
-          it('stringifies $date with with millis since epoch', function() {
-            const date = new Date(1452124800000);
-            const doc = { field: date };
-            const json = EJSON.stringify(doc, { legacy: true, relaxed: true });
-            expect(json).to.equal('{"field":{"$date":1452124800000}}');
-          });
-        });
       });
 
       context('when serializing regex', function() {
@@ -617,7 +608,7 @@ describe('Extended JSON', function() {
       context('when deserializing regex', function() {
         it('parses $regex and $options', function() {
           const regexp = new BSONRegExp('hello world', 'i');
-          const doc = { field: regexp };
+          const doc = { field: new RegExp(regexp.pattern, regexp.options) };
           const bson = EJSON.parse('{"field":{"$regex":"hello world","$options":"i"}}', {
             legacy: true
           });

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -540,7 +540,7 @@ describe('Extended JSON', function() {
       });
 
       context('when serializing dbref', function() {
-        it('stringifies $ref and $id', function() {
+        it('stringifies $ref and $id with no db', function() {
           const dbRef = new DBRef('tests', new Int32(1));
           const doc = { field: dbRef };
           const json = EJSON.stringify(doc, { legacy: true });
@@ -550,10 +550,10 @@ describe('Extended JSON', function() {
 
       context('when serializing dbref', function() {
         it('stringifies $ref and $id', function() {
-          const dbRef = new DBRef('tests', new Int32(1));
+          const dbRef = new DBRef('tests', new Int32(1), 'db');
           const doc = { field: dbRef };
           const json = EJSON.stringify(doc, { legacy: true });
-          expect(json).to.equal('{"field":{"$ref":"tests","$id":1}}');
+          expect(json).to.equal('{"field":{"$ref":"db.tests","$id":1}}');
         });
       });
 
@@ -627,9 +627,9 @@ describe('Extended JSON', function() {
 
       context('when deserializing dbref', function() {
         it('parses $ref and $id', function() {
-          const dbRef = new DBRef('tests', 1);
+          const dbRef = new DBRef('tests', 1, 'db');
           const doc = { field: dbRef };
-          const bson = EJSON.parse('{"field":{"$ref":"tests","$id":1}}', {
+          const bson = EJSON.parse('{"field":{"$ref":"db.tests","$id":1}}', {
             legacy: true
           });
           expect(bson).to.deep.equal(doc);

--- a/test/node/map_tests.js
+++ b/test/node/map_tests.js
@@ -9,7 +9,10 @@ describe('Map', function() {
    * @ignore
    */
   it('should correctly exercise the map', function(done) {
-    var m = new M([['a', 1], ['b', 2]]);
+    var m = new M([
+      ['a', 1],
+      ['b', 2]
+    ]);
     expect(m.has('a')).to.be.ok;
     expect(m.has('b')).to.be.ok;
     expect(1).to.equal(m.get('a'));
@@ -47,7 +50,10 @@ describe('Map', function() {
       values.push([key, value]);
     }, m);
 
-    expect([['a', 3], ['b', 2]]).to.deep.equal(values);
+    expect([
+      ['a', 3],
+      ['b', 2]
+    ]).to.deep.equal(values);
 
     // Modify the state
     expect(true).to.equal(m.delete('a'));
@@ -83,7 +89,10 @@ describe('Map', function() {
    */
   it('should serialize a map', function(done) {
     // Serialize top level map only
-    var m = new M([['a', 1], ['b', 2]]);
+    var m = new M([
+      ['a', 1],
+      ['b', 2]
+    ]);
     // Serialize the map
     var data = BSON.serialize(m, false, true);
     // Deserialize the data
@@ -91,7 +100,10 @@ describe('Map', function() {
     expect({ a: 1, b: 2 }).to.deep.equal(object);
 
     // Serialize nested maps
-    var m1 = new M([['a', 1], ['b', 2]]);
+    var m1 = new M([
+      ['a', 1],
+      ['b', 2]
+    ]);
     m = new M([['c', m1]]);
     // Serialize the map
     data = BSON.serialize(m, false, true);
@@ -101,7 +113,10 @@ describe('Map', function() {
     done();
 
     // Serialize top level map only
-    m = new M([['1', 1], ['0', 2]]);
+    m = new M([
+      ['1', 1],
+      ['0', 2]
+    ]);
     // Serialize the map, validating that the order in the resulting BSON is preserved
     data = BSON.serialize(m, false, true);
     expect('13000000103100010000001030000200000000').to.equal(data.toString('hex'));


### PR DESCRIPTION
This PR updates the legacy extended JSON compatibility introduced by mongodb/js-bson#339 to pass the existing Compass EJSON legacy test suite mongodb-js/extended-json#91

Once this is merged, mongodb-js/extended-json#91 can proceed and `mongodb-extended-json` can be officially deprecated and archived.