### PR TITLE
fix: spelling in deserializer errors

### DIFF
--- a/lib/parser/deserializer.js
+++ b/lib/parser/deserializer.js
@@ -287,9 +287,9 @@ function deserializeObject(buffer, index, options, isArray) {
           if (binarySize < 0)
             throw new Error('Negative binary type element size found for subtype 0x02');
           if (binarySize > totalBinarySize - 4)
-            throw new Error('Binary type with subtype 0x02 contains to long binary size');
+            throw new Error('Binary type with subtype 0x02 contains too long binary size');
           if (binarySize < totalBinarySize - 4)
-            throw new Error('Binary type with subtype 0x02 contains to short binary size');
+            throw new Error('Binary type with subtype 0x02 contains too short binary size');
         }
 
         if (promoteBuffers && promoteValues) {
@@ -312,9 +312,9 @@ function deserializeObject(buffer, index, options, isArray) {
           if (binarySize < 0)
             throw new Error('Negative binary type element size found for subtype 0x02');
           if (binarySize > totalBinarySize - 4)
-            throw new Error('Binary type with subtype 0x02 contains to long binary size');
+            throw new Error('Binary type with subtype 0x02 contains too long binary size');
           if (binarySize < totalBinarySize - 4)
-            throw new Error('Binary type with subtype 0x02 contains to short binary size');
+            throw new Error('Binary type with subtype 0x02 contains too short binary size');
         }
 
         // Copy the data
@@ -508,14 +508,14 @@ function deserializeObject(buffer, index, options, isArray) {
       // Adjust the index
       index = index + objectSize;
 
-      // Check if field length is to short
+      // Check if field length is too short
       if (totalSize < 4 + 4 + objectSize + stringSize) {
-        throw new Error('code_w_scope total size is to short, truncating scope');
+        throw new Error('code_w_scope total size is too short, truncating scope');
       }
 
-      // Check if totalSize field is to long
+      // Check if totalSize field is too long
       if (totalSize > 4 + 4 + objectSize + stringSize) {
-        throw new Error('code_w_scope total size is to long, clips outer document');
+        throw new Error('code_w_scope total size is too long, clips outer document');
       }
 
       // If we are evaluating the functions


### PR DESCRIPTION
Edits: "to long" -> "too long", "to short" -> "too short"