### PR TITLE
[NODE-2613] fix: parseInt value of Int32 in constructor

### DIFF
--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -14,11 +14,7 @@ class Int32 {
       value = value.valueOf();
     }
 
-    if (typeof value === 'string') {
-      value = parseInt(value, 10);
-    }
-
-    this.value = value;
+    this.value = +value;
   }
 
   /**

--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -6,7 +6,7 @@ class Int32 {
   /**
    * Create an Int32 type
    *
-   * @param {number|Number|string} value the number we want to represent as an int32.
+   * @param {*} value the number we want to represent as an int32.
    * @return {Int32}
    */
   constructor(value) {

--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -6,12 +6,16 @@ class Int32 {
   /**
    * Create an Int32 type
    *
-   * @param {number|Number} value the number we want to represent as an int32.
+   * @param {number|Number|string} value the number we want to represent as an int32.
    * @return {Int32}
    */
   constructor(value) {
     if (value instanceof Number) {
       value = value.valueOf();
+    }
+
+    if (typeof value === 'string') {
+      value = parseInt(value, 10)
     }
 
     this.value = value;

--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -15,7 +15,7 @@ class Int32 {
     }
 
     if (typeof value === 'string') {
-      value = parseInt(value, 10)
+      value = parseInt(value, 10);
     }
 
     this.value = value;

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -280,7 +280,7 @@ describe('Extended JSON', function() {
     expect(result.double.value).to.equal(10.1);
     // int32
     expect(result.int32).to.be.an.instanceOf(BSON.Int32);
-    expect(result.int32.value).to.equal('10');
+    expect(result.int32.value).to.equal(10);
     //long
     expect(result.long).to.be.an.instanceOf(BSON.Long);
     // maxKey
@@ -641,6 +641,24 @@ describe('Extended JSON', function() {
           const doc = { field: 1 };
           const bson = EJSON.parse('{"field":1}', { legacy: true });
           expect(bson).to.deep.equal(doc);
+        });
+
+        it('parses the numberInt without doc', function() {
+          const value = 1;
+          const bson = EJSON.parse('{ "$numberInt": "1" }');
+          expect(bson).to.deep.equal(value);
+        });
+
+        it('parses the numberInt', function() {
+          const doc = { field: 1 };
+          const bson = EJSON.parse('{"field": {"$numberInt": "1"}}');
+          expect(bson).to.deep.equal(doc);
+        });
+
+        it('parses the numberInt and stringify', function() {
+          const doc = { field: 1 };
+          const bson = EJSON.parse('{"field": {"$numberInt": "1"}}');
+          expect(EJSON.stringify(bson)).to.deep.equal(JSON.stringify(doc));
         });
       });
 

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -6,9 +6,9 @@ const expect = require('chai').expect;
 
 describe('Int32', function() {
   describe('Constructor', function() {
-    var hexValue = '0x2A';
-    var octalValue = 0o52;
-    var value = 42;
+    const hexValue = '0x2A';
+    const octalValue = 0o52;
+    const value = 42;
 
     it('Primitive number', function(done) {
       expect(new Int32(value).valueOf()).to.equal(value);
@@ -35,9 +35,11 @@ describe('Int32', function() {
       const plus = BSON.serialize({ key: new Int32(+'fortyTwo') });
       const intLedString = BSON.serialize({ key: new Int32('42fortyTwo') });
       const intLedPlus = BSON.serialize({ key: new Int32(+'42fortyTwo') });
-      const fortyTwo = BSON.serialize({ key: new Int32(42) });
-      const hexFortyTwo = BSON.serialize({ key: new Int32('0x2A') });
-      const plusHexFortyTwo = BSON.serialize({ key: new Int32(+'0x2A') });
+      const fortyTwo = BSON.serialize({ key: new Int32(value) });
+      const hexFortyTwo = BSON.serialize({ key: new Int32(hexValue) });
+      const plusHexFortyTwo = BSON.serialize({ key: new Int32(hexValue) });
+      const octal = BSON.serialize({ key: new Int32(octalValue) });
+      const plusOctal = BSON.serialize({ key: new Int32(+octalValue) });
       const zero = BSON.serialize({ key: new Int32(0) });
       const plusZero = BSON.serialize({ key: new Int32(+'0') });
       const positiveZero = BSON.serialize({ key: new Int32(+0) });
@@ -53,6 +55,8 @@ describe('Int32', function() {
       expect(intLedPlus.equals(zero)).to.be.true;
       expect(hexFortyTwo.equals(fortyTwo)).to.be.true;
       expect(plusHexFortyTwo.equals(fortyTwo)).to.be.true;
+      expect(octal.equals(fortyTwo)).to.be.true;
+      expect(plusOctal.equals(fortyTwo)).to.be.true;
       expect(plusZero.equals(zero)).to.be.true;
       expect(positiveZero.equals(zero)).to.be.true;
       expect(negativeZero.equals(zero)).to.be.true;

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -5,8 +5,9 @@ const Int32 = BSON.Int32;
 const expect = require('chai').expect;
 
 describe('Int32', function() {
-  describe('Constructor', function() {
-    const hexValue = '0x2A';
+  context('Constructor', function() {
+    const strHexValue = '0x2a';
+    const hexValue = 0x2a;
     const octalValue = 0o52;
     const value = 42;
 
@@ -20,6 +21,11 @@ describe('Int32', function() {
       done();
     });
 
+    it('String Hex', function(done) {
+      expect(new Int32(strHexValue).valueOf()).to.equal(value);
+      done();
+    });
+
     it('Hex', function(done) {
       expect(new Int32(hexValue).valueOf()).to.equal(value);
       done();
@@ -30,42 +36,24 @@ describe('Int32', function() {
       done();
     });
 
-    it('Cases covering Int32 value conversion using +', function(done) {
-      const string = BSON.serialize({ key: new Int32('fortyTwo') });
-      const plus = BSON.serialize({ key: new Int32(+'fortyTwo') });
-      const intLedString = BSON.serialize({ key: new Int32('42fortyTwo') });
-      const intLedPlus = BSON.serialize({ key: new Int32(+'42fortyTwo') });
-      const fortyTwo = BSON.serialize({ key: new Int32(value) });
-      const hexFortyTwo = BSON.serialize({ key: new Int32(hexValue) });
-      const plusHexFortyTwo = BSON.serialize({ key: new Int32(hexValue) });
-      const octal = BSON.serialize({ key: new Int32(octalValue) });
-      const plusOctal = BSON.serialize({ key: new Int32(+octalValue) });
-      const zero = BSON.serialize({ key: new Int32(0) });
-      const plusZero = BSON.serialize({ key: new Int32(+'0') });
-      const positiveZero = BSON.serialize({ key: new Int32(+0) });
-      const negativeZero = BSON.serialize({ key: new Int32(-0) });
-      const inf = BSON.serialize({ key: new Int32(Infinity) });
-      const strInf = BSON.serialize({ key: new Int32('Infinity') });
-      const plusStrInf = BSON.serialize({ key: new Int32(+'Infinity') });
-      const posInf = BSON.serialize({ key: new Int32(+Infinity) });
-      const negInf = BSON.serialize({ key: new Int32(-Infinity) });
-      expect(string.equals(zero)).to.be.true;
-      expect(plus.equals(zero)).to.be.true;
-      expect(intLedString.equals(zero)).to.be.true;
-      expect(intLedPlus.equals(zero)).to.be.true;
-      expect(hexFortyTwo.equals(fortyTwo)).to.be.true;
-      expect(plusHexFortyTwo.equals(fortyTwo)).to.be.true;
-      expect(octal.equals(fortyTwo)).to.be.true;
-      expect(plusOctal.equals(fortyTwo)).to.be.true;
-      expect(plusZero.equals(zero)).to.be.true;
-      expect(positiveZero.equals(zero)).to.be.true;
-      expect(negativeZero.equals(zero)).to.be.true;
-      expect(inf.equals(zero)).to.be.true;
-      expect(strInf.equals(zero)).to.be.true;
-      expect(plusStrInf.equals(zero)).to.be.true;
-      expect(posInf.equals(zero)).to.be.true;
-      expect(negInf.equals(zero)).to.be.true;
-      done();
+    it('should equal zero', function() {
+      const prop = 'key';
+      const zero = BSON.serialize({ [prop]: new Int32(0) }).toString();
+      // should equal zero
+      ['fortyTwo', '42fortyTwo', '0', 0, Infinity, 'Infinity'].forEach(value => {
+        expect(BSON.serialize({ [prop]: new Int32(value) }).toString()).to.equal(zero);
+        expect(BSON.serialize({ [prop]: new Int32(+value) }).toString()).to.equal(zero);
+      });
+    });
+
+    it('should equal fortyTwo', function() {
+      const prop = 'key';
+      const fortyTwo = BSON.serialize({ [prop]: new Int32(value) }).toString();
+      // should equal fortyTwo
+      [strHexValue, hexValue, octalValue].forEach(value => {
+        expect(BSON.serialize({ [prop]: new Int32(value) }).toString()).to.equal(fortyTwo);
+        expect(BSON.serialize({ [prop]: new Int32(+value) }).toString()).to.equal(fortyTwo);
+      });
     });
   });
 });

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -6,6 +6,8 @@ const expect = require('chai').expect;
 
 describe('Int32', function() {
   describe('Constructor', function() {
+    var hexValue = '0x2A';
+    var octalValue = 0o52;
     var value = 42;
 
     it('Primitive number', function(done) {
@@ -15,6 +17,50 @@ describe('Int32', function() {
 
     it('Number object', function(done) {
       expect(new Int32(new Number(value)).valueOf()).to.equal(value);
+      done();
+    });
+
+    it('Hex', function(done) {
+      expect(new Int32(hexValue).valueOf()).to.equal(value);
+      done();
+    });
+
+    it('Octal', function(done) {
+      expect(new Int32(octalValue).valueOf()).to.equal(value);
+      done();
+    });
+
+    it('Cases covering Int32 value conversion using +', function(done) {
+      const string = BSON.serialize({ key: new Int32('fortyTwo') });
+      const plus = BSON.serialize({ key: new Int32(+'fortyTwo') });
+      const intLedString = BSON.serialize({ key: new Int32('42fortyTwo') });
+      const intLedPlus = BSON.serialize({ key: new Int32(+'42fortyTwo') });
+      const fortyTwo = BSON.serialize({ key: new Int32(42) });
+      const hexFortyTwo = BSON.serialize({ key: new Int32('0x2A') });
+      const plusHexFortyTwo = BSON.serialize({ key: new Int32(+'0x2A') });
+      const zero = BSON.serialize({ key: new Int32(0) });
+      const plusZero = BSON.serialize({ key: new Int32(+'0') });
+      const positiveZero = BSON.serialize({ key: new Int32(+0) });
+      const negativeZero = BSON.serialize({ key: new Int32(-0) });
+      const inf = BSON.serialize({ key: new Int32(Infinity) });
+      const strInf = BSON.serialize({ key: new Int32('Infinity') });
+      const plusStrInf = BSON.serialize({ key: new Int32(+'Infinity') });
+      const posInf = BSON.serialize({ key: new Int32(+Infinity) });
+      const negInf = BSON.serialize({ key: new Int32(-Infinity) });
+      expect(string.equals(zero)).to.be.true;
+      expect(plus.equals(zero)).to.be.true;
+      expect(intLedString.equals(zero)).to.be.true;
+      expect(intLedPlus.equals(zero)).to.be.true;
+      expect(hexFortyTwo.equals(fortyTwo)).to.be.true;
+      expect(plusHexFortyTwo.equals(fortyTwo)).to.be.true;
+      expect(plusZero.equals(zero)).to.be.true;
+      expect(positiveZero.equals(zero)).to.be.true;
+      expect(negativeZero.equals(zero)).to.be.true;
+      expect(inf.equals(zero)).to.be.true;
+      expect(strInf.equals(zero)).to.be.true;
+      expect(plusStrInf.equals(zero)).to.be.true;
+      expect(posInf.equals(zero)).to.be.true;
+      expect(negInf.equals(zero)).to.be.true;
       done();
     });
   });


### PR DESCRIPTION
This update adds `parseInt` to the `Int32` constructor. 

Pre-Fix:

> [Here's a repl.it page with examples.](https://repl.it/@thomasreggi/NODE-2613-without-fix)

```js
> bson.EJSON.parse(`{"$numberInt":"1"}`, { relaxed: false });
Int32 { value: '1' }
> new bson.Int32('1')
Int32 { value: '1' }
```

Post-Fix

> [Here's a repl.it page with the changes from this branch introduced.](https://repl.it/@thomasreggi/NODE-2613-with-fix)

```js
> bson.EJSON.parse(`{"$numberInt":"1"}`, { relaxed: false });
Int32 { value: 1 }
> new bson.Int32('1')
Int32 { value: 1 }
```

[NODE-2613](https://jira.mongodb.org/browse/NODE-2613)