### PR TITLE
[NODE-2613] fix: Int32 parse fromExtendedJSON

### DIFF
--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -46,7 +46,8 @@ class Int32 {
    * @ignore
    */
   static fromExtendedJSON(doc, options) {
-    return options && options.relaxed ? parseInt(doc.$numberInt, 10) : new Int32(doc.$numberInt);
+    const parse = parseInt(doc.$numberInt, 10);
+    return options && options.relaxed ? parse : new Int32(parse);
   }
 }
 

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -280,7 +280,7 @@ describe('Extended JSON', function() {
     expect(result.double.value).to.equal(10.1);
     // int32
     expect(result.int32).to.be.an.instanceOf(BSON.Int32);
-    expect(result.int32.value).to.equal('10');
+    expect(result.int32.value).to.equal(10);
     //long
     expect(result.long).to.be.an.instanceOf(BSON.Long);
     // maxKey
@@ -641,6 +641,24 @@ describe('Extended JSON', function() {
           const doc = { field: 1 };
           const bson = EJSON.parse('{"field":1}', { legacy: true });
           expect(bson).to.deep.equal(doc);
+        });
+
+        it('parses the numberInt without doc', function() {
+          const value = 1;
+          const bson = EJSON.parse('{ "$numberInt": "1" }');
+          expect(bson).to.deep.equal(value);
+        });
+
+        it('parses the numberInt', function() {
+          const doc = { field: 1 };
+          const bson = EJSON.parse('{"field": {"$numberInt": "1"}}');
+          expect(bson).to.deep.equal(doc);
+        });
+
+        it('parses the numberInt and stringify', function() {
+          const doc = { field: 1 };
+          const bson = EJSON.parse('{"field": {"$numberInt": "1"}}');
+          expect(EJSON.stringify(bson)).to.deep.equal(JSON.stringify(doc));
         });
       });
 


### PR DESCRIPTION
Changes `Int32`'s `fromExtendedJSON` method to pass return of `parseInt` to the newly created `Int32`.

Pre-Fix:

> [Here's a repl.it page with examples.](https://repl.it/@thomasreggi/NODE-2613-without-fix)

```js
> bson.EJSON.parse(`{"$numberInt":"1"}`, { relaxed: false });
Int32 { value: '1' }
> new bson.Int32('1')
Int32 { value: '1' }
```

Post-Fix

> [Here's a repl.it page with the changes from this branch introduced.](https://repl.it/@thomasreggi/NODE-2613-with-fix-360)

```js
> bson.EJSON.parse(`{"$numberInt":"1"}`, { relaxed: false });
Int32 { value: 1 }
> new bson.Int32('1')
Int32 { value: "1" }
```

[NODE-2613](https://jira.mongodb.org/browse/NODE-2613)

