### PR TITLE
[NODE-2613] fix: int32 parseInt in toExtendedJSON

### DIFF
--- a/lib/int_32.js
+++ b/lib/int_32.js
@@ -38,7 +38,7 @@ class Int32 {
    * @ignore
    */
   toExtendedJSON(options) {
-    if (options && (options.relaxed || options.legacy)) return this.value;
+    if (options && (options.relaxed || options.legacy)) return parseInt(this.value, 10);
     return { $numberInt: this.value.toString() };
   }
 


### PR DESCRIPTION
This is an extra PR showing how we can change `toExtendedJSON` to abide spec.


BSON 1.1 Type or Convention | Canonical Extended JSON Format | Relaxed Extended JSON Format
-- | -- | --
Int32 | {"$numberInt": <32-bit signed integer as a string>} | integer



