### PR TITLE
fix bug when add toBSON to BigInt type and serialize a 0n value.

### DIFF
--- a/lib/parser/serializer.js
+++ b/lib/parser/serializer.js
@@ -686,7 +686,7 @@ function serializeInto(
       let value = object[i];
 
       // Is there an override value
-      if (value && value.toBSON) {
+      if (value != undefined && value != null && value.toBSON) {
         if (typeof value.toBSON !== 'function') throw new TypeError('toBSON is not a function');
         value = value.toBSON();
       }
@@ -880,7 +880,7 @@ function serializeInto(
     for (let key in object) {
       let value = object[key];
       // Is there an override value
-      if (value && value.toBSON) {
+      if (value != undefined && value != null && value.toBSON) {
         if (typeof value.toBSON !== 'function') throw new TypeError('toBSON is not a function');
         value = value.toBSON();
       }


### PR DESCRIPTION
when you use a BigInt type, and add toBSON method to the prototype
```javascript
BigInt.prototype.toBSON = function() {
	return this.toString()
}
```

When use mongodb native you make call like this:
```javascript
db.col.bulkWrite([updateOne:{$set:{value: 0n}])
```
then you will got an error something like $set is empty.

all because when the bson/serializer use toBSON custom method, it's nil value checking is wrong.