### PR TITLE
fix: support using `bson.ObjectId` with webpack build

### DIFF
--- a/lib/bson/bson.js
+++ b/lib/bson/bson.js
@@ -376,6 +376,7 @@ module.exports.BSON = BSON;
 module.exports.DBRef = DBRef;
 module.exports.Binary = Binary;
 module.exports.ObjectID = ObjectID;
+module.exports.ObjectId = ObjectID;
 module.exports.Long = Long;
 module.exports.Timestamp = Timestamp;
 module.exports.Double = Double;


### PR DESCRIPTION
For v1.x, you can use `require('bson').ObjectId` in Node, but when you use that in the browser `require('bson').ObjectId` is undefined.