### PR TITLE
fixes #324 - needs to merge it in another branch `3.0.3`

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -1,8 +1,4 @@
 'use strict';
-
-const hostname = require('os').hostname;
-const fnv1a24 = require('./fnv1a').fnv1a24;
-
 /**
  * Machine id.
  *
@@ -11,7 +7,7 @@ const fnv1a24 = require('./fnv1a').fnv1a24;
  * that would mean an asyc call to gethostname, so we don't bother.
  * @ignore
  */
-const MACHINE_ID = fnv1a24(hostname);
+var MACHINE_ID = parseInt(Math.random() * 0xffffff, 10);
 
 // Regular expression that checks for hex value
 var checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist",
     "bower.json"
   ],
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "Christian Amor Kvalheim <christkv@gmail.com>",
   "license": "Apache-2.0",
   "contributors": [],


### PR DESCRIPTION
Updates `objectid.js` to the version in branch `3.0` (https://github.com/mongodb/js-bson/blob/3.0/lib/bson/objectid.js), because the `3.0.2` tag doesn't have it.

This fixes #324 that is happening also with mongodb-extjson when using Node v12.

I propose a `3.0.3` package release when the tests are OK.