### PR TITLE
feat: add support for primitives to EJSON.stringify

### DIFF
--- a/lib/extended_json.js
+++ b/lib/extended_json.js
@@ -187,10 +187,7 @@ function stringify(value, replacer, space, options) {
   }
   options = Object.assign({}, { relaxed: true, legacy: false }, options);
 
-  const doc = Array.isArray(value)
-    ? serializeArray(value, options)
-    : serializeDocument(value, options);
-
+  const doc = serializeValue(value, options);
   return JSON.stringify(doc, replacer, space);
 }
 

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -159,6 +159,16 @@ describe('Extended JSON', function() {
     expect(serialized).to.equal('{"$binary":{"base64":"AQIDBAU=","subType":"00"}}');
   });
 
+  it('should correctly serialize strings', function() {
+    const serialized = EJSON.stringify('new string');
+    expect(serialized).to.equal('"new string"');
+  });
+
+  it('should correctly serialize numbers', function() {
+    const serialized = EJSON.stringify(42);
+    expect(serialized).to.equal('42');
+  });
+
   it('should correctly parse null values', function() {
     expect(EJSON.parse('null')).to.be.null;
     expect(EJSON.parse('[null]')[0]).to.be.null;


### PR DESCRIPTION
Since EJSON.stringify is often used as a replacement for built-in JSON.stringify, it would make sense that it would handle the same arguments as JSON.stringify, including primitive values.

Context: here's a place it's being used like JSON.stringify: https://github.com/mixmaxhq/mongo-cursor-pagination/pull/198