### PR TITLE
chore(ci): turn nvm on in windows

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -42,6 +42,7 @@ path: $NVM_SYMLINK
 EOT
 
   nvm install ${NODE_VERSION}
+  nvm on
 else
   curl -o- $NVM_URL | bash
   [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -26,7 +26,6 @@ if [ "$OS" == "Windows_NT" ]; then
   export NVM_HOME=`cygpath -w "$NVM_DIR"`
   export NVM_SYMLINK=`cygpath -w "$NODE_ARTIFACTS_PATH/bin"`
   export PATH=`cygpath $NVM_SYMLINK`:`cygpath $NVM_HOME`:$PATH
-  export APPDATA=${NVM_HOME}
 
   # download and install nvm
   curl -L $NVM_WINDOWS_URL -o nvm.zip

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -26,6 +26,7 @@ if [ "$OS" == "Windows_NT" ]; then
   export NVM_HOME=`cygpath -w "$NVM_DIR"`
   export NVM_SYMLINK=`cygpath -w "$NODE_ARTIFACTS_PATH/bin"`
   export PATH=`cygpath $NVM_SYMLINK`:`cygpath $NVM_HOME`:$PATH
+  export APPDATA=${NVM_HOME}
 
   # download and install nvm
   curl -L $NVM_WINDOWS_URL -o nvm.zip


### PR DESCRIPTION
Running `nvm on` in Windows fixes the error: `Failed to replace env in config: ${APPDATA}`