### PR TITLE
fix(object-id): harden the duck-typing [backport]

### DIFF
--- a/lib/bson/objectid.js
+++ b/lib/bson/objectid.js
@@ -66,7 +66,7 @@ var ObjectID = function ObjectID(id) {
   } else if (id != null && id.length === 12) {
     // assume 12 byte string
     this.id = id;
-  } else if (id != null && id.toHexString) {
+  } else if (id != null && typeof id.toHexString === 'function') {
     // Duck-typing to support ObjectId from different npm packages
     return id;
   } else {
@@ -357,7 +357,10 @@ ObjectID.isValid = function isValid(id) {
   }
 
   // Duck-Typing detection of ObjectId like objects
-  if (id.toHexString) {
+  if (
+      typeof id.toHexString === 'function' &&
+      (id.id instanceof _Buffer || typeof id.id === 'string')
+  ) {
     return id.id.length === 12 || (id.id.length === 24 && checkForHexRegExp.test(id.id));
   }
 


### PR DESCRIPTION
#### Backport of https://github.com/mongodb/js-bson/pull/382
----

The insufficient validation may otherwise lead to type confusions.

REF: NODE-2618
Signed-off-by: Jakob Ackermann <jakob.ackermann@overleaf.com>