### PR TITLE
NODE-2724/types-against-driver

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -19,11 +19,14 @@ import { MinKey } from './min_key';
 import { ObjectId } from './objectid';
 import { calculateObjectSize as internalCalculateObjectSize } from './parser/calculate_size';
 // Parts of the parser
-import { DeserializationOptions, deserialize as internalDeserialize } from './parser/deserializer';
-import { SerializationOptions, serializeInto as internalSerialize } from './parser/serializer';
+import { DeserializeOptions, deserialize as internalDeserialize } from './parser/deserializer';
+import { SerializeOptions, serializeInto as internalSerialize } from './parser/serializer';
 import { BSONRegExp } from './regexp';
 import { BSONSymbol } from './symbol';
 import { Timestamp } from './timestamp';
+
+export { SerializeOptions, DeserializeOptions };
+
 export {
   BSON_BINARY_SUBTYPE_BYTE_ARRAY,
   BSON_BINARY_SUBTYPE_DEFAULT,
@@ -118,7 +121,7 @@ export function setInternalBufferSize(size: number): void {
  * @param object - the Javascript object to serialize.
  * @returns Buffer object containing the serialized object.
  */
-export function serialize(object: Document, options: SerializationOptions = {}): Buffer {
+export function serialize(object: Document, options: SerializeOptions = {}): Buffer {
   // Unpack the options
   const checkKeys = typeof options.checkKeys === 'boolean' ? options.checkKeys : false;
   const serializeFunctions =
@@ -166,7 +169,7 @@ export function serialize(object: Document, options: SerializationOptions = {}):
 export function serializeWithBufferAndIndex(
   object: Document,
   finalBuffer: Buffer,
-  options: SerializationOptions = {}
+  options: SerializeOptions = {}
 ): number {
   // Unpack the options
   const checkKeys = typeof options.checkKeys === 'boolean' ? options.checkKeys : false;
@@ -198,13 +201,13 @@ export function serializeWithBufferAndIndex(
  * @param buffer - the buffer containing the serialized set of BSON documents.
  * @returns returns the deserialized Javascript Object.
  */
-export function deserialize(buffer: Buffer, options: DeserializationOptions = {}): Document {
+export function deserialize(buffer: Buffer, options: DeserializeOptions = {}): Document {
   buffer = ensureBuffer(buffer);
   return internalDeserialize(buffer, options);
 }
 
 export type CalculateObjectSizeOptions = Pick<
-  SerializationOptions,
+  SerializeOptions,
   'serializeFunctions' | 'ignoreUndefined'
 >;
 
@@ -245,7 +248,7 @@ export function deserializeStream(
   numberOfDocuments: number,
   documents: Document[],
   docStartIndex: number,
-  options: DeserializationOptions
+  options: DeserializeOptions
 ): number {
   const internalOptions = Object.assign(
     { allowObjectSmallerThanBufferSize: true, index: 0 },

--- a/src/long.ts
+++ b/src/long.ts
@@ -1,3 +1,4 @@
+import type { Timestamp } from './timestamp';
 import type { EJSONOptions } from './extended_json';
 import { isObjectLike } from './parser/utils';
 
@@ -297,7 +298,7 @@ export class Long {
   }
 
   /** Returns the sum of this and the specified Long. */
-  add(addend: string | number | Long): Long {
+  add(addend: string | number | Long | Timestamp): Long {
     if (!Long.isLong(addend)) addend = Long.fromValue(addend);
 
     // Divide each number into 4 chunks of 16 bits, and then sum the chunks.
@@ -334,7 +335,7 @@ export class Long {
    * Returns the sum of this and the specified Long.
    * @returns Sum
    */
-  and(other: string | number | Long): Long {
+  and(other: string | number | Long | Timestamp): Long {
     if (!Long.isLong(other)) other = Long.fromValue(other);
     return Long.fromBits(this.low & other.low, this.high & other.high, this.unsigned);
   }
@@ -343,7 +344,7 @@ export class Long {
    * Compares this Long's value with the specified's.
    * @returns 0 if they are the same, 1 if the this is greater and -1 if the given one is greater
    */
-  compare(other: string | number | Long): 0 | 1 | -1 {
+  compare(other: string | number | Long | Timestamp): 0 | 1 | -1 {
     if (!Long.isLong(other)) other = Long.fromValue(other);
     if (this.eq(other)) return 0;
     const thisNeg = this.isNegative(),
@@ -366,7 +367,7 @@ export class Long {
    * Returns this Long divided by the specified. The result is signed if this Long is signed or unsigned if this Long is unsigned.
    * @returns Quotient
    */
-  divide(divisor: string | number | Long): Long {
+  divide(divisor: string | number | Long | Timestamp): Long {
     if (!Long.isLong(divisor)) divisor = Long.fromValue(divisor);
     if (divisor.isZero()) throw Error('division by zero');
 
@@ -473,7 +474,7 @@ export class Long {
    * Tests if this Long's value equals the specified's.
    * @param other - Other value
    */
-  equals(other: string | number | Long): boolean {
+  equals(other: string | number | Long | Timestamp): boolean {
     if (!Long.isLong(other)) other = Long.fromValue(other);
     if (this.unsigned !== other.unsigned && this.high >>> 31 === 1 && other.high >>> 31 === 1)
       return false;
@@ -516,7 +517,7 @@ export class Long {
   }
 
   /** Tests if this Long's value is greater than the specified's. */
-  greaterThan(other: string | number | Long): boolean {
+  greaterThan(other: string | number | Long | Timestamp): boolean {
     return this.comp(other) > 0;
   }
 
@@ -524,7 +525,7 @@ export class Long {
   gt = Long.prototype.greaterThan;
 
   /** Tests if this Long's value is greater than or equal the specified's. */
-  greaterThanOrEqual(other: string | number | Long): boolean {
+  greaterThanOrEqual(other: string | number | Long | Timestamp): boolean {
     return this.comp(other) >= 0;
   }
 
@@ -559,7 +560,7 @@ export class Long {
   }
 
   /** Tests if this Long's value is less than the specified's. */
-  lessThan(other: string | number | Long): boolean {
+  lessThan(other: string | number | Long | Timestamp): boolean {
     return this.comp(other) < 0;
   }
 
@@ -567,7 +568,7 @@ export class Long {
   lt = Long.prototype.lessThan;
 
   /** Tests if this Long's value is less than or equal the specified's. */
-  lessThanOrEqual(other: string | number | Long): boolean {
+  lessThanOrEqual(other: string | number | Long | Timestamp): boolean {
     return this.comp(other) <= 0;
   }
 
@@ -575,7 +576,7 @@ export class Long {
   lte = Long.prototype.lessThanOrEqual;
 
   /** Returns this Long modulo the specified. */
-  modulo(divisor: string | number | Long): Long {
+  modulo(divisor: string | number | Long | Timestamp): Long {
     if (!Long.isLong(divisor)) divisor = Long.fromValue(divisor);
 
     // use wasm support if present
@@ -602,7 +603,7 @@ export class Long {
    * @param multiplier - Multiplier
    * @returns Product
    */
-  multiply(multiplier: string | number | Long): Long {
+  multiply(multiplier: string | number | Long | Timestamp): Long {
     if (this.isZero()) return Long.ZERO;
     if (!Long.isLong(multiplier)) multiplier = Long.fromValue(multiplier);
 
@@ -683,7 +684,7 @@ export class Long {
   }
 
   /** Tests if this Long's value differs from the specified's. */
-  notEquals(other: string | number | Long): boolean {
+  notEquals(other: string | number | Long | Timestamp): boolean {
     return !this.equals(other);
   }
 
@@ -773,7 +774,7 @@ export class Long {
    * @param subtrahend - Subtrahend
    * @returns Difference
    */
-  subtract(subtrahend: string | number | Long): Long {
+  subtract(subtrahend: string | number | Long | Timestamp): Long {
     if (!Long.isLong(subtrahend)) subtrahend = Long.fromValue(subtrahend);
     return this.add(subtrahend.neg());
   }

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -16,7 +16,7 @@ import { BSONSymbol } from '../symbol';
 import { Timestamp } from '../timestamp';
 import { validateUtf8 } from '../validate_utf8';
 
-export interface DeserializationOptions {
+export interface DeserializeOptions {
   /** evaluate functions in the BSON document scoped to the object deserialized. */
   evalFunctions?: boolean;
   /** cache evaluated functions for reuse. */
@@ -49,7 +49,7 @@ const functionCache: { [hash: string]: Function } = {};
 
 export function deserialize(
   buffer: Buffer,
-  options: DeserializationOptions,
+  options: DeserializeOptions,
   isArray?: boolean
 ): Document {
   options = options == null ? {} : options;
@@ -93,7 +93,7 @@ export function deserialize(
 function deserializeObject(
   buffer: Buffer,
   index: number,
-  options: DeserializationOptions,
+  options: DeserializeOptions,
   isArray = false
 ) {
   const evalFunctions = options['evalFunctions'] == null ? false : options['evalFunctions'];
@@ -253,8 +253,8 @@ function deserializeObject(
         arrayOptions = {};
         for (const n in options) {
           (arrayOptions as {
-            [key: string]: DeserializationOptions[keyof DeserializationOptions];
-          })[n] = options[n as keyof DeserializationOptions];
+            [key: string]: DeserializeOptions[keyof DeserializeOptions];
+          })[n] = options[n as keyof DeserializeOptions];
         }
         arrayOptions['raw'] = true;
       }

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -16,7 +16,7 @@ import type { ObjectId } from '../objectid';
 import type { BSONRegExp } from '../regexp';
 import { isDate, normalizedFunctionString } from './utils';
 
-export interface SerializationOptions {
+export interface SerializeOptions {
   /** the serializer will check if keys are valid. */
   checkKeys?: boolean;
   /** serialize the javascript functions **(default:false)**. */

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -427,16 +427,10 @@ describe('Extended JSON', function () {
         // symbol: { $symbol: 'symbol' },  // removed because this type is deprecated. See comment above.
         timestamp: { $timestamp: { t: 0, i: 0 } }
       };
-      const ejsonSerializationOptions = { relaxed: false };
-      const resultOld = EJSON.serialize(
-        deserialized.usingOldDeserializer,
-        ejsonSerializationOptions
-      );
+      const ejsonSerializeOptions = { relaxed: false };
+      const resultOld = EJSON.serialize(deserialized.usingOldDeserializer, ejsonSerializeOptions);
       expect(resultOld).to.deep.equal(ejsonExpected);
-      const resultNew = EJSON.serialize(
-        deserialized.usingNewDeserializer,
-        ejsonSerializationOptions
-      );
+      const resultNew = EJSON.serialize(deserialized.usingNewDeserializer, ejsonSerializeOptions);
       expect(resultNew).to.deep.equal(ejsonExpected);
     });
 
@@ -482,16 +476,10 @@ describe('Extended JSON', function () {
         usingOldDeserializer: OldBSON.deserialize(expectedBufferMinKey, deserializationOptions),
         usingNewDeserializer: BSON.deserialize(expectedBufferMinKey, deserializationOptions)
       };
-      const ejsonSerializationOptions = { relaxed: false };
-      const resultOld = EJSON.serialize(
-        deserialized.usingOldDeserializer,
-        ejsonSerializationOptions
-      );
+      const ejsonSerializeOptions = { relaxed: false };
+      const resultOld = EJSON.serialize(deserialized.usingOldDeserializer, ejsonSerializeOptions);
       expect(resultOld).to.deep.equal(ejsonExpected);
-      const resultNew = EJSON.serialize(
-        deserialized.usingNewDeserializer,
-        ejsonSerializationOptions
-      );
+      const resultNew = EJSON.serialize(deserialized.usingNewDeserializer, ejsonSerializeOptions);
       expect(resultNew).to.deep.equal(ejsonExpected);
     });
   }


### PR DESCRIPTION
[NODE-2724](https://jira.mongodb.org/browse/NODE-2724)

When comparing the newly exported types from BSON with the community types @types/bson, check for inconsistencies within the driver usage.

```
> mongodb@4.0.0-beta.0 build:ts /Users/thomasreggi/Desktop/git/mongodb/node-mongodb-native
> rimraf lib && tsc

src/bson.ts:32:15 - error TS2305: Module '"../node_modules/@types/bson"' has no exported member 'SerializeOptions'.

32 import type { SerializeOptions } from 'bson';
                 ~~~~~~~~~~~~~~~~

src/bulk/common.ts:604:18 - error TS2339: Property 'checkKeys' does not exist on type '{ ordered: boolean; } & BulkWriteOptions'.

604     finalOptions.checkKeys = false;
                     ~~~~~~~~~

src/bulk/common.ts:997:33 - error TS2339: Property 'checkKeys' does not exist on type 'BulkWriteOptions'.

997       checkKeys: typeof options.checkKeys === 'boolean' ? options.checkKeys : true
                                    ~~~~~~~~~

src/bulk/common.ts:997:67 - error TS2339: Property 'checkKeys' does not exist on type 'BulkWriteOptions'.

997       checkKeys: typeof options.checkKeys === 'boolean' ? options.checkKeys : true
                                                                      ~~~~~~~~~

src/cmap/wire_protocol/command.ts:105:51 - error TS2345: Argument of type 'Timestamp' is not assignable to parameter of type 'string | number | Long'.
  Type 'Timestamp' is not assignable to type 'Long'.
    Types of property '_bsontype' are incompatible.
      Type '"Timestamp"' is not assignable to type '"Long"'.

105       session.clusterTime.clusterTime.greaterThan(clusterTime.clusterTime)
                                                      ~~~~~~~~~~~~~~~~~~~~~~~

src/operations/find_and_modify.ts:113:13 - error TS2339: Property 'checkKeys' does not exist on type 'FindAndModifyOptions'.

113     options.checkKeys = false;
                ~~~~~~~~~

src/sdam/common.ts:75:46 - error TS2345: Argument of type 'Timestamp' is not assignable to parameter of type 'string | number | Long'.
  Type 'Timestamp' is not assignable to type 'Long'.

75     if ($clusterTime.clusterTime.greaterThan(topology.clusterTime.clusterTime)) {
                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/sessions.ts:175:35 - error TS2345: Argument of type 'Timestamp' is not assignable to parameter of type 'string | number | Long'.
  Type 'Timestamp' is not assignable to type 'Long'.

175     if (operationTime.greaterThan(this.operationTime)) {
                                      ~~~~~~~~~~~~~~~~~~

src/sessions.ts:194:30 - error TS2339: Property 'equals' does not exist on type 'BinarySequence'.
  Property 'equals' does not exist on type 'number[]'.

194     return this.id.id.buffer.equals(session.id.id.buffer);
                                 ~~~~~~


Found 9 errors.
```

This PR aims to fix 8 of the 9 issues, the 9th issue should be fixed by the [buffer resolution PR](https://github.com/mongodb/js-bson/pull/394).