### PR TITLE
NODE-2770/rm-crc32

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Starting with Angular 6, Angular CLI removed the shim for `global` and other nod
 Parse an Extended JSON string, constructing the JavaScript value or object described by that
 string.
 
-**Example**  
+**Example**
 ```js
 const { EJSON } = require('bson');
 const text = '{ "int32": { "$numberInt": "10" } }';
@@ -221,7 +221,7 @@ Converts a BSON document to an Extended JSON string, optionally replacing values
 function is specified or optionally including only the specified properties if a replacer array
 is specified.
 
-**Example**  
+**Example**
 ```js
 const { EJSON } = require('bson');
 const Int32 = require('mongodb').Int32;
@@ -278,7 +278,7 @@ Sets the size of the internal serialization buffer.
 
 Serialize a Javascript object.
 
-**Returns**: <code>Buffer</code> - returns the Buffer object containing the serialized object.  
+**Returns**: <code>Buffer</code> - returns the Buffer object containing the serialized object.
 <a name="serializeWithBufferAndIndex"></a>
 
 ### serializeWithBufferAndIndex(object, buffer)
@@ -294,7 +294,7 @@ Serialize a Javascript object.
 
 Serialize a Javascript object using a predefined Buffer and index into the buffer, useful when pre-allocating the space for serialization.
 
-**Returns**: <code>Number</code> - returns the index pointing to the last written byte in the buffer.  
+**Returns**: <code>Number</code> - returns the index pointing to the last written byte in the buffer.
 <a name="deserialize"></a>
 
 ### deserialize(buffer)
@@ -304,7 +304,6 @@ Serialize a Javascript object using a predefined Buffer and index into the buffe
 | buffer | <code>Buffer</code> |  | the buffer containing the serialized set of BSON documents. |
 | [options.evalFunctions] | <code>Object</code> | <code>false</code> | evaluate functions in the BSON document scoped to the object deserialized. |
 | [options.cacheFunctions] | <code>Object</code> | <code>false</code> | cache evaluated functions for reuse. |
-| [options.cacheFunctionsCrc32] | <code>Object</code> | <code>false</code> | use a crc32 code for caching, otherwise use the string of the function. |
 | [options.promoteLongs] | <code>Object</code> | <code>true</code> | when deserializing a Long will fit it into a Number if it's smaller than 53 bits |
 | [options.promoteBuffers] | <code>Object</code> | <code>false</code> | when deserializing a Binary will return it as a node.js Buffer instance. |
 | [options.promoteValues] | <code>Object</code> | <code>false</code> | when deserializing will promote BSON values to their Node.js closest equivalent types. |
@@ -314,7 +313,7 @@ Serialize a Javascript object using a predefined Buffer and index into the buffe
 
 Deserialize data as BSON.
 
-**Returns**: <code>Object</code> - returns the deserialized Javascript Object.  
+**Returns**: <code>Object</code> - returns the deserialized Javascript Object.
 <a name="calculateObjectSize"></a>
 
 ### calculateObjectSize(object)
@@ -327,7 +326,7 @@ Deserialize data as BSON.
 
 Calculate the bson size for a passed in Javascript object.
 
-**Returns**: <code>Number</code> - returns the number of bytes the BSON object will take up.  
+**Returns**: <code>Number</code> - returns the number of bytes the BSON object will take up.
 <a name="deserializeStream"></a>
 
 ### deserializeStream(data, startIndex, numberOfDocuments, documents, docStartIndex, [options])
@@ -342,7 +341,6 @@ Calculate the bson size for a passed in Javascript object.
 | [options] | <code>Object</code> |  | additional options used for the deserialization. |
 | [options.evalFunctions] | <code>Object</code> | <code>false</code> | evaluate functions in the BSON document scoped to the object deserialized. |
 | [options.cacheFunctions] | <code>Object</code> | <code>false</code> | cache evaluated functions for reuse. |
-| [options.cacheFunctionsCrc32] | <code>Object</code> | <code>false</code> | use a crc32 code for caching, otherwise use the string of the function. |
 | [options.promoteLongs] | <code>Object</code> | <code>true</code> | when deserializing a Long will fit it into a Number if it's smaller than 53 bits |
 | [options.promoteBuffers] | <code>Object</code> | <code>false</code> | when deserializing a Binary will return it as a node.js Buffer instance. |
 | [options.promoteValues] | <code>Object</code> | <code>false</code> | when deserializing will promote BSON values to their Node.js closest equivalent types. |
@@ -351,7 +349,7 @@ Calculate the bson size for a passed in Javascript object.
 
 Deserialize stream data as BSON documents.
 
-**Returns**: <code>Number</code> - returns the next index in the buffer after deserialization **x** numbers of documents.  
+**Returns**: <code>Number</code> - returns the next index in the buffer after deserialization **x** numbers of documents.
 
 ## FAQ
 

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -489,7 +489,7 @@ function deserializeObject(
         // If we have cache enabled let's look for the md5 of the function in the cache
         if (cacheFunctions) {
           // Got to do this to avoid V8 deoptimizing the call due to finding eval
-          object[name] = isolateEvalWithHash(functionCache, functionString, object);
+          object[name] = isolateEval(functionString, functionCache, object);
         } else {
           object[name] = isolateEval(functionString);
         }
@@ -557,7 +557,7 @@ function deserializeObject(
         // If we have cache enabled let's look for the md5 of the function in the cache
         if (cacheFunctions) {
           // Got to do this to avoid V8 deoptimizing the call due to finding eval
-          object[name] = isolateEvalWithHash(functionCache, functionString, object);
+          object[name] = isolateEval(functionString, functionCache, object);
         } else {
           object[name] = isolateEval(functionString);
         }
@@ -641,11 +641,12 @@ function deserializeObject(
  *
  * @internal
  */
-function isolateEvalWithHash(
-  functionCache: { [hash: string]: Function },
+function isolateEval(
   functionString: string,
-  object: Document
+  functionCache?: { [hash: string]: Function },
+  object?: Document
 ) {
+  if (!functionCache) return new Function(functionString);
   // Check for cache hit, eval if missing and return cached function
   if (functionCache[functionString] == null) {
     functionCache[functionString] = new Function(functionString);
@@ -653,13 +654,4 @@ function isolateEvalWithHash(
 
   // Set the object
   return functionCache[functionString].bind(object);
-}
-
-/**
- * Ensure eval is isolated.
- *
- * @internal
- */
-function isolateEval(functionString: string): Function {
-  return new Function(functionString);
 }

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -21,6 +21,12 @@ export interface DeserializationOptions {
   evalFunctions?: boolean;
   /** cache evaluated functions for reuse. */
   cacheFunctions?: boolean;
+  /**
+   * use a crc32 code for caching, otherwise use the string of the function.
+   * @deprecated this option to use the crc32 function never worked as intended
+   * due to the fact that the crc32 function itself was never implemented.
+   * */
+  cacheFunctionsCrc32?: boolean;
   /** when deserializing a Long will fit it into a Number if it's smaller than 53 bits */
   promoteLongs?: boolean;
   /** when deserializing a Binary will return it as a node.js Buffer instance. */


### PR DESCRIPTION
[NODE-2770](https://jira.mongodb.org/browse/NODE-2770)

PR to remove the `cacheFunctionsCrc32` option from the deserialize function. 

I've checked in a couple different prior tags / branches to see if there was ever an implementation of `crc32`, I only ever saw it set to `null`.

```js
const hash = cacheFunctionsCrc32 && crc32 ? crc32(functionString) : functionString;
```

With it set to null the hashing function would never be called an the hash would only ever be set to the `functionString`.

This deprecates the `crc32` hashing option as, it was never used.