### PR TITLE
fix: Throw on BigInt type values

### DIFF
--- a/src/long.ts
+++ b/src/long.ts
@@ -1,6 +1,6 @@
-import type { Timestamp } from './timestamp';
 import type { EJSONOptions } from './extended_json';
 import { isObjectLike } from './parser/utils';
+import type { Timestamp } from './timestamp';
 
 interface LongWASMHelpers {
   /** Gets the high bits of the last operation performed */
@@ -194,7 +194,7 @@ export class Long {
    * @returns The corresponding Long value
    */
   static fromBigInt(value: bigint, unsigned?: boolean): Long {
-    return Long.fromString(value.toString(10), unsigned);
+    return Long.fromString(value.toString(), unsigned);
   }
 
   /**

--- a/src/long.ts
+++ b/src/long.ts
@@ -188,6 +188,16 @@ export class Long {
   }
 
   /**
+   * Returns a Long representing the given value, provided that it is a finite number. Otherwise, zero is returned.
+   * @param value - The number in question
+   * @param unsigned - Whether unsigned or not, defaults to signed
+   * @returns The corresponding Long value
+   */
+  static fromBigInt(value: bigint, unsigned?: boolean): Long {
+    return Long.fromString(value.toString(10), unsigned);
+  }
+
+  /**
    * Returns a Long representation of the given string, written using the specified radix.
    * @param str - The textual representation of the Long
    * @param unsigned - Whether unsigned or not, defaults to signed
@@ -791,6 +801,11 @@ export class Long {
   toNumber(): number {
     if (this.unsigned) return (this.high >>> 0) * TWO_PWR_32_DBL + (this.low >>> 0);
     return this.high * TWO_PWR_32_DBL + (this.low >>> 0);
+  }
+
+  /** Converts the Long to a BigInt (arbitrary precision). */
+  toBigInt(): bigint {
+    return BigInt(this.toString());
   }
 
   /**

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -169,6 +169,8 @@ function serializeBigInt(
   index: number,
   isArray?: boolean
 ) {
+  throw new TypeError('Do not know how to serialize a BigInt');
+
   const typeIndicatorIndex = index;
   index += 1;
   const keyByteLength = !isArray

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -808,7 +808,7 @@ export function serializeInto(
       } else if (typeof value === 'number') {
         index = serializeNumber(buffer, key, value, index, true);
       } else if (typeof value === 'bigint') {
-        throw new TypeError('Do not know how to serialize a BigInt, please use Decimal128');
+        throw new TypeError('Unsupported type BigInt, please use Decimal128');
       } else if (typeof value === 'boolean') {
         index = serializeBoolean(buffer, key, value, index, true);
       } else if (value instanceof Date || isDate(value)) {
@@ -916,7 +916,7 @@ export function serializeInto(
       } else if (type === 'number') {
         index = serializeNumber(buffer, key, value, index);
       } else if (type === 'bigint' || isBigInt64Array(value) || isBigUInt64Array(value)) {
-        throw new TypeError('Do not know how to serialize a BigInt, please use Decimal128');
+        throw new TypeError('Unsupported type BigInt, please use Decimal128');
       } else if (type === 'boolean') {
         index = serializeBoolean(buffer, key, value, index);
       } else if (value instanceof Date || isDate(value)) {
@@ -1020,7 +1020,7 @@ export function serializeInto(
       } else if (type === 'number') {
         index = serializeNumber(buffer, key, value, index);
       } else if (type === 'bigint') {
-        throw new TypeError('Do not know how to serialize a BigInt, please use Decimal128');
+        throw new TypeError('Unsupported type BigInt, please use Decimal128');
       } else if (type === 'boolean') {
         index = serializeBoolean(buffer, key, value, index);
       } else if (value instanceof Date || isDate(value)) {

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -15,7 +15,7 @@ import { Map } from '../map';
 import type { MinKey } from '../min_key';
 import type { ObjectId } from '../objectid';
 import type { BSONRegExp } from '../regexp';
-import { isDate, isUint8Array, normalizedFunctionString } from './utils';
+import { isBigInt64Array, isBigUInt64Array, isDate, normalizedFunctionString } from './utils';
 
 export interface SerializeOptions {
   /** the serializer will check if keys are valid. */
@@ -966,7 +966,7 @@ export function serializeInto(
         index = serializeString(buffer, key, value, index);
       } else if (type === 'number') {
         index = serializeNumber(buffer, key, value, index);
-      } else if (type === 'bigint') {
+      } else if (type === 'bigint' || isBigInt64Array(value) || isBigUInt64Array(value)) {
         index = serializeBigInt(buffer, key, value, index);
       } else if (type === 'boolean') {
         index = serializeBoolean(buffer, key, value, index);

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -15,7 +15,13 @@ import { Map } from '../map';
 import type { MinKey } from '../min_key';
 import type { ObjectId } from '../objectid';
 import type { BSONRegExp } from '../regexp';
-import { isBigInt64Array, isBigUInt64Array, isDate, normalizedFunctionString } from './utils';
+import {
+  isBigInt64Array,
+  isBigUInt64Array,
+  isDate,
+  isUint8Array,
+  normalizedFunctionString
+} from './utils';
 
 export interface SerializeOptions {
   /** the serializer will check if keys are valid. */

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -4,7 +4,7 @@ import type { BSONSymbol, DBRef, Document, MaxKey } from '../bson';
 import type { Code } from '../code';
 import * as constants from '../constants';
 import type { DBRefLike } from '../db_ref';
-import { Decimal128 } from '../decimal128';
+import type { Decimal128 } from '../decimal128';
 import type { Double } from '../double';
 import { ensureBuffer } from '../ensure_buffer';
 import { isBSONType } from '../extended_json';

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -40,6 +40,24 @@ export function isUint8Array(value: unknown): value is Uint8Array {
   return Object.prototype.toString.call(value) === '[object Uint8Array]';
 }
 
+export function isBigInt64Array(value: unknown): value is BigInt64Array {
+  return Object.prototype.toString.call(value) === '[object BigInt64Array]';
+}
+
+export function isBigUInt64Array(value: unknown): value is BigUint64Array {
+  return Object.prototype.toString.call(value) === '[object BigUint64Array]';
+}
+
+/** Call to check if your environment has `Buffer` */
+export function haveBuffer(): boolean {
+  return typeof global !== 'undefined' && typeof global.Buffer !== 'undefined';
+}
+
+/** Callable in any environment to check if value is a Buffer */
+export function isBuffer(value: unknown): value is Buffer {
+  return haveBuffer() && Buffer.isBuffer(value);
+}
+
 // To ensure that 0.4 of node works correctly
 export function isDate(d: unknown): d is Date {
   return isObjectLike(d) && Object.prototype.toString.call(d) === '[object Date]';

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -18,6 +18,8 @@ function insecureRandomBytes(size: number): Uint8Array {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare let window: any;
 declare let require: Function;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare let global: any;
 
 export let randomBytes = insecureRandomBytes;
 if (typeof window !== 'undefined' && window.crypto && window.crypto.getRandomValues) {

--- a/test/node/bigint_tests.js
+++ b/test/node/bigint_tests.js
@@ -13,10 +13,7 @@ describe('BSON BigInt Support', function () {
   });
   it('Should serialize an int that fits in int32', function () {
     const testDoc = { b: BigInt(32) };
-    expect(() => BSON.serialize(testDoc)).to.throw(
-      TypeError,
-      'Do not know how to serialize a BigInt'
-    );
+    expect(() => BSON.serialize(testDoc)).to.throw(TypeError);
 
     // const serializedDoc = BSON.serialize(testDoc);
     // // prettier-ignore
@@ -28,10 +25,7 @@ describe('BSON BigInt Support', function () {
 
   it('Should serialize an int that fits in int64', function () {
     const testDoc = { b: BigInt(0x1ffffffff) };
-    expect(() => BSON.serialize(testDoc)).to.throw(
-      TypeError,
-      'Do not know how to serialize a BigInt'
-    );
+    expect(() => BSON.serialize(testDoc)).to.throw(TypeError);
 
     // const serializedDoc = BSON.serialize(testDoc);
     // // prettier-ignore
@@ -43,10 +37,7 @@ describe('BSON BigInt Support', function () {
 
   it('Should serialize an int that fits in decimal128', function () {
     const testDoc = { b: BigInt('9223372036854776001') }; // int64 max + 1
-    expect(() => BSON.serialize(testDoc)).to.throw(
-      TypeError,
-      'Do not know how to serialize a BigInt'
-    );
+    expect(() => BSON.serialize(testDoc)).to.throw(TypeError);
 
     // const serializedDoc = BSON.serialize(testDoc);
     // // prettier-ignore
@@ -61,10 +52,7 @@ describe('BSON BigInt Support', function () {
     const testDoc = {
       b: BigInt('9'.repeat(35))
     }; // decimal 128 can only encode 34 digits of precision
-    expect(() => BSON.serialize(testDoc)).to.throw(
-      TypeError,
-      'Do not know how to serialize a BigInt'
-    );
+    expect(() => BSON.serialize(testDoc)).to.throw(TypeError);
     // expect(() => BSON.serialize(testDoc)).to.throw();
   });
 });

--- a/test/node/bigint_tests.js
+++ b/test/node/bigint_tests.js
@@ -1,7 +1,6 @@
 /* globals BigInt */
 'use strict';
 
-const { Buffer } = require('buffer');
 const BSON = require('../register-bson');
 
 describe('BSON BigInt Support', function () {
@@ -14,49 +13,58 @@ describe('BSON BigInt Support', function () {
   });
   it('Should serialize an int that fits in int32', function () {
     const testDoc = { b: BigInt(32) };
-    const serializedDoc = BSON.serialize(testDoc);
+    expect(() => BSON.serialize(testDoc)).to.throw(
+      TypeError,
+      'Do not know how to serialize a BigInt'
+    );
 
-    // prettier-ignore
-    const resultBuffer = Buffer.from([0x0C, 0x00, 0x00, 0x00, 0x10, 0x62, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00]);
-
-    const resultDoc = BSON.deserialize(serializedDoc);
-
-    expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
-    expect(BigInt(resultDoc.b)).to.equal(testDoc.b);
+    // const serializedDoc = BSON.serialize(testDoc);
+    // // prettier-ignore
+    // const resultBuffer = Buffer.from([0x0C, 0x00, 0x00, 0x00, 0x10, 0x62, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00]);
+    // const resultDoc = BSON.deserialize(serializedDoc);
+    // expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
+    // expect(BigInt(resultDoc.b)).to.equal(testDoc.b);
   });
 
   it('Should serialize an int that fits in int64', function () {
     const testDoc = { b: BigInt(0x1ffffffff) };
-    const serializedDoc = BSON.serialize(testDoc);
+    expect(() => BSON.serialize(testDoc)).to.throw(
+      TypeError,
+      'Do not know how to serialize a BigInt'
+    );
 
-    // prettier-ignore
-    const resultBuffer = Buffer.from([0x10, 0x00, 0x00, 0x00, 0x12, 0x62, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00]);
-
-    const resultDoc = BSON.deserialize(serializedDoc);
-
-    expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
-    expect(BigInt(resultDoc.b)).to.equal(testDoc.b);
+    // const serializedDoc = BSON.serialize(testDoc);
+    // // prettier-ignore
+    // const resultBuffer = Buffer.from([0x10, 0x00, 0x00, 0x00, 0x12, 0x62, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00]);
+    // const resultDoc = BSON.deserialize(serializedDoc);
+    // expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
+    // expect(BigInt(resultDoc.b)).to.equal(testDoc.b);
   });
 
   it('Should serialize an int that fits in decimal128', function () {
     const testDoc = { b: BigInt('9223372036854776001') }; // int64 max + 1
-    const serializedDoc = BSON.serialize(testDoc);
+    expect(() => BSON.serialize(testDoc)).to.throw(
+      TypeError,
+      'Do not know how to serialize a BigInt'
+    );
 
-    // prettier-ignore
-    const resultBuffer = Buffer.from([0x18, 0x00, 0x00, 0x00, 0x13, 0x62, 0x00, 0xC1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x30, 0x00]);
-
-    const resultDoc = BSON.deserialize(serializedDoc);
-
-    expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
-    expect(resultDoc.b._bsontype).to.equal('Decimal128');
-    expect(BigInt(resultDoc.b.toString())).to.equal(testDoc.b);
+    // const serializedDoc = BSON.serialize(testDoc);
+    // // prettier-ignore
+    // const resultBuffer = Buffer.from([0x18, 0x00, 0x00, 0x00, 0x13, 0x62, 0x00, 0xC1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x30, 0x00]);
+    // const resultDoc = BSON.deserialize(serializedDoc);
+    // expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
+    // expect(resultDoc.b._bsontype).to.equal('Decimal128');
+    // expect(BigInt(resultDoc.b.toString())).to.equal(testDoc.b);
   });
 
   it('Should throw if BigInt is too large to serialize', function () {
     const testDoc = {
       b: BigInt('9'.repeat(35))
     }; // decimal 128 can only encode 34 digits of precision
-
-    expect(() => BSON.serialize(testDoc)).to.throw();
+    expect(() => BSON.serialize(testDoc)).to.throw(
+      TypeError,
+      'Do not know how to serialize a BigInt'
+    );
+    // expect(() => BSON.serialize(testDoc)).to.throw();
   });
 });

--- a/test/node/bigint_tests.js
+++ b/test/node/bigint_tests.js
@@ -5,6 +5,13 @@ const { Buffer } = require('buffer');
 const BSON = require('../register-bson');
 
 describe('BSON BigInt Support', function () {
+  before(function () {
+    try {
+      BigInt(0);
+    } catch (_) {
+      this.skip('JS VM does not support BigInt');
+    }
+  });
   it('Should serialize an int that fits in int32', function () {
     const testDoc = { b: BigInt(32) };
     const serializedDoc = BSON.serialize(testDoc);

--- a/test/node/bigint_tests.js
+++ b/test/node/bigint_tests.js
@@ -1,0 +1,55 @@
+/* globals BigInt */
+'use strict';
+
+const { Buffer } = require('buffer');
+const BSON = require('../register-bson');
+
+describe('BSON BigInt Support', function () {
+  it('Should serialize an int that fits in int32', function () {
+    const testDoc = { b: BigInt(32) };
+    const serializedDoc = BSON.serialize(testDoc);
+
+    // prettier-ignore
+    const resultBuffer = Buffer.from([0x0C, 0x00, 0x00, 0x00, 0x10, 0x62, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00]);
+
+    const resultDoc = BSON.deserialize(serializedDoc);
+
+    expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
+    expect(BigInt(resultDoc.b)).to.equal(testDoc.b);
+  });
+
+  it('Should serialize an int that fits in int64', function () {
+    const testDoc = { b: BigInt(0x1ffffffff) };
+    const serializedDoc = BSON.serialize(testDoc);
+
+    // prettier-ignore
+    const resultBuffer = Buffer.from([0x10, 0x00, 0x00, 0x00, 0x12, 0x62, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00]);
+
+    const resultDoc = BSON.deserialize(serializedDoc);
+
+    expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
+    expect(BigInt(resultDoc.b)).to.equal(testDoc.b);
+  });
+
+  it('Should serialize an int that fits in decimal128', function () {
+    const testDoc = { b: BigInt('9223372036854776001') }; // int64 max + 1
+    const serializedDoc = BSON.serialize(testDoc);
+
+    // prettier-ignore
+    const resultBuffer = Buffer.from([0x18, 0x00, 0x00, 0x00, 0x13, 0x62, 0x00, 0xC1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x30, 0x00]);
+
+    const resultDoc = BSON.deserialize(serializedDoc);
+
+    expect(Array.from(serializedDoc)).to.have.members(Array.from(resultBuffer));
+    expect(resultDoc.b._bsontype).to.equal('Decimal128');
+    expect(BigInt(resultDoc.b.toString())).to.equal(testDoc.b);
+  });
+
+  it('Should throw if BigInt is too large to serialize', function () {
+    const testDoc = {
+      b: BigInt('9'.repeat(35))
+    }; // decimal 128 can only encode 34 digits of precision
+
+    expect(() => BSON.serialize(testDoc)).to.throw();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": [
-      "ES2017"
+      "ES2017",
+      "ES2020.BigInt",
+      "ES2017.TypedArrays"
     ],
     "outDir": "lib",
     // We don't make use of tslib helpers


### PR DESCRIPTION
Given JavaScript's new BigInt type the serializer will attempt to fit the value in the smallest possible type. In the following order: Int32, Int64, Decimal128. Any values larger than Decimal128's maximum representable range will result in a thrown TypeError

NODE-2529

There's no logic in here to deserialize to big int only to accept it and serialize it to one of our BSON types. In terms of platform support I only used the BigInt constructor not the `23n` syntax so the code path will just go untravelled on older JS engines.