### PR TITLE
NODE-2720/coverage

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,5 +1,4 @@
 {
   "extends": "@istanbuljs/nyc-config-typescript",
-  "include": ["src/**/*.ts"],
-  "reporter": ["lcovonly", "text-summary"]
+  "reporter": ["lcovonly", "text-summary", "html"]
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "build": "npm run build:dts && npm run build:bundle",
     "lint": "eslint -v && eslint --ext '.js,.ts' --max-warnings=0 src test && tsc -v && tsc --noEmit",
     "format": "eslint --ext '.js,.ts' src test --fix",
-    "coverage": "nyc mocha test/node",
+    "coverage": "nyc npm run test-node",
+    "coverage:html": "npm run coverage && open ./coverage/index.html",
     "prepare": "node etc/prepare.js",
     "release": "standard-version -i HISTORY.md"
   },


### PR DESCRIPTION
[NODE-2720](https://jira.mongodb.org/browse/NODE-2720?filter=-1)

This PR fixes NYC coverage. The issue seems to be with the `includes` property within that NYC configuration. Simply removing this property allows the coverage to be reported.

This also adds HTML reporting, for and generates HTML output in the `coverage` folder. Also adds a `coverage:html` npm `script` to `open` the coverage report once it's finished.