### PR TITLE
feat: add extended json parsing for $uuid

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer';
 import { ensureBuffer } from './ensure_buffer';
 import type { EJSONOptions } from './extended_json';
-import { parseUUID } from './uuid';
+import { parseUUID, UUIDExtended } from './uuid';
 
 type BinarySequence = Uint8Array | Buffer | number[];
 
@@ -15,10 +15,6 @@ export interface BinaryExtended {
     subType: string;
     base64: string;
   };
-}
-
-export interface UUIDExtended {
-  $uuid: string;
 }
 
 /** A class representation of the BSON Binary type. */

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer';
 import { ensureBuffer } from './ensure_buffer';
 import type { EJSONOptions } from './extended_json';
+import { parseUUID } from './uuid';
 
 type BinarySequence = Uint8Array | Buffer | number[];
 
@@ -14,6 +15,10 @@ export interface BinaryExtended {
     subType: string;
     base64: string;
   };
+}
+
+export interface UUIDExtended {
+  $uuid: string;
 }
 
 /** A class representation of the BSON Binary type. */
@@ -202,7 +207,7 @@ export class Binary {
   }
 
   /** @internal */
-  toExtendedJSON(options?: EJSONOptions): BinaryExtendedLegacy | BinaryExtended {
+  toExtendedJSON(options?: EJSONOptions): BinaryExtendedLegacy | BinaryExtended | UUIDExtended {
     options = options || {};
     const base64String = this.buffer.toString('base64');
 
@@ -223,20 +228,25 @@ export class Binary {
 
   /** @internal */
   static fromExtendedJSON(
-    doc: BinaryExtendedLegacy | BinaryExtended,
+    doc: BinaryExtendedLegacy | BinaryExtended | UUIDExtended,
     options?: EJSONOptions
   ): Binary {
     options = options || {};
     let data: Buffer | undefined;
     let type;
-    if (options.legacy && typeof doc.$binary === 'string' && '$type' in doc) {
-      type = doc.$type ? parseInt(doc.$type, 16) : 0;
-      data = Buffer.from(doc.$binary, 'base64');
-    } else {
-      if (typeof doc.$binary !== 'string') {
-        type = doc.$binary.subType ? parseInt(doc.$binary.subType, 16) : 0;
-        data = Buffer.from(doc.$binary.base64, 'base64');
+    if ('$binary' in doc) {
+      if (options.legacy && typeof doc.$binary === 'string' && '$type' in doc) {
+        type = doc.$type ? parseInt(doc.$type, 16) : 0;
+        data = Buffer.from(doc.$binary, 'base64');
+      } else {
+        if (typeof doc.$binary !== 'string') {
+          type = doc.$binary.subType ? parseInt(doc.$binary.subType, 16) : 0;
+          data = Buffer.from(doc.$binary.base64, 'base64');
+        }
       }
+    } else if ('$uuid' in doc) {
+      type = 4;
+      data = Buffer.from(parseUUID(doc.$uuid));
     }
     if (!data) {
       throw new TypeError(`Unexpected Binary Extended JSON format ${JSON.stringify(doc)}`);

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -207,7 +207,7 @@ export class Binary {
   }
 
   /** @internal */
-  toExtendedJSON(options?: EJSONOptions): BinaryExtendedLegacy | BinaryExtended | UUIDExtended {
+  toExtendedJSON(options?: EJSONOptions): BinaryExtendedLegacy | BinaryExtended {
     options = options || {};
     const base64String = this.buffer.toString('base64');
 

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -52,6 +52,7 @@ export interface EJSONOptions {
 const keysToCodecs = {
   $oid: ObjectId,
   $binary: Binary,
+  $uuid: Binary,
   $symbol: BSONSymbol,
   $numberInt: Int32,
   $numberDecimal: Decimal128,

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,3 +1,7 @@
+/**
+ * UUID regular expression pattern copied from `uuid` npm module.
+ * @see https://github.com/uuidjs/uuid/blob/master/src/regex.js
+ */
 const UUID_RX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 
 export interface UUIDExtended {

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,0 +1,59 @@
+const UUIDPattern = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+
+export function formatUUID(uuid: string): string {
+  uuid = uuid.replace(/^.+:/, '');
+  if (!uuid.match('-')) {
+    const pieces = [
+      uuid.substr(0, 8),
+      uuid.substr(8, 4),
+      uuid.substr(8 + 4, 4),
+      uuid.substr(8 + 4 + 4, 4),
+      uuid.substr(8 + 4 + 4 + 4, 12)
+    ];
+    uuid = pieces.join('-');
+  }
+  return uuid;
+}
+
+export function parseUUID(uuid: string): Uint8Array {
+  uuid = formatUUID(uuid);
+
+  if (typeof uuid !== 'string') {
+    throw new Error('$uuid wrong type');
+  }
+  if (!UUIDPattern.test(uuid)) {
+    throw new Error('$uuid invalid value');
+  }
+
+  let v;
+  const arr = new Uint8Array(16);
+
+  // Parse ########-....-....-....-............
+  arr[0] = (v = parseInt(uuid.slice(0, 8), 16)) >>> 24;
+  arr[1] = (v >>> 16) & 0xff;
+  arr[2] = (v >>> 8) & 0xff;
+  arr[3] = v & 0xff;
+
+  // Parse ........-####-....-....-............
+  arr[4] = (v = parseInt(uuid.slice(9, 13), 16)) >>> 8;
+  arr[5] = v & 0xff;
+
+  // Parse ........-....-####-....-............
+  arr[6] = (v = parseInt(uuid.slice(14, 18), 16)) >>> 8;
+  arr[7] = v & 0xff;
+
+  // Parse ........-....-....-####-............
+  arr[8] = (v = parseInt(uuid.slice(19, 23), 16)) >>> 8;
+  arr[9] = v & 0xff;
+
+  // Parse ........-....-....-....-############
+  // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
+  arr[10] = ((v = parseInt(uuid.slice(24, 36), 16)) / 0x10000000000) & 0xff;
+  arr[11] = (v / 0x100000000) & 0xff;
+  arr[12] = (v >>> 24) & 0xff;
+  arr[13] = (v >>> 16) & 0xff;
+  arr[14] = (v >>> 8) & 0xff;
+  arr[15] = v & 0xff;
+
+  return arr;
+}

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,5 +1,6 @@
-const UUIDPattern = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+const UUID_RX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 
+/** @internal */
 export function formatUUID(uuid: string): string {
   uuid = uuid.replace(/^.+:/, '');
   const result = uuid.match(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/);
@@ -7,13 +8,18 @@ export function formatUUID(uuid: string): string {
   return uuid;
 }
 
+/**
+ * Parser function copied from `uuid` npm module.
+ * @see https://github.com/uuidjs/uuid/blob/master/src/parse.js
+ * @internal
+ */
 export function parseUUID(uuid: string): Uint8Array {
   uuid = formatUUID(uuid);
 
   if (typeof uuid !== 'string') {
     throw new Error('$uuid wrong type');
   }
-  if (!UUIDPattern.test(uuid)) {
+  if (!UUID_RX.test(uuid)) {
     throw new Error('$uuid invalid value');
   }
 

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,7 +1,7 @@
 const UUID_RX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 
 /** @internal */
-export function formatUUID(uuid: string): string {
+function formatUUID(uuid: string): string {
   uuid = uuid.replace(/^.+:/, '');
   const result = uuid.match(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/);
   if (result) uuid = result.slice(1, 6).join('-');

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,11 +1,5 @@
-const UUID_RX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
-
-/** @internal */
-function formatUUID(uuid: string): string {
-  uuid = uuid.replace(/^.+:/, '');
-  const result = uuid.match(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/);
-  if (result) uuid = result.slice(1, 6).join('-');
-  return uuid;
+export interface UUIDExtended {
+  $uuid: string;
 }
 
 /**
@@ -14,11 +8,12 @@ function formatUUID(uuid: string): string {
  * @internal
  */
 export function parseUUID(uuid: string): Uint8Array {
-  uuid = formatUUID(uuid);
-
   if (typeof uuid !== 'string') {
     throw new Error('$uuid wrong type');
   }
+
+  const UUID_RX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+
   if (!UUID_RX.test(uuid)) {
     throw new Error('$uuid invalid value');
   }

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -2,16 +2,8 @@ const UUIDPattern = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]
 
 export function formatUUID(uuid: string): string {
   uuid = uuid.replace(/^.+:/, '');
-  if (!uuid.match('-')) {
-    const pieces = [
-      uuid.substr(0, 8),
-      uuid.substr(8, 4),
-      uuid.substr(8 + 4, 4),
-      uuid.substr(8 + 4 + 4, 4),
-      uuid.substr(8 + 4 + 4 + 4, 12)
-    ];
-    uuid = pieces.join('-');
-  }
+  const result = uuid.match(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/);
+  if (result) uuid = result.slice(1, 6).join('-');
   return uuid;
 }
 

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,3 +1,5 @@
+const UUID_RX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+
 export interface UUIDExtended {
   $uuid: string;
 }
@@ -9,13 +11,11 @@ export interface UUIDExtended {
  */
 export function parseUUID(uuid: string): Uint8Array {
   if (typeof uuid !== 'string') {
-    throw new Error('$uuid wrong type');
+    throw new TypeError('Invalid type for UUID, expected string but got ' + typeof uuid);
   }
 
-  const UUID_RX = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
-
   if (!UUID_RX.test(uuid)) {
-    throw new Error('$uuid invalid value');
+    throw new TypeError('Invalid format for UUID: ' + uuid);
   }
 
   let v;

--- a/test/node/specs/bson-corpus/binary.json
+++ b/test/node/specs/bson-corpus/binary.json
@@ -40,6 +40,12 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}"
         },
         {
+            "description": "subtype 0x04 UUID",
+            "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
+            "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
+        },
+        {
             "description": "subtype 0x05",
             "canonical_bson": "1D000000057800100000000573FFD26444B34C6990E8E7D1DFC035D400",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"05\"}}}"
@@ -80,6 +86,16 @@
         {
             "description": "subtype 0x02 length negative one",
             "bson": "130000000578000600000002FFFFFFFFFFFF00"
+        }
+    ],
+    "parseErrors": [
+        {
+            "description": "$uuid wrong type",
+            "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"
+        },
+        {
+            "description": "$uuid invalid value",
+            "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-90e8-e7d1dfc035d4\"}}"
         }
     ]
 }


### PR DESCRIPTION
[NODE-2805](https://jira.mongodb.org/browse/NODE-2805?filter=-1)

* Adds in extended JSON parsing for `$uuid`.
* Had a learning curve to understand how UUID's are converted to a binary string for `base64` encoding, until I realized it was a specialized for UUID's.
* Added a couple of UUID helper methods `UUIDPattern`, `parseUUID`, `formatUUID` to a new `uuid.ts` file, some pulled in from the [`uuid` module](https://www.npmjs.com/package/uuid). With the intention on adding the dependency at a later time if necessary.
* Seeking advice on where to put these methods new helper methods (and naming), as we may want to reserve the `uuid.ts` file for the `UUID` class in the future.
* Alternatively could create `UUID` class now and add static `parse` and `format` methods, swappable if we ever use the `uuid` module,  the `UUIDExtended` interface could also live in `uuid.ts` rather then`binary.ts`
* <s>Includes a `formatUUID` function not provided by the UUID package, in order to format the [UUID in accordance with python's `uuid.UUID` method](https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#user-content-special-rules-for-parsing-uuid-fields:~:text=Parsers%20MUST%20interpret%20the%20%24uuid%20key,between%20hex%20character%20groups%20(e.g.%20c8edabc3f7384ca3b68dab92a91478a3).), where the `urn:uuid ` prefix is stripped and `-` are added in if they are not there prior to `base64` encoding.</s>
