### PR TITLE
fix: Correct API Extractor config to omit definition file from dist

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -9,6 +9,7 @@
   },
   "dtsRollup": {
     "enabled": true,
+    "untrimmedFilePath": "", // Force API extractor to not create d.ts in dist folder
     "publicTrimmedFilePath": "<projectFolder>/<unscopedPackageName>.d.ts"
   },
   "tsdocMetadata": {


### PR DESCRIPTION
Omit untrimmed definitions file from dist