### PR TITLE
fix: remove stringify overloads

### DIFF
--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -349,8 +349,6 @@ export namespace EJSON {
    * console.log(EJSON.stringify(doc));
    * ```
    */
-  export function stringify(value: SerializableTypes): string;
-  export function stringify(value: SerializableTypes, options?: EJSON.Options): string;
   export function stringify(
     value: SerializableTypes,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
NODE-2846

For some reason with the overloads on `stringify` the `d.ts` build was not including the base-level argument types. Because this function has all successive arguments optional AND there's the same return type, there's no reason to have overloads for this function at all.