### PR TITLE
fix: make inspect for ObjectId work

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -338,6 +338,20 @@ export class ObjectId {
   static fromExtendedJSON(doc: ObjectIdExtended): ObjectId {
     return new ObjectId(doc.$oid);
   }
+
+  /**
+   * Converts to a string representation of this Id.
+   *
+   * @returns return the 24 character hex string representation.
+   * @internal
+   */
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
+    return this.inspect();
+  }
+
+  inspect(): string {
+    return `ObjectId("${this.toHexString()}")`;
+  }
 }
 
 // Deprecated methods
@@ -359,15 +373,5 @@ Object.defineProperty(ObjectId.prototype, 'get_inc', {
 Object.defineProperty(ObjectId, 'get_inc', {
   value: deprecate(() => ObjectId.getInc(), 'Please use the static `ObjectId.getInc()` instead')
 });
-
-const inspect = Symbol.for('nodejs.util.inspect.custom');
-/**
- * Converts to a string representation of this Id.
- *
- * @returns return the 24 character hex string representation.
- * @internal
- */
-Object.defineProperty(ObjectId.prototype, inspect, ObjectId.prototype.toString);
-Object.defineProperty(ObjectId.prototype, 'inspect', ObjectId.prototype.toString);
 
 Object.defineProperty(ObjectId.prototype, '_bsontype', { value: 'ObjectID' });

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -66,16 +66,7 @@ describe('ObjectId', function () {
   it('should correctly allow for node.js inspect to work with ObjectId', function (done) {
     var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
     var b = new ObjectId(a);
-    util.inspect(b);
-
-    // var c = b.equals(a); // => false
-    // expect(true).to.equal(c);
-    //
-    // var a = 'aaaaaaaaaaaaaaaaaaaaaaaa';
-    // var b = new ObjectId(a);
-    // var c = b.equals(a); // => true
-    // expect(true).to.equal(c);
-    // expect(a).to.equal(b.toString());
+    expect(util.inspect(b)).to.equal('ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")');
 
     done();
   });


### PR DESCRIPTION
The previous `Object.defineProperty()` calls did not work because
they did not specify a property descriptor, and even if they had
worked, the signatures of `.inspect()` and `.toString()` would
have mismatched, and even if they weren’t, the result would not
have been very useful as debugging output, because it only returned
the raw hex content of the `ObjectId` and not even e.g. the fact
that this object is an `ObjectId`.

I’m happy with any other solution, but this particular one would
make my life a tiny bit easier :)

## Description

Make the `inspect` and `[util.inspect.custom]` methods on `ObjectId` work.

---

Not sure if I should open a JIRA ticket for this, but happy to do so if it helps :)
