### PR TITLE
fix: make inspection result of Binary evaluatable NODE-2947

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -263,7 +263,7 @@ export class Binary {
 
   inspect(): string {
     const asBuffer = this.value(true);
-    return `Binary(Buffer.from("${asBuffer.toString('hex')}", "hex"), ${this.sub_type})`;
+    return `new Binary(Buffer.from("${asBuffer.toString('hex')}", "hex"), ${this.sub_type})`;
   }
 }
 

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -263,7 +263,7 @@ export class Binary {
 
   inspect(): string {
     const asBuffer = this.value(true);
-    return `Binary("${asBuffer.toString('hex')}", ${this.sub_type})`;
+    return `Binary(Buffer.from("${asBuffer.toString('hex')}", "hex"), ${this.sub_type})`;
   }
 }
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -50,7 +50,9 @@ export class Code {
 
   inspect(): string {
     const codeJson = this.toJSON();
-    return `Code("${codeJson.code}"${codeJson.scope ? `, ${JSON.stringify(codeJson.scope)}` : ''})`;
+    return `new Code("${codeJson.code}"${
+      codeJson.scope ? `, ${JSON.stringify(codeJson.scope)}` : ''
+    })`;
   }
 }
 

--- a/src/db_ref.ts
+++ b/src/db_ref.ts
@@ -108,7 +108,9 @@ export class DBRef {
     // NOTE: if OID is an ObjectId class it will just print the oid string.
     const oid =
       this.oid === undefined || this.oid.toString === undefined ? this.oid : this.oid.toString();
-    return `DBRef("${this.namespace}", "${oid}"${this.db ? `, "${this.db}"` : ''})`;
+    return `new DBRef("${this.namespace}", new ObjectId("${oid}")${
+      this.db ? `, "${this.db}"` : ''
+    })`;
   }
 }
 

--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -794,7 +794,7 @@ export class Decimal128 {
   }
 
   inspect(): string {
-    return `Decimal128("${this.toString()}")`;
+    return `Decimal128.fromString("${this.toString()}")`;
   }
 }
 

--- a/src/double.ts
+++ b/src/double.ts
@@ -78,7 +78,7 @@ export class Double {
 
   inspect(): string {
     const eJSON = this.toExtendedJSON() as DoubleExtended;
-    return `Double(${eJSON.$numberDouble})`;
+    return `new Double(${eJSON.$numberDouble})`;
   }
 }
 

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -57,7 +57,7 @@ export class Int32 {
   }
 
   inspect(): string {
-    return `Int32(${this.valueOf()})`;
+    return `new Int32(${this.valueOf()})`;
   }
 }
 

--- a/src/long.ts
+++ b/src/long.ts
@@ -992,7 +992,7 @@ export class Long {
   }
 
   inspect(): string {
-    return `Long("${this.toString()}")`;
+    return `new Long("${this.toString()}")`;
   }
 }
 

--- a/src/max_key.ts
+++ b/src/max_key.ts
@@ -26,7 +26,7 @@ export class MaxKey {
   }
 
   inspect(): string {
-    return 'MaxKey()';
+    return 'new MaxKey()';
   }
 }
 

--- a/src/min_key.ts
+++ b/src/min_key.ts
@@ -26,7 +26,7 @@ export class MinKey {
   }
 
   inspect(): string {
-    return 'MinKey()';
+    return 'new MinKey()';
   }
 }
 

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -350,7 +350,7 @@ export class ObjectId {
   }
 
   inspect(): string {
-    return `ObjectId("${this.toHexString()}")`;
+    return `new ObjectId("${this.toHexString()}")`;
   }
 }
 

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -30,7 +30,7 @@ export class BSONSymbol {
 
   /** @internal */
   inspect(): string {
-    return `BSONSymbol("${this.value}")`;
+    return `new BSONSymbol("${this.value}")`;
   }
 
   /** @internal */

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -98,6 +98,6 @@ export class Timestamp extends LongWithoutOverridesClass {
   }
 
   inspect(): string {
-    return `Timestamp(${this.getLowBits().toString()}, ${this.getHighBits().toString()})`;
+    return `new Timestamp(${this.getLowBits().toString()}, ${this.getHighBits().toString()})`;
   }
 }

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -2276,7 +2276,9 @@ describe('BSON', function () {
      */
     it('Binary', function () {
       const binary = new Binary(Buffer.from('0123456789abcdef0123456789abcdef', 'hex'), 4);
-      expect(inspect(binary)).to.equal('Binary(Buffer.from("0123456789abcdef0123456789abcdef", "hex"), 4)');
+      expect(inspect(binary)).to.equal(
+        'Binary(Buffer.from("0123456789abcdef0123456789abcdef", "hex"), 4)'
+      );
     });
 
     /**

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -2277,7 +2277,7 @@ describe('BSON', function () {
     it('Binary', function () {
       const binary = new Binary(Buffer.from('0123456789abcdef0123456789abcdef', 'hex'), 4);
       expect(inspect(binary)).to.equal(
-        'Binary(Buffer.from("0123456789abcdef0123456789abcdef", "hex"), 4)'
+        'new Binary(Buffer.from("0123456789abcdef0123456789abcdef", "hex"), 4)'
       );
     });
 
@@ -2286,7 +2286,7 @@ describe('BSON', function () {
      */
     it('BSONSymbol', function () {
       const symbol = new BSONSymbol('sym');
-      expect(inspect(symbol)).to.equal('BSONSymbol("sym")');
+      expect(inspect(symbol)).to.equal('new BSONSymbol("sym")');
     });
 
     /**
@@ -2294,7 +2294,7 @@ describe('BSON', function () {
      */
     it('Code', function () {
       const code = new Code('this.a > i', { i: 1 });
-      expect(inspect(code)).to.equal('Code("this.a > i", {"i":1})');
+      expect(inspect(code)).to.equal('new Code("this.a > i", {"i":1})');
     });
 
     /**
@@ -2304,7 +2304,7 @@ describe('BSON', function () {
       const oid = new ObjectId('deadbeefdeadbeefdeadbeef');
       const dbref = new DBRef('namespace', oid, 'integration_tests_');
       expect(inspect(dbref)).to.equal(
-        'DBRef("namespace", "deadbeefdeadbeefdeadbeef", "integration_tests_")'
+        'new DBRef("namespace", new ObjectId("deadbeefdeadbeefdeadbeef"), "integration_tests_")'
       );
     });
 
@@ -2313,7 +2313,7 @@ describe('BSON', function () {
      */
     it('Decimal128', function () {
       const dec = Decimal128.fromString('1.42');
-      expect(inspect(dec)).to.equal('Decimal128("1.42")');
+      expect(inspect(dec)).to.equal('Decimal128.fromString("1.42")');
     });
 
     /**
@@ -2321,7 +2321,7 @@ describe('BSON', function () {
      */
     it('Double', function () {
       const double = new Double(-42.42);
-      expect(inspect(double)).to.equal('Double(-42.42)');
+      expect(inspect(double)).to.equal('new Double(-42.42)');
     });
 
     /**
@@ -2329,7 +2329,7 @@ describe('BSON', function () {
      */
     it('Int32', function () {
       const int = new Int32(42);
-      expect(inspect(int)).to.equal('Int32(42)');
+      expect(inspect(int)).to.equal('new Int32(42)');
     });
 
     /**
@@ -2337,7 +2337,7 @@ describe('BSON', function () {
      */
     it('Long', function () {
       const long = Long.fromString('42');
-      expect(inspect(long)).to.equal('Long("42")');
+      expect(inspect(long)).to.equal('new Long("42")');
     });
 
     /**
@@ -2345,7 +2345,7 @@ describe('BSON', function () {
      */
     it('MaxKey', function () {
       const maxKey = new MaxKey();
-      expect(inspect(maxKey)).to.equal('MaxKey()');
+      expect(inspect(maxKey)).to.equal('new MaxKey()');
     });
 
     /**
@@ -2353,7 +2353,7 @@ describe('BSON', function () {
      */
     it('MinKey', function () {
       const minKey = new MinKey();
-      expect(inspect(minKey)).to.equal('MinKey()');
+      expect(inspect(minKey)).to.equal('new MinKey()');
     });
 
     /**
@@ -2361,7 +2361,7 @@ describe('BSON', function () {
      */
     it('Timestamp', function () {
       const timestamp = new Timestamp(1, 100);
-      expect(inspect(timestamp)).to.equal('Timestamp(1, 100)');
+      expect(inspect(timestamp)).to.equal('new Timestamp(1, 100)');
     });
   });
 });

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -2276,7 +2276,7 @@ describe('BSON', function () {
      */
     it('Binary', function () {
       const binary = new Binary(Buffer.from('0123456789abcdef0123456789abcdef', 'hex'), 4);
-      expect(inspect(binary)).to.equal('Binary("0123456789abcdef0123456789abcdef", 4)');
+      expect(inspect(binary)).to.equal('Binary(Buffer.from("0123456789abcdef0123456789abcdef", "hex"), 4)');
     });
 
     /**

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -66,7 +66,7 @@ describe('ObjectId', function () {
   it('should correctly allow for node.js inspect to work with ObjectId', function (done) {
     var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
     var b = new ObjectId(a);
-    expect(util.inspect(b)).to.equal('ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")');
+    expect(util.inspect(b)).to.equal('new ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")');
 
     done();
   });


### PR DESCRIPTION
Make sure that evaluating the inspection result of a `Binary` object
returns a result that can be evaluated to give an object equivalent
to the original.

