### PR TITLE
isBuffer: Check object equality not class name

### DIFF
--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -58,7 +58,7 @@ export function haveBuffer(): boolean {
 
 /** Callable in any environment to check if value is a Buffer */
 export function isBuffer(value: unknown): value is Buffer {
-  return isUint8Array(value) && typeof value?.toJSON === 'function';
+  return isUint8Array(value) && typeof (value as any)?.toJSON === 'function';
 }
 
 // To ensure that 0.4 of node works correctly

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -58,7 +58,7 @@ export function haveBuffer(): boolean {
 
 /** Callable in any environment to check if value is a Buffer */
 export function isBuffer(value: unknown): value is Buffer {
-  return typeof value === 'object' && value?.constructor === Buffer;
+  return isUint8Array(value) && typeof value?.toJSON === 'function';
 }
 
 // To ensure that 0.4 of node works correctly

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -58,7 +58,7 @@ export function haveBuffer(): boolean {
 
 /** Callable in any environment to check if value is a Buffer */
 export function isBuffer(value: unknown): value is Buffer {
-  return typeof value === 'object' && value?.constructor?.name === 'Buffer';
+  return typeof value === 'object' && value?.constructor === Buffer;
 }
 
 // To ensure that 0.4 of node works correctly

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -58,6 +58,7 @@ export function haveBuffer(): boolean {
 
 /** Callable in any environment to check if value is a Buffer */
 export function isBuffer(value: unknown): value is Buffer {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return isUint8Array(value) && typeof (value as any)?.toJSON === 'function';
 }
 


### PR DESCRIPTION
isBuffer: Check object equality not class name
    
If minified, the name of the buffer class may change, breaking the `isBuffer()` function, and thus the library.

Since 5167be2752369d5832057f7b69da0e240ed4c204 binary fields have been broken for users minifying their source. The `.buffer` attribute would contain the raw BSON blob, rather than just the field's value.

NODE-2963