### PR TITLE
check both window and self

### DIFF
--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -77,7 +77,7 @@ export function isObjectLike(candidate: unknown): candidate is Record<string, un
 
 declare let console: { warn(...message: unknown[]): void };
 export function deprecate<T extends Function>(fn: T, message: string): T {
-  if (typeof window === 'undefined' || typeof self === 'undefined') {
+  if (typeof window === 'undefined' && typeof self === 'undefined') {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require('util').deprecate(fn, message);
   }


### PR DESCRIPTION
## Description

This PR makes this package usable in a web-worker.


Another approach would be to use `globalThis`. But, that would required node 12+, I see there is quite good support for it in browsers.