### PR TITLE
fix: clean up instanceof usage

### DIFF
--- a/src/ensure_buffer.ts
+++ b/src/ensure_buffer.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import { isBuffer } from './parser/utils';
+import { isBuffer, isAnyArrayBuffer } from './parser/utils';
 
 /**
  * Makes sure that, if a Uint8Array is passed in, it is wrapped in a Buffer.
@@ -18,11 +18,7 @@ export function ensureBuffer(potentialBuffer: Buffer | ArrayBufferView | ArrayBu
     return Buffer.from(potentialBuffer.buffer);
   }
 
-  if (
-    ['[object ArrayBuffer]', '[object SharedArrayBuffer]'].includes(
-      Object.prototype.toString.call(potentialBuffer)
-    )
-  ) {
+  if (isAnyArrayBuffer(potentialBuffer)) {
     return Buffer.from(potentialBuffer);
   }
 

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -9,7 +9,7 @@ import { Long } from './long';
 import { MaxKey } from './max_key';
 import { MinKey } from './min_key';
 import { ObjectId } from './objectid';
-import { isObjectLike } from './parser/utils';
+import { isDate, isObjectLike, isRegExp } from './parser/utils';
 import { BSONRegExp } from './regexp';
 import { BSONSymbol } from './symbol';
 import { Timestamp } from './timestamp';
@@ -157,7 +157,7 @@ function serializeValue(value: any, options: EJSON.Options): any {
 
   if (value === undefined) return null;
 
-  if (value instanceof Date) {
+  if (value instanceof Date || isDate(value)) {
     const dateNum = value.getTime(),
       // is it in year range 1970-9999?
       inRange = dateNum > -1 && dateNum < 253402318800000;
@@ -185,7 +185,7 @@ function serializeValue(value: any, options: EJSON.Options): any {
     return { $numberDouble: value.toString() };
   }
 
-  if (value instanceof RegExp) {
+  if (value instanceof RegExp || isRegExp(value)) {
     let flags = value.flags;
     if (flags === undefined) {
       const match = value.toString().match(/[gimuy]*$/);

--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -83,7 +83,11 @@ function calculateElement(
         return (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + (12 + 1);
       } else if (value instanceof Date || isDate(value)) {
         return (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + (8 + 1);
-      } else if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer || isAnyArrayBuffer(value)) {
+      } else if (
+        ArrayBuffer.isView(value) ||
+        value instanceof ArrayBuffer ||
+        isAnyArrayBuffer(value)
+      ) {
         return (
           (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) + (1 + 4 + 1) + value.byteLength
         );
@@ -185,10 +189,7 @@ function calculateElement(
       }
     case 'function':
       // WTF for 0.4.X where typeof /someregexp/ === 'function'
-      if (
-        value instanceof RegExp || isRegExp(value) ||
-        String.call(value) === '[object RegExp]'
-      ) {
+      if (value instanceof RegExp || isRegExp(value) || String.call(value) === '[object RegExp]') {
         return (
           (name != null ? Buffer.byteLength(name, 'utf8') + 1 : 0) +
           1 +

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -20,6 +20,8 @@ import {
   isBigUInt64Array,
   isBuffer,
   isDate,
+  isMap,
+  isRegExp,
   isUint8Array,
   normalizedFunctionString
 } from './utils';
@@ -40,10 +42,6 @@ export interface SerializeOptions {
 
 const regexp = /\x00/; // eslint-disable-line no-control-regex
 const ignoreKeys = new Set(['$db', '$ref', '$id', '$clusterTime']);
-
-function isRegExp(d: unknown): d is RegExp {
-  return Object.prototype.toString.call(d) === '[object RegExp]';
-}
 
 /*
  * isArray indicates if we are writing to a BSON array (type 0x04)
@@ -843,7 +841,7 @@ export function serializeInto(
         throw new TypeError('Unrecognized or invalid _bsontype: ' + value['_bsontype']);
       }
     }
-  } else if (object instanceof Map) {
+  } else if (object instanceof Map || isMap(object)) {
     const iterator = object.entries();
     let done = false;
 

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -62,6 +62,11 @@ const detectRandomBytes = (): RandomBytesFunction => {
 
 export const randomBytes = detectRandomBytes();
 
+export function isAnyArrayBuffer(value: unknown): value is ArrayBuffer {
+  return ['[object ArrayBuffer]', '[object SharedArrayBuffer]'].includes(
+    Object.prototype.toString.call(value));
+}
+
 export function isUint8Array(value: unknown): value is Uint8Array {
   return Object.prototype.toString.call(value) === '[object Uint8Array]';
 }
@@ -72,6 +77,14 @@ export function isBigInt64Array(value: unknown): value is BigInt64Array {
 
 export function isBigUInt64Array(value: unknown): value is BigUint64Array {
   return Object.prototype.toString.call(value) === '[object BigUint64Array]';
+}
+
+export function isRegExp(d: unknown): d is RegExp {
+  return Object.prototype.toString.call(d) === '[object RegExp]';
+}
+
+export function isMap(d: unknown): d is Map<unknown, unknown> {
+  return Object.prototype.toString.call(d) === '[object Map]';
 }
 
 /** Call to check if your environment has `Buffer` */

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -64,7 +64,8 @@ export const randomBytes = detectRandomBytes();
 
 export function isAnyArrayBuffer(value: unknown): value is ArrayBuffer {
   return ['[object ArrayBuffer]', '[object SharedArrayBuffer]'].includes(
-    Object.prototype.toString.call(value));
+    Object.prototype.toString.call(value)
+  );
 }
 
 export function isUint8Array(value: unknown): value is Uint8Array {

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -2,6 +2,7 @@
 
 const BSON = require('../register-bson');
 const EJSON = BSON.EJSON;
+const vm = require('vm');
 
 // BSON types
 const Binary = BSON.Binary;
@@ -228,7 +229,9 @@ describe('Extended JSON', function () {
       oldObjectID: OldObjectID.createFromHexString('111111111111111111111111'),
       bsonRegExp: new BSONRegExp('hello world', 'i'),
       symbol: new BSONSymbol('symbol'),
-      timestamp: new Timestamp()
+      timestamp: new Timestamp(),
+      foreignRegExp: vm.runInNewContext('/abc/'),
+      foreignDate: vm.runInNewContext('new Date(0)')
     };
 
     const result = EJSON.serialize(doc, { relaxed: false });
@@ -247,7 +250,9 @@ describe('Extended JSON', function () {
       oldObjectID: { $oid: '111111111111111111111111' },
       bsonRegExp: { $regularExpression: { pattern: 'hello world', options: 'i' } },
       symbol: { $symbol: 'symbol' },
-      timestamp: { $timestamp: { t: 0, i: 0 } }
+      timestamp: { $timestamp: { t: 0, i: 0 } },
+      foreignDate: { $date: { $numberLong: '0' } },
+      foreignRegExp: { $regularExpression: { pattern: 'abc', options: '' } }
     });
   });
 


### PR DESCRIPTION
Similarly to 99722f66d, instanceof is not a great brand check in JS
in general, and using `Object.prototype.toString.call()` is better
at detecting built-in types.

This particular change is needed for mongosh, because the user input
it not evaluated in the same `vm.Context` as the bson package that
we’re using.

NODE-3208

## Description

**What changed?**
