### PR TITLE
feat: make circular input errors for EJSON expressive

### DIFF
--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -495,6 +495,21 @@ describe('Extended JSON', function () {
     // expect(() => EJSON.serialize(badMap)).to.throw(); // uncomment when EJSON supports ES6 Map
   });
 
+  it('should throw a helpful error message for input with circular references', function () {
+    const obj = {
+      some: {
+        property: {
+          array: []
+        }
+      }
+    };
+    obj.some.property.array.push(obj.some);
+    expect(() => EJSON.serialize(obj)).to.throw(`\
+Converting circular structure to EJSON:
+    (input) -> some -> property -> array -> index 0
+                 \\-----------------------------/`);
+  });
+
   context('when dealing with legacy extended json', function () {
     describe('.stringify', function () {
       context('when serializing binary', function () {


### PR DESCRIPTION
Give errors roughly in the style of those thrown by
`JSON.stringify()` on modern Node.js/V8 versions, where the path to
the property and its circularity are visualized instead of just
recursive indefinitely.

This is just one suggested solution – it would be nice to have *some*
kind of better error in these cases, and I think actually displaying
the path would be nice in terms of UX, but I can also see an argument
for avoiding the extra bits of complexity here.

NODE-3226

## Description

**What changed?**
