### PR TITLE
fix: make Long inspect result evaluable

### DIFF
--- a/src/long.ts
+++ b/src/long.ts
@@ -994,7 +994,7 @@ export class Long {
   }
 
   inspect(): string {
-    return `new Long("${this.toString()}")`;
+    return `Long.fromString("${this.toString()}"${this.unsigned ? ', true' : ''})`;
   }
 }
 

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -2356,7 +2356,10 @@ describe('BSON', function () {
      */
     it('Long', function () {
       const long = Long.fromString('42');
-      expect(inspect(long)).to.equal('new Long("42")');
+      expect(inspect(long)).to.equal('Long.fromString("42")');
+
+      const unsignedLong = Long.fromString('42', true);
+      expect(inspect(unsignedLong)).to.equal('Long.fromString("42", true)');
     });
 
     /**


### PR DESCRIPTION
Do basically the same thing we’re already doing for `Decimal128` to
ensure that the inspect result accurately represents the contents
in a way that can be used to evaluate it again.

NODE-3256

## Description

**What changed?**
