### PR TITLE
ObjectId's PROCESS_UNIQUE lazy loaded

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -2,9 +2,6 @@ import { Buffer } from 'buffer';
 import { ensureBuffer } from './ensure_buffer';
 import { deprecate, isUint8Array, randomBytes } from './parser/utils';
 
-// constants
-const PROCESS_UNIQUE = randomBytes(5);
-
 // Regular expression that checks for hex value
 const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
 
@@ -19,6 +16,9 @@ const decodeLookup: number[] = [];
 let i = 0;
 while (i < 10) decodeLookup[0x30 + i] = i++;
 while (i < 16) decodeLookup[0x41 - 10 + i] = decodeLookup[0x61 - 10 + i] = i++;
+
+// Unique sequence for the current process (initialized on first use)
+let PROCESS_UNIQUE: Uint8Array | null = null;
 
 /** @public */
 export interface ObjectIdLike {
@@ -175,6 +175,11 @@ export class ObjectId {
 
     // 4-byte timestamp
     buffer.writeUInt32BE(time, 0);
+
+    // set PROCESS_UNIQUE if yet not initialized
+    if (PROCESS_UNIQUE === null) {
+      PROCESS_UNIQUE = randomBytes(5);
+    }
 
     // 5-byte process unique
     buffer[4] = PROCESS_UNIQUE[0];

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -5,18 +5,6 @@ import { deprecate, isUint8Array, randomBytes } from './parser/utils';
 // Regular expression that checks for hex value
 const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
 
-// Precomputed hex table enables speedy hex string conversion
-const hexTable: string[] = [];
-for (let i = 0; i < 256; i++) {
-  hexTable[i] = (i <= 15 ? '0' : '') + i.toString(16);
-}
-
-// Lookup tables
-const decodeLookup: number[] = [];
-let i = 0;
-while (i < 10) decodeLookup[0x30 + i] = i++;
-while (i < 16) decodeLookup[0x41 - 10 + i] = decodeLookup[0x61 - 10 + i] = i++;
-
 // Unique sequence for the current process (initialized on first use)
 let PROCESS_UNIQUE: Uint8Array | null = null;
 


### PR DESCRIPTION
## Description

This PR changes `PROCESS_UNIQUE` in the `ObjectId` class to be lazy loaded. The main reason is allow for the `randomBytes` fallback-warning to only trigger if/when utilized.

I also took the liberty to remove som unused variables.
