### PR TITLE
test: bson corpus spec runner calling wrong fn

### DIFF
--- a/test/node/bson_corpus_tests.js
+++ b/test/node/bson_corpus_tests.js
@@ -2,7 +2,6 @@
 
 const Buffer = require('buffer').Buffer;
 const BSON = require('../register-bson');
-const Decimal128 = BSON.Decimal128;
 const EJSON = BSON.EJSON;
 
 const deserializeOptions = {

--- a/test/node/bson_corpus_tests.js
+++ b/test/node/bson_corpus_tests.js
@@ -192,7 +192,7 @@ describe('BSON Corpus', function () {
         describe('parseErrors', function () {
           scenario.parseErrors.forEach(p => {
             it(p.description, function () {
-              expect(() => Decimal128.fromString(scenario.string)).to.throw();
+              expect(() => jsonToNative(scenario.string)).to.throw();
             });
           });
         });


### PR DESCRIPTION
I ran across this one-liner when looking into `Decimal128` usages. (Of course they all were passing since `Decimal.128.fromString` would never be able to deserialize the EJSON, so we now use the EJSON parse helper function, which passes, but aren't false positives)

NODE-3277