### PR TITLE
chore(test): add timeout to older versions test

### DIFF
--- a/test/bson_older_versions_tests.js
+++ b/test/bson_older_versions_tests.js
@@ -42,6 +42,7 @@ function downloadZip(version, done) {
 describe('Current version', function () {
   OLD_VERSIONS.forEach(version => {
     before(function (done) {
+      this.timeout(30000); // Downloading may take a few seconds.
       if (Number(process.version.split('.')[0].substring(1)) < 8) {
         // WHATWG fetch doesn't download correctly prior to node 8
         // but we should be safe by testing on node 8 +


### PR DESCRIPTION

## Description

This sometimes flakes out for me locally because it takes
slightly longer than the mocha default of 2 seconds to download
the legacy bson zip.

