### PR TITLE
fix(NODE-3390): serialize non-finite doubles correctly in EJSON

### DIFF
--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -213,7 +213,7 @@ function serializeValue(value: any, options: EJSONSerializeOptions): any {
       : { $date: { $numberLong: value.getTime().toString() } };
   }
 
-  if (typeof value === 'number' && !options.relaxed) {
+  if (typeof value === 'number' && (!options.relaxed || !isFinite(value))) {
     // it's an integer
     if (Math.floor(value) === value) {
       const int32Range = value >= BSON_INT32_MIN && value <= BSON_INT32_MAX,

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -168,6 +168,15 @@ describe('Extended JSON', function () {
     expect(serialized).to.equal('42');
   });
 
+  it('should correctly serialize non-finite numbers', function () {
+    const numbers = { neginf: -Infinity, posinf: Infinity, nan: NaN };
+    const serialized = EJSON.stringify(numbers);
+    expect(serialized).to.equal(
+      '{"neginf":{"$numberDouble":"-Infinity"},"posinf":{"$numberDouble":"Infinity"},"nan":{"$numberDouble":"NaN"}}'
+    );
+    expect(EJSON.parse(serialized)).to.deep.equal(numbers);
+  });
+
   it('should correctly parse null values', function () {
     expect(EJSON.parse('null')).to.be.null;
     expect(EJSON.parse('[null]')[0]).to.be.null;


### PR DESCRIPTION
## Description

In relaxed mode, non-finite doubles are supposed to be serialized
the same way as in non-relaxed/canonical mode.
