### PR TITLE
feat(NODE-3504): add unambiguous `Timestamp()` constructor overload

### DIFF
--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -2120,8 +2120,8 @@ describe('BSON', function () {
      * @ignore
      */
     it('Timestamp', function () {
-      const timestamp = new Timestamp(1, 100);
-      expect(inspect(timestamp)).to.equal('new Timestamp(1, 100)');
+      const timestamp = new Timestamp({ t: 100, i: 1 });
+      expect(inspect(timestamp)).to.equal('new Timestamp({ t: 100, i: 1 })');
     });
   });
 });

--- a/test/node/timestamp_tests.js
+++ b/test/node/timestamp_tests.js
@@ -17,7 +17,8 @@ describe('Timestamp', function () {
       new BSON.Timestamp(new BSON.Long(0xffffffff, 0xfffffffff, false)),
       new BSON.Timestamp(new BSON.Long(0xffffffff, 0xfffffffff, true)),
       new BSON.Timestamp({ t: 0xffffffff, i: 0xfffffffff }),
-      new BSON.Timestamp({ t: -1, i: -1 })
+      new BSON.Timestamp({ t: -1, i: -1 }),
+      new BSON.Timestamp({ t: new BSON.Int32(0xffffffff), i: new BSON.Int32(0xffffffff) })
     ].forEach(timestamp => {
       expect(timestamp).to.have.property('unsigned', true);
     });
@@ -36,5 +37,11 @@ describe('Timestamp', function () {
     const input = { t: 89, i: 144 };
     const timestamp = new BSON.Timestamp(input);
     expect(timestamp.toExtendedJSON()).to.deep.equal({ $timestamp: input });
+  });
+
+  it('should accept a { t, i } object as constructor input and coerce to integer', function () {
+    const input = { t: new BSON.Int32(89), i: new BSON.Int32(144) };
+    const timestamp = new BSON.Timestamp(input);
+    expect(timestamp.toExtendedJSON()).to.deep.equal({ $timestamp: { t: 89, i: 144 } });
   });
 });

--- a/test/node/timestamp_tests.js
+++ b/test/node/timestamp_tests.js
@@ -15,7 +15,9 @@ describe('Timestamp', function () {
       new BSON.Timestamp(-1, -1),
       new BSON.Timestamp(new BSON.Timestamp(0xffffffff, 0xffffffff)),
       new BSON.Timestamp(new BSON.Long(0xffffffff, 0xfffffffff, false)),
-      new BSON.Timestamp(new BSON.Long(0xffffffff, 0xfffffffff, true))
+      new BSON.Timestamp(new BSON.Long(0xffffffff, 0xfffffffff, true)),
+      new BSON.Timestamp({ t: 0xffffffff, i: 0xfffffffff }),
+      new BSON.Timestamp({ t: -1, i: -1 })
     ].forEach(timestamp => {
       expect(timestamp).to.have.property('unsigned', true);
     });
@@ -28,5 +30,11 @@ describe('Timestamp', function () {
     expect(timestamp.toExtendedJSON()).to.deep.equal({
       $timestamp: { t: 4294967295, i: 4294967295 }
     });
+  });
+
+  it('should accept a { t, i } object as constructor input', function () {
+    const input = { t: 89, i: 144 };
+    const timestamp = new BSON.Timestamp(input);
+    expect(timestamp.toExtendedJSON()).to.deep.equal({ $timestamp: input });
   });
 });


### PR DESCRIPTION
## Description

Add a `Timestamp({ t: <number>, i: <number> })` overload,
and mark the `Timestamp(low, high)` overload as deprecated.
