### PR TITLE
fix(NODE-3451): fix performance regression from v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "types": "bson.d.ts",
   "version": "4.4.1",
-  "author": { 
-    "name": "The MongoDB NodeJS Team", 
+  "author": {
+    "name": "The MongoDB NodeJS Team",
     "email": "dbx-node@mongodb.com"
   },
   "license": "Apache-2.0",

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -216,7 +216,7 @@ export function deserialize(
   buffer: Buffer | ArrayBufferView | ArrayBuffer,
   options: DeserializeOptions = {}
 ): Document {
-  return internalDeserialize(ensureBuffer(buffer), options);
+  return internalDeserialize(buffer instanceof Buffer ? buffer : ensureBuffer(buffer), options);
 }
 
 /** @public */

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -156,7 +156,7 @@ function deserializeObject(
     // If are at the end of the buffer there is a problem with the document
     if (i >= buffer.byteLength) throw new Error('Bad BSON Document: illegal CString');
     const name = isArray ? arrayIndex++ : buffer.toString('utf8', index, i);
-    if (isPossibleDBRef !== false && (name as string).startsWith('$')) {
+    if (isPossibleDBRef !== false && (name as string)[0] === '$') {
       isPossibleDBRef = allowedDBRefKeys.test(name as string);
     }
     let value;

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -93,6 +93,8 @@ export function deserialize(
   return deserializeObject(buffer, index, options, isArray);
 }
 
+const allowedDBRefKeys = /^\$ref$|^\$id$|^\$db$/;
+
 function deserializeObject(
   buffer: Buffer,
   index: number,
@@ -134,6 +136,8 @@ function deserializeObject(
   let arrayIndex = 0;
   const done = false;
 
+  let isPossibleDBRef = isArray ? false : null;
+
   // While we have more left data left keep parsing
   while (!done) {
     // Read the type
@@ -152,6 +156,9 @@ function deserializeObject(
     // If are at the end of the buffer there is a problem with the document
     if (i >= buffer.byteLength) throw new Error('Bad BSON Document: illegal CString');
     const name = isArray ? arrayIndex++ : buffer.toString('utf8', index, i);
+    if (isPossibleDBRef !== false && (name as string).startsWith('$')) {
+      isPossibleDBRef = allowedDBRefKeys.test(name as string);
+    }
     let value;
 
     index = i + 1;
@@ -625,15 +632,8 @@ function deserializeObject(
     throw new Error('corrupt object bson');
   }
 
-  // check if object's $ keys are those of a DBRef
-  const dollarKeys = Object.keys(object).filter(k => k.startsWith('$'));
-  let valid = true;
-  dollarKeys.forEach(k => {
-    if (['$ref', '$id', '$db'].indexOf(k) === -1) valid = false;
-  });
-
-  // if a $key not in "$ref", "$id", "$db", don't make a DBRef
-  if (!valid) return object;
+  // if we did not find "$ref", "$id", "$db", or found an extraneous $key, don't make a DBRef
+  if (!isPossibleDBRef) return object;
 
   if (isDBRefLike(object)) {
     const copy = Object.assign({}, object) as Partial<DBRefLike>;

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -176,11 +176,16 @@ function deserializeObject(
       )
         throw new Error('bad string length in bson');
 
-      if (!validateUtf8(buffer, index, index + stringSize - 1)) {
-        throw new Error('Invalid UTF-8 string in BSON document');
-      }
-
       value = buffer.toString('utf8', index, index + stringSize - 1);
+
+      for (let i = 0; i < value.length; i++) {
+        if (value.charCodeAt(i) === 0xfffd) {
+          if (!validateUtf8(buffer, index, index + stringSize - 1)) {
+            throw new Error('Invalid UTF-8 string in BSON document');
+          }
+          break;
+        }
+      }
 
       index = index + stringSize;
     } else if (elementType === constants.BSON_DATA_OID) {


### PR DESCRIPTION
## Description

NODE-3451 documents a performance regression in the node driver v4, which is actually due to a performance regression in js-bson v4 deserialization method (compared to v1).

The notable culprits were:
- Mandatory rewrapping of all input types, even buffer, into a Buffer class via ensureBuffer
- Looping over all string bytes via validateUtf8
- Suboptimal loops over object keys to identify and handle DBRefs

**What changed?**
- The entry point `deserialize` method has been updated to check `instanceof Buffer` and skip the rewrapping in those instances; this is a temporary measure that only addresses performance for Node.js buffers
  - NOTE: `deserializeStream` was left untouched for scope reasons
- The `deserializeObject` method was updated to check for the presence of potential DBRef keys as it goes, removing the negative performance impact for any objects that do not contain any DBRef keys; there is some further optimization that could be done to eliminate the `isDBRefLike` check altogether, but since we expect these to be pretty rare, it didn't seem worth optimizing that specific edge case
- The `validateUtf8` method was updated to only run if the `\uFFFD` character is present: technically, this makes the performance worse for strings that do contain that special character, however, for all other strings, the loop over the resulting string with `charCodeAt` is faster; unfortunately there is not much else that can be done to optimize string deserialization without losing the validation (short of doing our own decoding)
  - NOTE: the `validateUtf8` call in DBPOINTER type was left untouched for scope reasons

After these changes, there may still be a residual 5% performance degradation for the typical use case relative to v1 which can be attributed to the remaining buffer and string validation.