### PR TITLE
fix(NODE-3021): fix a long standing bug in Decimal128.fromString()

### DIFF
--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -304,7 +304,7 @@ export class Decimal128 {
       lastDigit = nDigitsStored - 1;
       significantDigits = nDigits;
       if (significantDigits !== 1) {
-        while (representation[firstNonZero + significantDigits - 1] === '0') {
+        while (digits[firstNonZero + significantDigits - 1] === 0) {
           significantDigits = significantDigits - 1;
         }
       }

--- a/test/node/decimal128_tests.js
+++ b/test/node/decimal128_tests.js
@@ -1210,6 +1210,8 @@ describe('Decimal128', function () {
     expect(new Decimal128('00').toString()).to.equal('0');
     expect(new Decimal128('0.5').toString()).to.equal('0.5');
     expect(new Decimal128('-0.5').toString()).to.equal('-0.5');
+    expect(new Decimal128('-0.0097').toString()).to.equal('-0.0097');
+    expect(new Decimal128('-0.0011').toString()).to.equal('-0.0011');
     expect(new Decimal128('-1e400').toString()).to.equal('-1E+400');
     done();
   });

--- a/test/node/decimal128_tests.js
+++ b/test/node/decimal128_tests.js
@@ -1212,6 +1212,9 @@ describe('Decimal128', function () {
     expect(new Decimal128('-0.5').toString()).to.equal('-0.5');
     expect(new Decimal128('-0.0097').toString()).to.equal('-0.0097');
     expect(new Decimal128('-0.0011').toString()).to.equal('-0.0011');
+    expect(new Decimal128('-0.00110').toString()).to.equal('-0.00110');
+    expect(new Decimal128('0.0011').toString()).to.equal('0.0011');
+    expect(new Decimal128('0.00110').toString()).to.equal('0.00110');
     expect(new Decimal128('-1e400').toString()).to.equal('-1E+400');
     done();
   });


### PR DESCRIPTION
## Description

Fix a long standing bug in `Decimal128.fromString()`

  - https://github.com/mongodb/js-bson/issues/334
  - https://jira.mongodb.org/browse/NODE-3021

**What changed?**

The `representation` string was wrongly used to find the significant digits. The `digits` array should be used instead.

Note that the v2.0 and v3.0 branches also have this bug.