### PR TITLE
feat(NODE-1046): natively support UUID (de)serialization

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -15,7 +15,11 @@ import { ObjectId } from './objectid';
 import { BSONError, BSONTypeError } from './error';
 import { calculateObjectSize as internalCalculateObjectSize } from './parser/calculate_size';
 // Parts of the parser
-import { deserialize as internalDeserialize, DeserializeOptions } from './parser/deserializer';
+import {
+  deserialize as internalDeserialize,
+  DeserializeOptions,
+  DefaultDeserializeOptions
+} from './parser/deserializer';
 import { serializeInto as internalSerialize, SerializeOptions } from './parser/serializer';
 import { BSONRegExp } from './regexp';
 import { BSONSymbol } from './symbol';
@@ -77,7 +81,7 @@ export {
   TimestampOverrides
 } from './timestamp';
 export { UUIDExtended } from './uuid';
-export { SerializeOptions, DeserializeOptions };
+export { SerializeOptions, DeserializeOptions, DefaultDeserializeOptions };
 export {
   Code,
   Map,

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -841,6 +841,8 @@ export function serializeInto(
         index = serializeInt32(buffer, key, value, index, true);
       } else if (value['_bsontype'] === 'MinKey' || value['_bsontype'] === 'MaxKey') {
         index = serializeMinMax(buffer, key, value, index, true);
+      } else if (value['_bsontype'] === 'UUID') {
+        index = serializeBinary(buffer, key, value.toBinary(), index);
       } else if (typeof value['_bsontype'] !== 'undefined') {
         throw new BSONTypeError('Unrecognized or invalid _bsontype: ' + value['_bsontype']);
       }
@@ -942,6 +944,8 @@ export function serializeInto(
         index = serializeInt32(buffer, key, value, index);
       } else if (value['_bsontype'] === 'MinKey' || value['_bsontype'] === 'MaxKey') {
         index = serializeMinMax(buffer, key, value, index);
+      } else if (value['_bsontype'] === 'UUID') {
+        index = serializeBinary(buffer, key, value.toBinary(), index);
       } else if (typeof value['_bsontype'] !== 'undefined') {
         throw new BSONTypeError('Unrecognized or invalid _bsontype: ' + value['_bsontype']);
       }
@@ -1048,6 +1052,8 @@ export function serializeInto(
         index = serializeInt32(buffer, key, value, index);
       } else if (value['_bsontype'] === 'MinKey' || value['_bsontype'] === 'MaxKey') {
         index = serializeMinMax(buffer, key, value, index);
+      } else if (value['_bsontype'] === 'UUID') {
+        index = serializeBinary(buffer, key, value.toBinary(), index);
       } else if (typeof value['_bsontype'] !== 'undefined') {
         throw new BSONTypeError('Unrecognized or invalid _bsontype: ' + value['_bsontype']);
       }


### PR DESCRIPTION
This introduces a global `DefaultDeserializeOptions.convertUUIDs` and also extends the existing `DeserializeOptions` with a new `convertUUIDs` flag. Setting the flag will simply deserialize `Binary` values with subtype `SUBTYPE_UUID` as actual `UUID` instances.

It's great that we have the `UUID` type, but I really want to avoid having to tediously map these values/fields back-and-fort. This is bound to end up in subtle bugs sooner or later. As a bonus, `UUID` also features a `toJSON` eliminating mapping altogether when returning data as JSON.

In case you're using Typescript, you can define fields as `UUID` and it "just works":

```
export interface SomeDocument {
...
externalId: UUID;
...
}
```

I tried to get some feedback via https://github.com/mongodb/js-bson/issues/234, but thought I might as well open a PR 🙂.
