### PR TITLE
fix(NODE-3662): error checking to make sure that ObjectId results in object with correct properties

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -62,7 +62,9 @@ export class ObjectId {
           try {
             this[kId] = ensureBuffer(id.id);
           } catch {
-            throw new BSONTypeError('Argument passed in must have an id that is of type string or Buffer');
+            throw new BSONTypeError(
+              'Argument passed in must have an id that is of type string or Buffer'
+            );
           }
         }
       } else if (id == null || typeof id === 'number') {
@@ -85,9 +87,7 @@ export class ObjectId {
           );
         }
       } else {
-        throw new TypeError(
-          'Argument passed in does not match the accepted types'
-        );
+        throw new BSONTypeError('Argument passed in does not match the accepted types');
       }
       // If we are caching the hex string
       if (ObjectId.cacheHexString) {

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -31,7 +31,7 @@ export class ObjectId {
   _bsontype!: 'ObjectId';
 
   /** @internal */
-  static index = ~~(Math.random() * 0xffffff);
+  static index = Math.floor(Math.random() * 0xffffff);
 
   static cacheHexString: boolean;
 
@@ -48,6 +48,7 @@ export class ObjectId {
   constructor(inputId?: string | Buffer | number | ObjectIdLike | ObjectId) {
     if (!(this instanceof ObjectId)) return new ObjectId(inputId);
 
+    // workingId is set based on type of input and whether valid id exists for the input
     let workingId;
     if (typeof inputId === 'object' && inputId && 'id' in inputId) {
       if (typeof inputId.id !== 'string' && !ArrayBuffer.isView(inputId.id)) {
@@ -63,7 +64,8 @@ export class ObjectId {
     } else {
       workingId = inputId;
     }
-    // the following checks use workingId to construct an ObjectId
+
+    // the following cases use workingId to construct an ObjectId
     if (workingId == null || typeof workingId === 'number') {
       // The most common use case (blank id, new objectId instance)
       // Generate a new id
@@ -152,7 +154,7 @@ export class ObjectId {
    */
   static generate(time?: number): Buffer {
     if ('number' !== typeof time) {
-      time = ~~(Date.now() / 1000);
+      time = Math.floor(Date.now() / 1000);
     }
 
     const inc = ObjectId.getInc();

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -43,44 +43,44 @@ export class ObjectId {
   /**
    * Create an ObjectId type
    *
-   * @param id - Can be a 24 character hex string, 12 byte binary Buffer, or a number.
+   * @param inputId - Can be a 24 character hex string, 12 byte binary Buffer, or a number.
    */
-  constructor(id?: string | Buffer | number | ObjectIdLike | ObjectId) {
-    if (!(this instanceof ObjectId)) return new ObjectId(id);
+  constructor(inputId?: string | Buffer | number | ObjectIdLike | ObjectId) {
+    if (!(this instanceof ObjectId)) return new ObjectId(inputId);
 
     // Duck-typing to support ObjectId from different npm packages
-    if (id instanceof ObjectId) {
-      this[kId] = id.id;
-      this.__id = id.__id;
+    if (inputId instanceof ObjectId) {
+      this[kId] = inputId.id;
+      this.__id = inputId.__id;
     } else {
-      if (typeof id === 'object' && id && 'id' in id) {
-        if ('toHexString' in id && typeof id.toHexString === 'function') {
-          this[kId] = Buffer.from(id.toHexString(), 'hex');
-        } else if (typeof id.id === 'string') {
-          this[kId] = Buffer.from(id.id);
+      if (typeof inputId === 'object' && inputId && 'id' in inputId) {
+        if ('toHexString' in inputId && typeof inputId.toHexString === 'function') {
+          this[kId] = Buffer.from(inputId.toHexString(), 'hex');
+        } else if (typeof inputId.id === 'string') {
+          this[kId] = Buffer.from(inputId.id);
         } else {
           try {
-            this[kId] = ensureBuffer(id.id);
+            this[kId] = ensureBuffer(inputId.id);
           } catch {
             throw new BSONTypeError(
               'Argument passed in must have an id that is of type string or Buffer'
             );
           }
         }
-      } else if (id == null || typeof id === 'number') {
+      } else if (inputId == null || typeof inputId === 'number') {
         // The most common use case (blank id, new objectId instance)
         // Generate a new id
-        this[kId] = ObjectId.generate(typeof id === 'number' ? id : undefined);
-      } else if (ArrayBuffer.isView(id) && id.byteLength === 12) {
-        this[kId] = ensureBuffer(id);
-      } else if (typeof id === 'string') {
-        if (id.length === 12) {
-          const bytes = Buffer.from(id);
+        this[kId] = ObjectId.generate(typeof inputId === 'number' ? inputId : undefined);
+      } else if (ArrayBuffer.isView(inputId) && inputId.byteLength === 12) {
+        this[kId] = ensureBuffer(inputId);
+      } else if (typeof inputId === 'string') {
+        if (inputId.length === 12) {
+          const bytes = Buffer.from(inputId);
           if (bytes.byteLength === 12) {
             this[kId] = bytes;
           }
-        } else if (id.length === 24 && checkForHexRegExp.test(id)) {
-          this[kId] = Buffer.from(id, 'hex');
+        } else if (inputId.length === 24 && checkForHexRegExp.test(inputId)) {
+          this[kId] = Buffer.from(inputId, 'hex');
         } else {
           throw new BSONTypeError(
             'Argument passed in must be a Buffer or string of 12 bytes or a string of 24 hex characters'

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -56,8 +56,14 @@ export class ObjectId {
       if (typeof id === 'object' && id && 'id' in id) {
         if ('toHexString' in id && typeof id.toHexString === 'function') {
           this[kId] = Buffer.from(id.toHexString(), 'hex');
+        } else if (typeof id.id === 'string') {
+          this[kId] = Buffer.from(id.id);
         } else {
-          this[kId] = typeof id.id === 'string' ? Buffer.from(id.id) : id.id;
+          try {
+            this[kId] = ensureBuffer(id.id);
+          } catch {
+            throw new BSONTypeError('Argument passed in must be a Buffer or string of 12 bytes or a string of 24 hex characters');
+          }
         }
       } else if (id == null || typeof id === 'number') {
         // The most common use case (blank id, new objectId instance)

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -63,6 +63,7 @@ export class ObjectId {
     } else {
       workingId = inputId;
     }
+    // the following checks use workingId to construct an ObjectId
     if (workingId == null || typeof workingId === 'number') {
       // The most common use case (blank id, new objectId instance)
       // Generate a new id

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -77,6 +77,8 @@ export class ObjectId {
         const bytes = Buffer.from(workingId);
         if (bytes.byteLength === 12) {
           this[kId] = bytes;
+        } else {
+          throw new BSONTypeError('Argument passed in must be a string of 12 bytes');
         }
       } else if (workingId.length === 24 && checkForHexRegExp.test(workingId)) {
         this[kId] = Buffer.from(workingId, 'hex');

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -62,7 +62,7 @@ export class ObjectId {
           try {
             this[kId] = ensureBuffer(id.id);
           } catch {
-            throw new BSONTypeError('Argument passed in must be a Buffer or string of 12 bytes or a string of 24 hex characters');
+            throw new BSONTypeError('Argument passed in must have an id that is of type string or Buffer');
           }
         }
       } else if (id == null || typeof id === 'number') {

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -57,9 +57,7 @@ export class ObjectId {
         if ('toHexString' in id && typeof id.toHexString === 'function') {
           this[kId] = Buffer.from(id.toHexString(), 'hex');
         } else {
-          throw new TypeError(
-            'Object passed in does not have toHexString() function'
-          );
+          this[kId] = typeof id.id === 'string' ? Buffer.from(id.id) : id.id;
         }
       } else if (id == null || typeof id === 'number') {
         // The most common use case (blank id, new objectId instance)

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -30,12 +30,12 @@ describe('ObjectId', function () {
   });
 
   const invalidInputs = [
-    {input: [], description: 'empty array'},
-    {input: ['abcdefŽhijkl'], description: 'nonempty array'},
-    {input: {}, description: 'empty object'}
-  ]
+    { input: [], description: 'empty array' },
+    { input: ['abcdefŽhijkl'], description: 'nonempty array' },
+    { input: {}, description: 'empty object' }
+  ];
 
-  for (const {input, description} of invalidInputs) {
+  for (const { input, description } of invalidInputs) {
     it(`should throw error if ${description} is passed in`, function () {
       expect(() => new ObjectId(input)).to.throw(TypeError);
     });
@@ -164,13 +164,13 @@ describe('ObjectId', function () {
   });
 
   const numericIO = [
-    {input: 42, output: 42},
-    {input: 0x2a, output: 0x2a},
-    {input: 4.2, output: 4},
-    {input: NaN, output: 0}
-  ]
+    { input: 42, output: 42 },
+    { input: 0x2a, output: 0x2a },
+    { input: 4.2, output: 4 },
+    { input: NaN, output: 0 }
+  ];
 
-  for (const {input, output} of numericIO) {
+  for (const { input, output } of numericIO) {
     it(`should correctly create ObjectId from ${input} and result in ${output}`, function () {
       const objId = new ObjectId(input);
       expect(objId).to.have.property('id');

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -27,7 +27,7 @@ describe.only('ObjectId', function () {
 
   it('should correctly create ObjectId from ObjectId', function () {
     var tmp = new ObjectId();
-    expect(() => new ObjectId(tmp).toHexString()).to.not.throw();
+    expect(() => new ObjectId(tmp)).to.not.throw();
   });
 
   it('should throw error if empty array is passed in', function () {
@@ -53,47 +53,75 @@ describe.only('ObjectId', function () {
     expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
   });
 
-  it('should correctly create ObjectId from object with Buffer or string id', function () {
-    var objectStringId = {
+  it('should correctly create ObjectId from object with valid string id', function () {
+    var objectValidStringId1 = {
       id: 'aaaaaaaaaaaaaaaaaaaaaaaa'
     };
-    var objectBufferId = {
-      id: Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex')
+    var objectValidStringId2 = {
+      id: 'abcdefghijkl'
     };
-    var objectBufferFromArray = {
-      id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
-    };
-
-    expect(() => new ObjectId(objectStringId).toHexString()).to.not.throw(TypeError);
-    expect(() => new ObjectId(objectBufferId).toHexString()).to.not.throw(TypeError);
-    expect(() => new ObjectId(objectBufferFromArray).toHexString()).to.not.throw(TypeError);
+    var buf1 = Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaa', 'hex');
+    var buf2 = Buffer.from('abcdefghijkl', 'hex');
+    expect(() => new ObjectId(objectValidStringId1).toHexString()).to.not.throw(TypeError);
+    expect(Buffer.from(new ObjectId(objectValidStringId1).id).equals(buf1));
+    expect(() => new ObjectId(objectValidStringId2).toHexString()).to.not.throw(TypeError);
+    expect(Buffer.from(new ObjectId(objectValidStringId2).id).equals(buf2));
   });
 
-  it('should correctly create ObjectId from object with Buffer or string id and override toHexString', function () {
+  it('should correctly create ObjectId from object with valid string id and toHexString method', function () {
     function newToHexString() {
       return 'BBBBBBBBBBBBBBBBBBBBBBBB';
     }
     var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
-    var objectStringId = {
+    var objectValidStringId1 = {
       id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
       toHexString: newToHexString
     };
+    var objectValidStringId2 = {
+      id: 'abcdefghijkl',
+      toHexString: newToHexString
+    };
+    expect(() => new ObjectId(objectValidStringId1).toHexString()).to.not.throw(TypeError);
+    expect(Buffer.from(new ObjectId(objectValidStringId1).id).equals(buf));
+    expect(() => new ObjectId(objectValidStringId2).toHexString()).to.not.throw(TypeError);
+    expect(Buffer.from(new ObjectId(objectValidStringId2).id).equals(buf));
+  });
+
+  it('should correctly create ObjectId from object with valid Buffer id', function () {
+    var validBuffer1 = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex');
+    var validBuffer2 = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     var objectBufferId = {
-      id: Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex'),
+      id: validBuffer1
+    };
+    var objectBufferFromArray = {
+      id: validBuffer2
+    };
+    expect(() => new ObjectId(objectBufferId).toHexString()).to.not.throw(TypeError);
+    expect(Buffer.from(new ObjectId(objectBufferId).id).equals(validBuffer1));
+    expect(() => new ObjectId(objectBufferFromArray).toHexString()).to.not.throw(TypeError);
+    expect(Buffer.from(new ObjectId(objectBufferId).id).equals(validBuffer2));
+  });
+
+  it('should correctly create ObjectId from object with valid Buffer id and toHexString method', function () {
+    var validBuffer1 = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex');
+    var validBuffer2 = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    var bufferToHex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    function newToHexString() {
+      return 'BBBBBBBBBBBBBBBBBBBBBBBB';
+    }
+    var objectBufferId = {
+      id: validBuffer1,
       toHexString: newToHexString
     };
     var objectBufferFromArray = {
-      id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+      id: validBuffer2,
       toHexString: newToHexString
     };
-    expect(() => new ObjectId(objectStringId).toHexString()).to.not.throw(TypeError);
-    expect(Buffer.from(new ObjectId(objectStringId).id).equals(buf));
-
     expect(() => new ObjectId(objectBufferId).toHexString()).to.not.throw(TypeError);
-    expect(Buffer.from(new ObjectId(objectBufferId).id).equals(buf));
+    expect(Buffer.from(new ObjectId(objectBufferId).id).equals(bufferToHex));
 
     expect(() => new ObjectId(objectBufferFromArray).toHexString()).to.not.throw(TypeError);
-    expect(Buffer.from(new ObjectId(objectBufferFromArray).id).equals(buf));
+    expect(Buffer.from(new ObjectId(objectBufferFromArray).id).equals(bufferToHex));
   });
 
   it('should throw error if object with non-Buffer non-string id is passed in', function () {
@@ -103,7 +131,6 @@ describe.only('ObjectId', function () {
     var objectNullId = {
       id: null
     };
-
     expect(() => new ObjectId(objectNumId)).to.throw(TypeError);
     expect(() => new ObjectId(objectNullId)).to.throw(TypeError);
   });
@@ -115,11 +142,37 @@ describe.only('ObjectId', function () {
     expect(() => new ObjectId(objectInvalidString)).to.throw(TypeError);
   });
 
+  it('should correctly create ObjectId from object with invalid string id and toHexString method', function () {
+    function newToHexString() {
+      return 'BBBBBBBBBBBBBBBBBBBBBBBB';
+    }
+    var objectInvalidString = {
+      id: 'FFFFFFFFFFFFFFFFFFFFFFFG',
+      toHexString: newToHexString
+    };
+    var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    expect(() => new ObjectId(objectInvalidString)).to.not.throw(TypeError);
+    expect(Buffer.from(new ObjectId(objectInvalidString).id).equals(buf));
+  });
+
   it('should throw an error if object with invalid Buffer id is passed in', function () {
     var objectInvalidBuffer = {
-      id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+      id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
     };
     expect(() => new ObjectId(objectInvalidBuffer)).to.throw(TypeError);
+  });
+
+  it('should correctly create ObjectId from object with invalid Buffer id and toHexString method', function () {
+    function newToHexString() {
+      return 'BBBBBBBBBBBBBBBBBBBBBBBB';
+    }
+    var objectInvalidBuffer = {
+      id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+      toHexString: newToHexString
+    };
+    var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    expect(() => new ObjectId(objectInvalidBuffer)).to.not.throw(TypeError);
+    expect(Buffer.from(new ObjectId(objectInvalidBuffer).id).equals(buf));
   });
 
   it('should correctly create ObjectId from object with objectIdLike properties', function () {
@@ -143,7 +196,8 @@ describe.only('ObjectId', function () {
 
   it('should throw error if non-12 byte non-24 hex string passed in', function () {
     expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFG')).to.throw();
-    expect(() => new ObjectId('thisismorethan12chars')).to.throw();
+    expect(() => new ObjectId('thisstringisdefinitelytoolong')).to.throw();
+    expect(() => new ObjectId('tooshort')).to.throw();
     expect(() => new ObjectId('101010')).to.throw();
     expect(() => new ObjectId('')).to.throw();
   });
@@ -181,7 +235,7 @@ describe.only('ObjectId', function () {
   /**
    * @ignore
    */
-  it('should correctly create ObjectId from Buffer', function (done) {
+  it('should correctly create ObjectId from valid Buffer', function (done) {
     if (!Buffer.from) return done();
     var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
     var b = new ObjectId(Buffer.from(a, 'hex'));

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -26,7 +26,7 @@ describe('ObjectId', function () {
 
   it('should correctly create ObjectId from ObjectId', function () {
     var tmp = new ObjectId();
-    expect(new ObjectId(tmp).id.equals(Buffer.from(tmp.id, 'hex')));
+    expect(new ObjectId(tmp).id).to.deep.equal(Buffer.from(tmp.id, 'hex'));
   });
 
   const invalidInputs = [
@@ -78,8 +78,8 @@ describe('ObjectId', function () {
       id: 'abcdefghijkl',
       toHexString: newToHexString
     };
-    expect(Buffer.from(new ObjectId(objectValidStringId1).id).equals(buf));
-    expect(Buffer.from(new ObjectId(objectValidStringId2).id).equals(buf));
+    expect(Buffer.from(new ObjectId(objectValidStringId1).id)).to.deep.equal(buf);
+    expect(Buffer.from(new ObjectId(objectValidStringId2).id)).to.deep.equal(buf);
   });
 
   it('should correctly create ObjectId from object with valid Buffer id', function () {
@@ -91,8 +91,8 @@ describe('ObjectId', function () {
     var objectBufferFromArray = {
       id: validBuffer2
     };
-    expect(Buffer.from(new ObjectId(objectBufferId).id).equals(validBuffer1));
-    expect(Buffer.from(new ObjectId(objectBufferFromArray).id).equals(validBuffer2));
+    expect(Buffer.from(new ObjectId(objectBufferId).id)).to.deep.equals(validBuffer1);
+    expect(Buffer.from(new ObjectId(objectBufferFromArray).id)).to.deep.equals(validBuffer2);
   });
 
   it('should correctly create ObjectId from object with valid Buffer id and toHexString method', function () {
@@ -110,8 +110,8 @@ describe('ObjectId', function () {
       id: validBuffer2,
       toHexString: newToHexString
     };
-    expect(Buffer.from(new ObjectId(objectBufferId).id).equals(bufferToHex));
-    expect(Buffer.from(new ObjectId(objectBufferFromArray).id).equals(bufferToHex));
+    expect(Buffer.from(new ObjectId(objectBufferId).id)).to.deep.equal(bufferToHex);
+    expect(Buffer.from(new ObjectId(objectBufferFromArray).id)).to.deep.equal(bufferToHex);
   });
 
   it('should throw error if object with non-Buffer non-string id is passed in', function () {
@@ -141,7 +141,7 @@ describe('ObjectId', function () {
       toHexString: newToHexString
     };
     var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
-    expect(Buffer.from(new ObjectId(objectInvalidString).id).equals(buf));
+    expect(Buffer.from(new ObjectId(objectInvalidString).id)).to.deep.equal(buf);
   });
 
   it('should throw an error if object with invalid Buffer id is passed in', function () {
@@ -160,7 +160,7 @@ describe('ObjectId', function () {
       toHexString: newToHexString
     };
     var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
-    expect(Buffer.from(new ObjectId(objectInvalidBuffer).id).equals(buf));
+    expect(Buffer.from(new ObjectId(objectInvalidBuffer).id)).to.deep.equal(buf);
   });
 
   const numericIO = [
@@ -207,7 +207,7 @@ describe('ObjectId', function () {
 
   it('should correctly create ObjectId from 12 byte sequence', function () {
     var a = '111111111111';
-    expect(Buffer.from(new ObjectId(a).id).equals(Buffer.from(a, 'latin1')));
+    expect(Buffer.from(new ObjectId(a).id)).to.deep.equal(Buffer.from(a, 'latin1'));
   });
 
   /**

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -110,8 +110,13 @@ describe('ObjectId', function () {
   it('should correctly create ObjectId from 12 byte or 24 hex string', function () {
     expect(() => new ObjectId('AAAAAAAAAAAAAAAAAAAAAAAA').toHexString()).to.not.throw();
     expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFF').toHexString()).to.not.throw();
-    expect(() => new ObjectId('111111111111').toHexString()).to.not.throw();
     expect(() => new ObjectId('abcdefghijkl').toHexString()).to.not.throw();
+  });
+
+  it('should correctly create ObjectId from 12 byte sequence', function () {
+    var a = '111111111111';
+    expect(() => new ObjectId(a).toHexString()).to.not.throw();
+    expect(Buffer.from(new ObjectId(a).id).equals(Buffer.from('111111111111', 'latin1')));
   });
 
   /**

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -7,11 +7,11 @@ const ObjectId = BSON.ObjectId;
 
 describe('ObjectId', function () {
   it('should correctly handle objectId timestamps', function (done) {
-    let a = ObjectId.createFromTime(1);
+    const a = ObjectId.createFromTime(1);
     expect(Buffer.from([0, 0, 0, 1])).to.deep.equal(a.id.slice(0, 4));
     expect(1000).to.equal(a.getTimestamp().getTime());
 
-    let b = new ObjectId();
+    const b = new ObjectId();
     b.generationTime = 1;
     expect(Buffer.from([0, 0, 0, 1])).to.deep.equal(b.id.slice(0, 4));
     expect(1).to.equal(b.generationTime);

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -27,7 +27,6 @@ describe('ObjectId', function () {
 
   it('should correctly create ObjectId from ObjectId', function () {
     var tmp = new ObjectId();
-    expect(() => new ObjectId(tmp)).to.not.throw();
     expect(() => new ObjectId(tmp).id.equals(Buffer.from(tmp, 'hex')));
   });
 
@@ -63,9 +62,7 @@ describe('ObjectId', function () {
     };
     var buf1 = Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaa', 'hex');
     var buf2 = Buffer.from('abcdefghijkl', 'hex');
-    expect(() => new ObjectId(objectValidStringId1).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectValidStringId1).id).equals(buf1));
-    expect(() => new ObjectId(objectValidStringId2).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectValidStringId2).id).equals(buf2));
   });
 
@@ -82,9 +79,7 @@ describe('ObjectId', function () {
       id: 'abcdefghijkl',
       toHexString: newToHexString
     };
-    expect(() => new ObjectId(objectValidStringId1).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectValidStringId1).id).equals(buf));
-    expect(() => new ObjectId(objectValidStringId2).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectValidStringId2).id).equals(buf));
   });
 
@@ -97,10 +92,8 @@ describe('ObjectId', function () {
     var objectBufferFromArray = {
       id: validBuffer2
     };
-    expect(() => new ObjectId(objectBufferId).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectBufferId).id).equals(validBuffer1));
-    expect(() => new ObjectId(objectBufferFromArray).toHexString()).to.not.throw(TypeError);
-    expect(Buffer.from(new ObjectId(objectBufferId).id).equals(validBuffer2));
+    expect(Buffer.from(new ObjectId(objectBufferFromArray).id).equals(validBuffer2));
   });
 
   it('should correctly create ObjectId from object with valid Buffer id and toHexString method', function () {
@@ -118,9 +111,7 @@ describe('ObjectId', function () {
       id: validBuffer2,
       toHexString: newToHexString
     };
-    expect(() => new ObjectId(objectBufferId).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectBufferId).id).equals(bufferToHex));
-    expect(() => new ObjectId(objectBufferFromArray).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectBufferFromArray).id).equals(bufferToHex));
   });
 
@@ -151,7 +142,6 @@ describe('ObjectId', function () {
       toHexString: newToHexString
     };
     var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
-    expect(() => new ObjectId(objectInvalidString)).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectInvalidString).id).equals(buf));
   });
 
@@ -171,7 +161,6 @@ describe('ObjectId', function () {
       toHexString: newToHexString
     };
     var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
-    expect(() => new ObjectId(objectInvalidBuffer)).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectInvalidBuffer).id).equals(buf));
   });
 
@@ -183,21 +172,16 @@ describe('ObjectId', function () {
         return tmp.toHexString();
       }
     };
-    expect(() => new ObjectId(objectIdLike).toHexString()).to.not.throw(TypeError);
     expect(() => new ObjectId(objectIdLike).id.equals(Buffer.from(tmp, 'hex')));
   });
 
   it('should correctly create ObjectId from number or null', function () {
-    expect(() => new ObjectId(42).toHexString()).to.not.throw();
-    expect(() => new ObjectId(42).id.equals(Buffer.from(42, 'hex')));
-    expect(() => new ObjectId(0x2a).toHexString()).to.not.throw();
-    expect(() => new ObjectId(0x2a).id.equals(Buffer.from(0x2a, 'hex')));
-    expect(() => new ObjectId(4.2).toHexString()).to.not.throw();
-    expect(() => new ObjectId(4.2).id.equals(Buffer.from(4, 'hex')));
-    expect(() => new ObjectId(NaN).toHexString()).to.not.throw();
-    expect(() => new ObjectId(NaN).id.equals(Buffer.from(NaN, 'hex')));
-    expect(() => new ObjectId(null).toHexString()).to.not.throw();
+    expect(new ObjectId(42).id.readUint32BE(0)).to.equal(42);
+    expect(new ObjectId(0x2a).id.readUint32BE(0)).to.equal(0x2a);
+    expect(new ObjectId(4.2).id.readUint32BE(0)).to.equal(4);
+    expect(new ObjectId(NaN).id.readUint32BE(0)).to.equal(0);
     expect(() => new ObjectId(null).id.equals(Buffer.from(null, 'hex')));
+    expect(() => new ObjectId(undefined).id.equals(Buffer.from(undefined, 'hex')));
   });
 
   it('should throw error if non-12 byte non-24 hex string passed in', function () {
@@ -212,17 +196,13 @@ describe('ObjectId', function () {
     var str1 = 'AAAAAAAAAAAAAAAAAAAAAAAA';
     var str2 = 'FFFFFFFFFFFFFFFFFFFFFFFF';
     var str3 = 'abcdefghijkl';
-    expect(() => new ObjectId(str1).toHexString()).to.not.throw();
     expect(() => new ObjectId(str1).id.equals(Buffer.from(str1, 'hex')));
-    expect(() => new ObjectId(str2).toHexString()).to.not.throw();
     expect(() => new ObjectId(str2).id.equals(Buffer.from(str2, 'hex')));
-    expect(() => new ObjectId(str3).toHexString()).to.not.throw();
     expect(() => new ObjectId(str3).id.equals(Buffer.from(str3, 'hex')));
   });
 
   it('should correctly create ObjectId from 12 byte sequence', function () {
     var a = '111111111111';
-    expect(() => new ObjectId(a).toHexString()).to.not.throw();
     expect(Buffer.from(new ObjectId(a).id).equals(Buffer.from(a, 'latin1')));
   });
 

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -5,7 +5,7 @@ const BSON = require('../register-bson');
 const util = require('util');
 const ObjectId = BSON.ObjectId;
 
-describe.only('ObjectId', function () {
+describe('ObjectId', function () {
   /**
    * @ignore
    */
@@ -28,6 +28,7 @@ describe.only('ObjectId', function () {
   it('should correctly create ObjectId from ObjectId', function () {
     var tmp = new ObjectId();
     expect(() => new ObjectId(tmp)).to.not.throw();
+    expect(() => new ObjectId(tmp).id.equals(Buffer.from(tmp, 'hex')));
   });
 
   it('should throw error if empty array is passed in', function () {
@@ -119,7 +120,6 @@ describe.only('ObjectId', function () {
     };
     expect(() => new ObjectId(objectBufferId).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectBufferId).id).equals(bufferToHex));
-
     expect(() => new ObjectId(objectBufferFromArray).toHexString()).to.not.throw(TypeError);
     expect(Buffer.from(new ObjectId(objectBufferFromArray).id).equals(bufferToHex));
   });
@@ -183,15 +183,21 @@ describe.only('ObjectId', function () {
         return tmp.toHexString();
       }
     };
-
     expect(() => new ObjectId(objectIdLike).toHexString()).to.not.throw(TypeError);
+    expect(() => new ObjectId(objectIdLike).id.equals(Buffer.from(tmp, 'hex')));
   });
 
   it('should correctly create ObjectId from number or null', function () {
     expect(() => new ObjectId(42).toHexString()).to.not.throw();
+    expect(() => new ObjectId(42).id.equals(Buffer.from(42, 'hex')));
     expect(() => new ObjectId(0x2a).toHexString()).to.not.throw();
+    expect(() => new ObjectId(0x2a).id.equals(Buffer.from(0x2a, 'hex')));
+    expect(() => new ObjectId(4.2).toHexString()).to.not.throw();
+    expect(() => new ObjectId(4.2).id.equals(Buffer.from(4, 'hex')));
     expect(() => new ObjectId(NaN).toHexString()).to.not.throw();
+    expect(() => new ObjectId(NaN).id.equals(Buffer.from(NaN, 'hex')));
     expect(() => new ObjectId(null).toHexString()).to.not.throw();
+    expect(() => new ObjectId(null).id.equals(Buffer.from(null, 'hex')));
   });
 
   it('should throw error if non-12 byte non-24 hex string passed in', function () {
@@ -203,15 +209,21 @@ describe.only('ObjectId', function () {
   });
 
   it('should correctly create ObjectId from 12 byte or 24 hex string', function () {
-    expect(() => new ObjectId('AAAAAAAAAAAAAAAAAAAAAAAA').toHexString()).to.not.throw();
-    expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFF').toHexString()).to.not.throw();
-    expect(() => new ObjectId('abcdefghijkl').toHexString()).to.not.throw();
+    var str1 = 'AAAAAAAAAAAAAAAAAAAAAAAA';
+    var str2 = 'FFFFFFFFFFFFFFFFFFFFFFFF';
+    var str3 = 'abcdefghijkl';
+    expect(() => new ObjectId(str1).toHexString()).to.not.throw();
+    expect(() => new ObjectId(str1).id.equals(Buffer.from(str1, 'hex')));
+    expect(() => new ObjectId(str2).toHexString()).to.not.throw();
+    expect(() => new ObjectId(str2).id.equals(Buffer.from(str2, 'hex')));
+    expect(() => new ObjectId(str3).toHexString()).to.not.throw();
+    expect(() => new ObjectId(str3).id.equals(Buffer.from(str3, 'hex')));
   });
 
   it('should correctly create ObjectId from 12 byte sequence', function () {
     var a = '111111111111';
     expect(() => new ObjectId(a).toHexString()).to.not.throw();
-    expect(Buffer.from(new ObjectId(a).id).equals(Buffer.from('111111111111', 'latin1')));
+    expect(Buffer.from(new ObjectId(a).id).equals(Buffer.from(a, 'latin1')));
   });
 
   /**
@@ -250,10 +262,9 @@ describe.only('ObjectId', function () {
     done();
   });
 
-  it('should throw an error if invalid Buffer passed in', function (done) {
+  it('should throw an error if invalid Buffer passed in', function () {
     var a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
     expect(() => new ObjectId(a)).to.throw(TypeError);
-    done();
   });
 
   /**

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -176,10 +176,10 @@ describe('ObjectId', function () {
   });
 
   it('should correctly create ObjectId from number or null', function () {
-    expect(new ObjectId(42).id.readUint32BE(0)).to.equal(42);
-    expect(new ObjectId(0x2a).id.readUint32BE(0)).to.equal(0x2a);
-    expect(new ObjectId(4.2).id.readUint32BE(0)).to.equal(4);
-    expect(new ObjectId(NaN).id.readUint32BE(0)).to.equal(0);
+    expect(() => new ObjectId(42).id.readUint32BE(0).equals(42));
+    expect(() => new ObjectId(0x2a).id.readUint32BE(0).equals(0x2a));
+    expect(() => new ObjectId(4.2).id.readUint32BE(0).equals(4));
+    expect(() => new ObjectId(NaN).id.readUint32BE(0).equals(0));
     expect(() => new ObjectId(null).id.equals(Buffer.from(null, 'hex')));
     expect(() => new ObjectId(undefined).id.equals(Buffer.from(undefined, 'hex')));
   });

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -27,7 +27,7 @@ describe('ObjectId', function () {
 
   it('should correctly create ObjectId from ObjectId', function () {
     var tmp = new ObjectId();
-    expect(() => new ObjectId(tmp)).to.not.throw();
+    expect(() => new ObjectId(tmp).toHexString()).to.not.throw();
   });
 
   it('should throw error if empty array is passed in', function () {
@@ -74,14 +74,14 @@ describe('ObjectId', function () {
       }
     };
 
-    expect(() => new ObjectId(objectIdLike)).to.not.throw(TypeError);
+    expect(() => new ObjectId(objectIdLike).toHexString()).to.not.throw(TypeError);
   });
 
   it('should correctly create ObjectId from number or null', function () {
-    expect(() => new ObjectId(42)).to.not.throw();
-    expect(() => new ObjectId(0x2a)).to.not.throw();
-    expect(() => new ObjectId(NaN)).to.not.throw();
-    expect(() => new ObjectId(null)).to.not.throw();
+    expect(() => new ObjectId(42).toHexString()).to.not.throw();
+    expect(() => new ObjectId(0x2a).toHexString()).to.not.throw();
+    expect(() => new ObjectId(NaN).toHexString()).to.not.throw();
+    expect(() => new ObjectId(null).toHexString()).to.not.throw();
   });
 
   it('should correctly create ObjectId with Buffer or string id', function () {
@@ -95,9 +95,9 @@ describe('ObjectId', function () {
       id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
     };
 
-    expect(() => new ObjectId(objectStringId)).to.not.throw(TypeError);
-    expect(() => new ObjectId(objectBufferId)).to.not.throw(TypeError);
-    expect(() => new ObjectId(objectBufferFromArray)).to.not.throw(TypeError);
+    expect(() => new ObjectId(objectStringId).toHexString()).to.not.throw(TypeError);
+    expect(() => new ObjectId(objectBufferId).toHexString()).to.not.throw(TypeError);
+    expect(() => new ObjectId(objectBufferFromArray).toHexString()).to.not.throw(TypeError);
   });
 
   it('should throw error if non-12 byte non-24 hex string passed in', function () {
@@ -108,10 +108,10 @@ describe('ObjectId', function () {
   });
 
   it('should correctly create ObjectId from 12 byte or 24 hex string', function () {
-    expect(() => new ObjectId('AAAAAAAAAAAAAAAAAAAAAAAA')).to.not.throw();
-    expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFF')).to.not.throw();
-    expect(() => new ObjectId('111111111111')).to.not.throw();
-    expect(() => new ObjectId('abcdefghijkl')).to.not.throw();
+    expect(() => new ObjectId('AAAAAAAAAAAAAAAAAAAAAAAA').toHexString()).to.not.throw();
+    expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFF').toHexString()).to.not.throw();
+    expect(() => new ObjectId('111111111111').toHexString()).to.not.throw();
+    expect(() => new ObjectId('abcdefghijkl').toHexString()).to.not.throw();
   });
 
   /**

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -1,21 +1,17 @@
 'use strict';
+
 const Buffer = require('buffer').Buffer;
 const BSON = require('../register-bson');
 const util = require('util');
 const ObjectId = BSON.ObjectId;
 
 describe('ObjectId', function () {
-  /**
-   * @ignore
-   */
-
   it('should correctly handle objectId timestamps', function (done) {
-    // var test_number = {id: ObjectI()};
-    var a = ObjectId.createFromTime(1);
+    let a = ObjectId.createFromTime(1);
     expect(Buffer.from([0, 0, 0, 1])).to.deep.equal(a.id.slice(0, 4));
     expect(1000).to.equal(a.getTimestamp().getTime());
 
-    var b = new ObjectId();
+    let b = new ObjectId();
     b.generationTime = 1;
     expect(Buffer.from([0, 0, 0, 1])).to.deep.equal(b.id.slice(0, 4));
     expect(1).to.equal(b.generationTime);
@@ -25,8 +21,8 @@ describe('ObjectId', function () {
   });
 
   it('should correctly create ObjectId from ObjectId', function () {
-    var tmp = new ObjectId();
-    expect(new ObjectId(tmp).id).to.deep.equal(Buffer.from(tmp.id, 'hex'));
+    const noArgObjID = new ObjectId();
+    expect(new ObjectId(noArgObjID).id).to.deep.equal(Buffer.from(noArgObjID.id, 'hex'));
   });
 
   const invalidInputs = [
@@ -42,10 +38,10 @@ describe('ObjectId', function () {
   }
 
   it('should throw error if object without an id property is passed in', function () {
-    var tmp = new ObjectId();
-    var objectIdLike = {
+    const noArgObjID = new ObjectId();
+    const objectIdLike = {
       toHexString: function () {
-        return tmp.toHexString();
+        return noArgObjID.toHexString();
       }
     };
 
@@ -53,72 +49,72 @@ describe('ObjectId', function () {
   });
 
   it('should correctly create ObjectId from object with valid string id', function () {
-    var objectValidStringId1 = {
+    const objectValidString24Hex = {
       id: 'aaaaaaaaaaaaaaaaaaaaaaaa'
     };
-    var objectValidStringId2 = {
+    const objectValidString12Bytes = {
       id: 'abcdefghijkl'
     };
-    var buf1 = Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaa', 'hex');
-    var buf2 = Buffer.from('abcdefghijkl', 'hex');
-    expect(Buffer.from(new ObjectId(objectValidStringId1).id).equals(buf1));
-    expect(Buffer.from(new ObjectId(objectValidStringId2).id).equals(buf2));
+    const buf24Hex = Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaa', 'hex');
+    const buf12Bytes = Buffer.from('abcdefghijkl');
+    expect(new ObjectId(objectValidString24Hex).id).to.deep.equal(buf24Hex);
+    expect(new ObjectId(objectValidString12Bytes).id).to.deep.equal(buf12Bytes);
   });
 
   it('should correctly create ObjectId from object with valid string id and toHexString method', function () {
-    function newToHexString() {
+    function new24HexToHexString() {
       return 'BBBBBBBBBBBBBBBBBBBBBBBB';
     }
-    var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
-    var objectValidStringId1 = {
+    const buf24hex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    const objectValidString24Hex = {
       id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
-      toHexString: newToHexString
+      toHexString: new24HexToHexString
     };
-    var objectValidStringId2 = {
+    const objectValidString12Bytes = {
       id: 'abcdefghijkl',
-      toHexString: newToHexString
+      toHexString: new24HexToHexString
     };
-    expect(Buffer.from(new ObjectId(objectValidStringId1).id)).to.deep.equal(buf);
-    expect(Buffer.from(new ObjectId(objectValidStringId2).id)).to.deep.equal(buf);
+    expect(new ObjectId(objectValidString24Hex).id).to.deep.equal(buf24hex);
+    expect(new ObjectId(objectValidString12Bytes).id).to.deep.equal(buf24hex);
   });
 
   it('should correctly create ObjectId from object with valid Buffer id', function () {
-    var validBuffer1 = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex');
-    var validBuffer2 = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-    var objectBufferId = {
-      id: validBuffer1
+    const validBuffer24Hex = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex');
+    const validBuffer12Array = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const objectBufferId = {
+      id: validBuffer24Hex
     };
-    var objectBufferFromArray = {
-      id: validBuffer2
+    const objectBufferFromArray = {
+      id: validBuffer12Array
     };
-    expect(Buffer.from(new ObjectId(objectBufferId).id)).to.deep.equals(validBuffer1);
-    expect(Buffer.from(new ObjectId(objectBufferFromArray).id)).to.deep.equals(validBuffer2);
+    expect(new ObjectId(objectBufferId).id).to.deep.equals(validBuffer24Hex);
+    expect(new ObjectId(objectBufferFromArray).id).to.deep.equals(validBuffer12Array);
   });
 
   it('should correctly create ObjectId from object with valid Buffer id and toHexString method', function () {
-    var validBuffer1 = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex');
-    var validBuffer2 = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-    var bufferToHex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    const validBuffer24Hex = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex');
+    const validBuffer12Array = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const bufferNew24Hex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
     function newToHexString() {
       return 'BBBBBBBBBBBBBBBBBBBBBBBB';
     }
-    var objectBufferId = {
-      id: validBuffer1,
+    const objectBufferHex = {
+      id: validBuffer24Hex,
       toHexString: newToHexString
     };
-    var objectBufferFromArray = {
-      id: validBuffer2,
+    const objectBufferArray = {
+      id: validBuffer12Array,
       toHexString: newToHexString
     };
-    expect(Buffer.from(new ObjectId(objectBufferId).id)).to.deep.equal(bufferToHex);
-    expect(Buffer.from(new ObjectId(objectBufferFromArray).id)).to.deep.equal(bufferToHex);
+    expect(new ObjectId(objectBufferHex).id).to.deep.equal(bufferNew24Hex);
+    expect(new ObjectId(objectBufferArray).id).to.deep.equal(bufferNew24Hex);
   });
 
   it('should throw error if object with non-Buffer non-string id is passed in', function () {
-    var objectNumId = {
+    const objectNumId = {
       id: 5
     };
-    var objectNullId = {
+    const objectNullId = {
       id: null
     };
     expect(() => new ObjectId(objectNumId)).to.throw(TypeError);
@@ -126,26 +122,26 @@ describe('ObjectId', function () {
   });
 
   it('should throw an error if object with invalid string id is passed in', function () {
-    var objectInvalidString = {
+    const objectInvalid24HexStr = {
       id: 'FFFFFFFFFFFFFFFFFFFFFFFG'
     };
-    expect(() => new ObjectId(objectInvalidString)).to.throw(TypeError);
+    expect(() => new ObjectId(objectInvalid24HexStr)).to.throw(TypeError);
   });
 
   it('should correctly create ObjectId from object with invalid string id and toHexString method', function () {
     function newToHexString() {
       return 'BBBBBBBBBBBBBBBBBBBBBBBB';
     }
-    var objectInvalidString = {
+    const objectInvalid24HexStr = {
       id: 'FFFFFFFFFFFFFFFFFFFFFFFG',
       toHexString: newToHexString
     };
-    var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
-    expect(Buffer.from(new ObjectId(objectInvalidString).id)).to.deep.equal(buf);
+    const bufferNew24Hex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    expect(new ObjectId(objectInvalid24HexStr).id).to.deep.equal(bufferNew24Hex);
   });
 
   it('should throw an error if object with invalid Buffer id is passed in', function () {
-    var objectInvalidBuffer = {
+    const objectInvalidBuffer = {
       id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
     };
     expect(() => new ObjectId(objectInvalidBuffer)).to.throw(TypeError);
@@ -155,19 +151,19 @@ describe('ObjectId', function () {
     function newToHexString() {
       return 'BBBBBBBBBBBBBBBBBBBBBBBB';
     }
-    var objectInvalidBuffer = {
+    const objectInvalidBuffer = {
       id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
       toHexString: newToHexString
     };
-    var buf = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
-    expect(Buffer.from(new ObjectId(objectInvalidBuffer).id)).to.deep.equal(buf);
+    const bufferNew24Hex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    expect(new ObjectId(objectInvalidBuffer).id).to.deep.equal(bufferNew24Hex);
   });
 
   const numericIO = [
-    { input: 42, output: 42 },
-    { input: 0x2a, output: 0x2a },
-    { input: 4.2, output: 4 },
-    { input: NaN, output: 0 }
+    { input: 42, output: 42, description: '42' },
+    { input: 0x2a, output: 0x2a, description: '0x2a' },
+    { input: 4.2, output: 4, description: '4.2' },
+    { input: NaN, output: 0, description: 'NaN' }
   ];
 
   for (const { input, output } of numericIO) {
@@ -196,27 +192,20 @@ describe('ObjectId', function () {
     expect(() => new ObjectId('')).to.throw(TypeError);
   });
 
-  it('should correctly create ObjectId from 12 byte or 24 hex string', function () {
-    var str1 = 'AAAAAAAAAAAAAAAAAAAAAAAA';
-    var str2 = 'FFFFFFFFFFFFFFFFFFFFFFFF';
-    var str3 = 'abcdefghijkl';
-    expect(new ObjectId(str1).id.equals(Buffer.from(str1, 'hex')));
-    expect(new ObjectId(str2).id.equals(Buffer.from(str2, 'hex')));
-    expect(new ObjectId(str3).id.equals(Buffer.from(str3, 'hex')));
+  it('should correctly create ObjectId from 24 hex string', function () {
+    const validStr24Hex = 'FFFFFFFFFFFFFFFFFFFFFFFF';
+    expect(new ObjectId(validStr24Hex).id).to.deep.equal(Buffer.from(validStr24Hex, 'hex'));
   });
 
   it('should correctly create ObjectId from 12 byte sequence', function () {
-    var a = '111111111111';
-    expect(Buffer.from(new ObjectId(a).id)).to.deep.equal(Buffer.from(a, 'latin1'));
+    const byteSequence12 = '111111111111';
+    expect(new ObjectId(byteSequence12).id).to.deep.equal(Buffer.from(byteSequence12, 'latin1'));
   });
 
-  /**
-   * @ignore
-   */
   it('should correctly create ObjectId from uppercase hexstring', function (done) {
-    var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
-    var b = new ObjectId(a);
-    var c = b.equals(a); // => false
+    let a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
+    let b = new ObjectId(a);
+    let c = b.equals(a); // => false
     expect(true).to.equal(c);
 
     a = 'aaaaaaaaaaaaaaaaaaaaaaaa';
@@ -228,14 +217,11 @@ describe('ObjectId', function () {
     done();
   });
 
-  /**
-   * @ignore
-   */
   it('should correctly create ObjectId from valid Buffer', function (done) {
     if (!Buffer.from) return done();
-    var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
-    var b = new ObjectId(Buffer.from(a, 'hex'));
-    var c = b.equals(a); // => false
+    let a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
+    let b = new ObjectId(Buffer.from(a, 'hex'));
+    let c = b.equals(a); // => false
     expect(true).to.equal(c);
 
     a = 'aaaaaaaaaaaaaaaaaaaaaaaa';
@@ -247,28 +233,22 @@ describe('ObjectId', function () {
   });
 
   it('should throw an error if invalid Buffer passed in', function () {
-    var a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    const a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
     expect(() => new ObjectId(a)).to.throw(TypeError);
   });
 
-  /**
-   * @ignore
-   */
   it('should correctly allow for node.js inspect to work with ObjectId', function (done) {
-    var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
-    var b = new ObjectId(a);
+    const a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
+    const b = new ObjectId(a);
     expect(util.inspect(b)).to.equal('new ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")');
 
     done();
   });
 
-  /**
-   * @ignore
-   */
   it('should isValid check input Buffer length', function (done) {
-    var buffTooShort = Buffer.from([]);
-    var buffTooLong = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-    var buff12Bytes = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const buffTooShort = Buffer.from([]);
+    const buffTooLong = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    const buff12Bytes = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
     expect(ObjectId.isValid(buffTooShort)).to.be.false;
     expect(ObjectId.isValid(buffTooLong)).to.be.false;
@@ -276,13 +256,21 @@ describe('ObjectId', function () {
     done();
   });
 
-  it('should throw if a 12-char string is passed in with character codes greater than 256', function () {
-    expect(() => new ObjectId('abcdefghijkl').toHexString()).to.not.throw();
-    expect(() => new ObjectId('abcdefŽhijkl').toHexString()).to.throw(TypeError);
+  it('should throw if a 12-char length but non-12 byte string is passed in', function () {
+    const characterCodesLargerThan256 = 'abcdefŽhijkl';
+    const length12Not12Bytes = '🐶🐶🐶🐶🐶🐶';
+    expect(() => new ObjectId(characterCodesLargerThan256).toHexString()).to.throw(
+      TypeError,
+      'Argument passed in must be a string of 12 bytes'
+    );
+    expect(() => new ObjectId(length12Not12Bytes).id).to.throw(
+      TypeError,
+      'Argument passed in must be a string of 12 bytes'
+    );
   });
 
   it('should correctly interpret timestamps beyond 2038', function () {
-    var farFuture = new Date('2040-01-01T00:00:00.000Z').getTime();
+    const farFuture = new Date('2040-01-01T00:00:00.000Z').getTime();
     expect(
       new BSON.ObjectId(BSON.ObjectId.generate(farFuture / 1000)).getTimestamp().getTime()
     ).to.equal(farFuture);

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -5,10 +5,11 @@ const BSON = require('../register-bson');
 const util = require('util');
 const ObjectId = BSON.ObjectId;
 
-describe('ObjectId', function () {
+describe.only('ObjectId', function () {
   /**
    * @ignore
    */
+ 
   it('should correctly handle objectId timestamps', function (done) {
     // var test_number = {id: ObjectI()};
     var a = ObjectId.createFromTime(1);
@@ -22,6 +23,45 @@ describe('ObjectId', function () {
     expect(1000).to.equal(b.getTimestamp().getTime());
 
     done();
+  });
+
+  it('should throw error if empty array is passed in', function () {
+    expect(() => new ObjectId([])).to.throw(TypeError);
+  });
+
+  it('should throw error if nonempty array is passed in', function () {
+    expect(() => new ObjectId(['abcdefŽhijkl'])).to.throw(TypeError);
+  });
+
+  it('should throw error if empty object is passed in', function () {
+    expect(() => new ObjectId({})).to.throw(TypeError);
+  });
+
+  it('should throw error if object without an id property is passed in', function () {
+    var tmp = new ObjectId();
+    var objectIdLike = {
+      toHexString: function () {
+        return tmp.toHexString();
+      }
+    };
+
+    expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
+  });
+
+  it('should throw error if object without toHexString function is passed in', function () {
+    var tmp = new ObjectId();
+    var objectIdLike = {
+      id: tmp.id
+    };
+    objectIdLike.id.toHexString = null;
+
+    expect(() => new ObjectId(objectIdLike).toHexString()).to.throw(TypeError);
+  });
+
+  it('should correctly create ObjectId from number', function () {
+    expect(() => new ObjectId(42)).to.not.throw();
+    expect(() => new ObjectId(0x2a)).to.not.throw();
+    expect(() => new ObjectId(NaN)).to.not.throw();
   });
 
   /**

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -5,7 +5,7 @@ const BSON = require('../register-bson');
 const util = require('util');
 const ObjectId = BSON.ObjectId;
 
-describe.only('ObjectId', function () {
+describe('ObjectId', function () {
   /**
    * @ignore
    */
@@ -46,16 +46,6 @@ describe.only('ObjectId', function () {
     };
 
     expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
-  });
-
-  it('should throw error if object without toHexString function is passed in', function () {
-    var tmp = new ObjectId();
-    var objectIdLike = {
-      id: tmp.id
-    };
-    objectIdLike.id.toHexString = null;
-
-    expect(() => new ObjectId(objectIdLike).toHexString()).to.throw(TypeError);
   });
 
   it('should correctly create ObjectId from number', function () {

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -48,6 +48,14 @@ describe('ObjectId', function () {
     expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
   });
 
+  it('should throw error if object without string or buffer id is passed in', function () {
+    var objectIdLike = {
+      id: 5
+    };
+
+    expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
+  });
+
   it('should correctly create ObjectId from number', function () {
     expect(() => new ObjectId(42)).to.not.throw();
     expect(() => new ObjectId(0x2a)).to.not.throw();

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -9,7 +9,7 @@ describe('ObjectId', function () {
   /**
    * @ignore
    */
- 
+
   it('should correctly handle objectId timestamps', function (done) {
     // var test_number = {id: ObjectI()};
     var a = ObjectId.createFromTime(1);
@@ -23,6 +23,11 @@ describe('ObjectId', function () {
     expect(1000).to.equal(b.getTimestamp().getTime());
 
     done();
+  });
+
+  it('should correctly create ObjectId from ObjectId', function () {
+    var tmp = new ObjectId();
+    expect(() => new ObjectId(tmp)).to.not.throw();
   });
 
   it('should throw error if empty array is passed in', function () {
@@ -48,18 +53,65 @@ describe('ObjectId', function () {
     expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
   });
 
-  it('should throw error if object without string or buffer id is passed in', function () {
-    var objectIdLike = {
+  it('should throw error if object with non-Buffer non-string id is passed in', function () {
+    var objectNumId = {
       id: 5
     };
+    var objectNullId = {
+      id: null
+    };
 
-    expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
+    expect(() => new ObjectId(objectNumId)).to.throw(TypeError);
+    expect(() => new ObjectId(objectNullId)).to.throw(TypeError);
   });
 
-  it('should correctly create ObjectId from number', function () {
+  it('should correctly create ObjectId with objectIdLike properties', function () {
+    var tmp = new ObjectId();
+    var objectIdLike = {
+      id: tmp.id,
+      toHexString: function () {
+        return tmp.toHexString();
+      }
+    };
+
+    expect(() => new ObjectId(objectIdLike)).to.not.throw(TypeError);
+  });
+
+  it('should correctly create ObjectId from number or null', function () {
     expect(() => new ObjectId(42)).to.not.throw();
     expect(() => new ObjectId(0x2a)).to.not.throw();
     expect(() => new ObjectId(NaN)).to.not.throw();
+    expect(() => new ObjectId(null)).to.not.throw();
+  });
+
+  it('should correctly create ObjectId with Buffer or string id', function () {
+    var objectStringId = {
+      id: 'thisisastringid'
+    };
+    var objectBufferId = {
+      id: Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex')
+    };
+    var objectBufferFromArray = {
+      id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+    };
+
+    expect(() => new ObjectId(objectStringId)).to.not.throw(TypeError);
+    expect(() => new ObjectId(objectBufferId)).to.not.throw(TypeError);
+    expect(() => new ObjectId(objectBufferFromArray)).to.not.throw(TypeError);
+  });
+
+  it('should throw error if non-12 byte non-24 hex string passed in', function () {
+    expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFG')).to.throw();
+    expect(() => new ObjectId('thisismorethan12chars')).to.throw();
+    expect(() => new ObjectId('101010')).to.throw();
+    expect(() => new ObjectId('')).to.throw();
+  });
+
+  it('should correctly create ObjectId from 12 byte or 24 hex string', function () {
+    expect(() => new ObjectId('AAAAAAAAAAAAAAAAAAAAAAAA')).to.not.throw();
+    expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFF')).to.not.throw();
+    expect(() => new ObjectId('111111111111')).to.not.throw();
+    expect(() => new ObjectId('abcdefghijkl')).to.not.throw();
   });
 
   /**


### PR DESCRIPTION
Tightens the logic within the ObjectId constructor to make sure that inputs to the constructor are of the proper types, otherwise throws a TypeError. Tests to make sure that invalid inputs have an error thrown (rather than creating a "broken" ObjectId object with no 'id' property, for instance) are added. 