### PR TITLE
fix(Node 3724): Fix BSONTypeError and BSONError to correctly handle instanceof checks

### DIFF
--- a/src/ensure_buffer.ts
+++ b/src/ensure_buffer.ts
@@ -8,7 +8,7 @@ import { isAnyArrayBuffer } from './parser/utils';
  * @param potentialBuffer - The potential buffer
  * @returns Buffer the input if potentialBuffer is a buffer, or a buffer that
  * wraps a passed in Uint8Array
- * @throws TypeError If anything other than a Buffer or Uint8Array is passed in
+ * @throws BSONTypeError If anything other than a Buffer or Uint8Array is passed in
  */
 export function ensureBuffer(potentialBuffer: Buffer | ArrayBufferView | ArrayBuffer): Buffer {
   if (ArrayBuffer.isView(potentialBuffer)) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,7 +1,7 @@
 /** @public */
 export class BSONError extends Error {
-  constructor(m: string) {
-    super(m);
+  constructor(message: string) {
+    super(message);
     Object.setPrototypeOf(this, BSONError.prototype);
   }
 
@@ -12,8 +12,8 @@ export class BSONError extends Error {
 
 /** @public */
 export class BSONTypeError extends TypeError {
-  constructor(m: string) {
-    super(m);
+  constructor(message: string) {
+    super(message);
     Object.setPrototypeOf(this, BSONTypeError.prototype);
   }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,10 @@
 /** @public */
 export class BSONError extends Error {
+  constructor(m: string) {
+    super(m);
+    Object.setPrototypeOf(this, BSONError.prototype);
+  }
+
   get name(): string {
     return 'BSONError';
   }
@@ -7,6 +12,11 @@ export class BSONError extends Error {
 
 /** @public */
 export class BSONTypeError extends TypeError {
+  constructor(m: string) {
+    super(m);
+    Object.setPrototypeOf(this, BSONTypeError.prototype);
+  }
+
   get name(): string {
     return 'BSONTypeError';
   }

--- a/test/binary_parser.js
+++ b/test/binary_parser.js
@@ -1,4 +1,8 @@
 'use strict';
+
+const BSON = require('./register-bson');
+const BSONError = BSON.BSONError;
+
 /**
  * Binary Parser.
  * Jonas Raoni Soares Silva
@@ -20,7 +24,7 @@ function BinaryParser(bigEndian, allowExceptions) {
 
 BinaryParser.warn = function warn(msg) {
   if (this.allowExceptions) {
-    throw new Error(msg);
+    throw new BSONError(msg);
   }
 
   return 1;
@@ -419,7 +423,7 @@ BinaryParserBuffer.prototype.hasNeededBits = function hasNeededBits(neededBits) 
 
 BinaryParserBuffer.prototype.checkBuffer = function checkBuffer(neededBits) {
   if (!this.hasNeededBits(neededBits)) {
-    throw new Error('checkBuffer::missing bytes');
+    throw new BSONError('checkBuffer::missing bytes');
   }
 };
 

--- a/test/node/bigint_tests.js
+++ b/test/node/bigint_tests.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const BSON = require('../register-bson');
+const BSONTypeError = BSON.BSONTypeError;
 
 describe('BSON BigInt Support', function () {
   before(function () {
@@ -13,7 +14,7 @@ describe('BSON BigInt Support', function () {
   });
   it('Should serialize an int that fits in int32', function () {
     const testDoc = { b: BigInt(32) };
-    expect(() => BSON.serialize(testDoc)).to.throw(TypeError);
+    expect(() => BSON.serialize(testDoc)).to.throw(BSONTypeError);
 
     // const serializedDoc = BSON.serialize(testDoc);
     // // prettier-ignore
@@ -25,7 +26,7 @@ describe('BSON BigInt Support', function () {
 
   it('Should serialize an int that fits in int64', function () {
     const testDoc = { b: BigInt(0x1ffffffff) };
-    expect(() => BSON.serialize(testDoc)).to.throw(TypeError);
+    expect(() => BSON.serialize(testDoc)).to.throw(BSONTypeError);
 
     // const serializedDoc = BSON.serialize(testDoc);
     // // prettier-ignore
@@ -37,7 +38,7 @@ describe('BSON BigInt Support', function () {
 
   it('Should serialize an int that fits in decimal128', function () {
     const testDoc = { b: BigInt('9223372036854776001') }; // int64 max + 1
-    expect(() => BSON.serialize(testDoc)).to.throw(TypeError);
+    expect(() => BSON.serialize(testDoc)).to.throw(BSONTypeError);
 
     // const serializedDoc = BSON.serialize(testDoc);
     // // prettier-ignore
@@ -52,7 +53,7 @@ describe('BSON BigInt Support', function () {
     const testDoc = {
       b: BigInt('9'.repeat(35))
     }; // decimal 128 can only encode 34 digits of precision
-    expect(() => BSON.serialize(testDoc)).to.throw(TypeError);
+    expect(() => BSON.serialize(testDoc)).to.throw(BSONTypeError);
     // expect(() => BSON.serialize(testDoc)).to.throw();
   });
 

--- a/test/node/bson_corpus_tests.js
+++ b/test/node/bson_corpus_tests.js
@@ -3,6 +3,7 @@
 
 const Buffer = require('buffer').Buffer;
 const BSON = require('../register-bson');
+const BSONError = BSON.BSONError;
 const EJSON = BSON.EJSON;
 
 const deserializeOptions = {
@@ -89,19 +90,19 @@ const parseErrorForRootDocument = scenario => {
       }
 
       if (/Null/.test(parseError.description)) {
-        expect(caughtError).to.be.instanceOf(Error);
+        expect(caughtError).to.be.instanceOf(BSONError);
         expect(caughtError.message).to.match(/null bytes/);
       } else if (/Bad/.test(parseError.description)) {
         // There is a number of failing tests that start with 'Bad'
         // so this check is essentially making the test optional for now
-        // This should assert that e is an Error and something about the message
+        // This should assert that e is a BSONError and something about the message
         // TODO(NODE-3637): remove special logic and use expect().to.throw() and add errors to lib
         expect(caughtError).to.satisfy(e => {
-          if (e instanceof Error) return true;
+          if (e instanceof BSONError) return true;
           else this.skip();
         });
       } else {
-        expect(caughtError).to.be.instanceOf(Error);
+        expect(caughtError).to.be.instanceOf(BSONError);
       }
     });
   }

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -16,6 +16,7 @@ const Int32 = BSON.Int32;
 const Double = BSON.Double;
 const MinKey = BSON.MinKey;
 const MaxKey = BSON.MaxKey;
+const BSONError = BSON.BSONError;
 const { BinaryParser } = require('../binary_parser');
 const vm = require('vm');
 const { assertBuffersEqual } = require('./tools/utils');
@@ -33,7 +34,7 @@ var ISODate = function (string) {
 
   const match = string.match(ISO_REGEX);
   if (!match) {
-    throw new Error(`Invalid ISO 8601 date given: ${string}`);
+    throw new BSONError(`Invalid ISO 8601 date given: ${string}`);
   }
 
   var date = new Date();

--- a/test/node/ensure_buffer_test.js
+++ b/test/node/ensure_buffer_test.js
@@ -3,6 +3,8 @@
 
 const { Buffer } = require('buffer');
 const { ensureBuffer } = require('../register-bson');
+const BSON = require('../register-bson');
+const BSONTypeError = BSON.BSONTypeError;
 
 describe('ensureBuffer tests', function () {
   it('should be a function', function () {
@@ -15,7 +17,7 @@ describe('ensureBuffer tests', function () {
 
     expect(function () {
       bufferOut = ensureBuffer(bufferIn);
-    }).to.not.throw(Error);
+    }).to.not.throw(BSONTypeError);
 
     expect(bufferOut).to.be.an.instanceOf(Buffer);
     expect(bufferOut.buffer).to.equal(bufferIn.buffer);
@@ -29,7 +31,7 @@ describe('ensureBuffer tests', function () {
 
     expect(function () {
       bufferOut = ensureBuffer(arrayIn);
-    }).to.not.throw(Error);
+    }).to.not.throw(BSONTypeError);
 
     expect(bufferOut).to.be.an.instanceOf(Buffer);
     expect(bufferOut.buffer).to.equal(arrayIn.buffer);
@@ -41,7 +43,7 @@ describe('ensureBuffer tests', function () {
 
     expect(function () {
       bufferOut = ensureBuffer(arrayBufferIn);
-    }).to.not.throw(Error);
+    }).to.not.throw(BSONTypeError);
 
     expect(bufferOut).to.be.an.instanceOf(Buffer);
     expect(bufferOut.buffer).to.equal(arrayBufferIn);
@@ -57,7 +59,7 @@ describe('ensureBuffer tests', function () {
 
     expect(function () {
       bufferOut = ensureBuffer(arrayBufferIn);
-    }).to.not.throw(Error);
+    }).to.not.throw(BSONTypeError);
 
     expect(bufferOut).to.be.an.instanceOf(Buffer);
     expect(bufferOut.buffer).to.equal(arrayBufferIn);
@@ -69,7 +71,7 @@ describe('ensureBuffer tests', function () {
 
     expect(function () {
       bufferOut = ensureBuffer(input);
-    }).to.not.throw(Error);
+    }).to.not.throw(BSONTypeError);
 
     expect(bufferOut).to.be.an.instanceOf(Buffer);
     expect(bufferOut.byteLength).to.equal(3);
@@ -80,7 +82,7 @@ describe('ensureBuffer tests', function () {
     it(`should throw if input is ${typeof item}: ${item}`, function () {
       expect(function () {
         ensureBuffer(item);
-      }).to.throw(TypeError);
+      }).to.throw(BSONTypeError);
     });
   });
 

--- a/test/node/error_test.js
+++ b/test/node/error_test.js
@@ -4,23 +4,31 @@ const BSON = require('../register-bson');
 const BSONTypeError = BSON.BSONTypeError;
 const BSONError = BSON.BSONError;
 
-describe('BSON error tests', function () {
-  it('should correctly validate instanceof checks for BSONTypeError and BSONError', function () {
+describe('BSONTypeError', function () {
+  it('should evaluate true on instanceof BSONTypeError and TypeError', function () {
     const bsonTypeErr = new BSONTypeError();
-    const bsonErr = new BSONError();
-
+    expect(bsonTypeErr instanceof BSONTypeError).to.be.true;
     expect(bsonTypeErr).to.be.instanceOf(BSONTypeError);
     expect(bsonTypeErr).to.be.instanceOf(TypeError);
+  });
+
+  it('should correctly set BSONTypeError name and message properties', function () {
+    const bsonTypeErr = new BSONTypeError('This is a BSONTypeError message');
+    expect(bsonTypeErr.name).equals('BSONTypeError');
+    expect(bsonTypeErr.message).equals('This is a BSONTypeError message');
+  });
+});
+
+describe('BSONError', function () {
+  it('should evaluate true on instanceof BSONError and Error', function () {
+    const bsonErr = new BSONError();
+    expect(bsonErr instanceof BSONError).to.be.true;
     expect(bsonErr).to.be.instanceOf(BSONError);
     expect(bsonErr).to.be.instanceOf(Error);
   });
 
-  it('should correctly get correct names for BSONTypeError and BSONError', function () {
-    const bsonTypeErr = new BSONTypeError('This is a BSONTypeError message');
+  it('should correctly set BSONError name and message properties', function () {
     const bsonErr = new BSONError('This is a BSONError message');
-
-    expect(bsonTypeErr.name).equals('BSONTypeError');
-    expect(bsonTypeErr.message).equals('This is a BSONTypeError message');
     expect(bsonErr.name).equals('BSONError');
     expect(bsonErr.message).equals('This is a BSONError message');
   });

--- a/test/node/error_test.js
+++ b/test/node/error_test.js
@@ -9,8 +9,10 @@ describe('BSON error tests', function () {
     const bsonTypeErr = new BSONTypeError();
     const bsonErr = new BSONError();
 
-    expect(bsonTypeErr instanceof BSONTypeError).to.be.true;
-    expect(bsonErr instanceof BSONError).to.be.true;
+    expect(bsonTypeErr).to.be.instanceOf(BSONTypeError);
+    expect(bsonTypeErr).to.be.instanceOf(TypeError);
+    expect(bsonErr).to.be.instanceOf(BSONError);
+    expect(bsonErr).to.be.instanceOf(Error);
   });
 
   it('should correctly get correct names for BSONTypeError and BSONError', function () {

--- a/test/node/error_test.js
+++ b/test/node/error_test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const BSON = require('../register-bson');
+const BSONTypeError = BSON.BSONTypeError;
+const BSONError = BSON.BSONError;
+
+describe('BSON error tests', function () {
+  it('should correctly validate instanceof checks for BSONTypeError and BSONError', function () {
+    const bsonTypeErr = new BSONTypeError();
+    const bsonErr = new BSONError();
+
+    expect(bsonTypeErr instanceof BSONTypeError).to.be.true;
+    expect(bsonErr instanceof BSONError).to.be.true;
+  });
+
+  it('should correctly get correct names for BSONTypeError and BSONError', function () {
+    const bsonTypeErr = new BSONTypeError('This is a BSONTypeError message');
+    const bsonErr = new BSONError('This is a BSONError message');
+
+    expect(bsonTypeErr.name).equals('BSONTypeError');
+    expect(bsonTypeErr.message).equals('This is a BSONTypeError message');
+    expect(bsonErr.name).equals('BSONError');
+    expect(bsonErr.message).equals('This is a BSONError message');
+  });
+});

--- a/test/node/error_test.js
+++ b/test/node/error_test.js
@@ -8,6 +8,7 @@ describe('BSONTypeError', function () {
   it('should evaluate true on instanceof BSONTypeError and TypeError', function () {
     const bsonTypeErr = new BSONTypeError();
     expect(bsonTypeErr instanceof BSONTypeError).to.be.true;
+    expect(bsonTypeErr instanceof TypeError).to.be.true;
     expect(bsonTypeErr).to.be.instanceOf(BSONTypeError);
     expect(bsonTypeErr).to.be.instanceOf(TypeError);
   });
@@ -23,6 +24,7 @@ describe('BSONError', function () {
   it('should evaluate true on instanceof BSONError and Error', function () {
     const bsonErr = new BSONError();
     expect(bsonErr instanceof BSONError).to.be.true;
+    expect(bsonErr instanceof Error).to.be.true;
     expect(bsonErr).to.be.instanceOf(BSONError);
     expect(bsonErr).to.be.instanceOf(Error);
   });

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -6,16 +6,12 @@ const util = require('util');
 const ObjectId = BSON.ObjectId;
 
 describe('ObjectId', function () {
-  /**
-   * @ignore
-   */
   it('should correctly handle objectId timestamps', function (done) {
-    // var test_number = {id: ObjectI()};
-    var a = ObjectId.createFromTime(1);
+    const a = ObjectId.createFromTime(1);
     expect(Buffer.from([0, 0, 0, 1])).to.deep.equal(a.id.slice(0, 4));
     expect(1000).to.equal(a.getTimestamp().getTime());
 
-    var b = new ObjectId();
+    const b = new ObjectId();
     b.generationTime = 1;
     expect(Buffer.from([0, 0, 0, 1])).to.deep.equal(b.id.slice(0, 4));
     expect(1).to.equal(b.generationTime);
@@ -24,13 +20,192 @@ describe('ObjectId', function () {
     done();
   });
 
-  /**
-   * @ignore
-   */
+  it('should correctly create ObjectId from ObjectId', function () {
+    const noArgObjID = new ObjectId();
+    expect(new ObjectId(noArgObjID).id).to.deep.equal(Buffer.from(noArgObjID.id, 'hex'));
+  });
+
+  const invalidInputs = [
+    { input: [], description: 'empty array' },
+    { input: ['abcdefŽhijkl'], description: 'nonempty array' },
+    { input: {}, description: 'empty object' }
+  ];
+
+  for (const { input, description } of invalidInputs) {
+    it(`should throw error if ${description} is passed in`, function () {
+      expect(() => new ObjectId(input)).to.throw(TypeError);
+    });
+  }
+
+  it('should throw error if object without an id property is passed in', function () {
+    const noArgObjID = new ObjectId();
+    const objectIdLike = {
+      toHexString: function () {
+        return noArgObjID.toHexString();
+      }
+    };
+
+    expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
+  });
+
+  it('should correctly create ObjectId from object with valid string id', function () {
+    const objectValidString24Hex = {
+      id: 'aaaaaaaaaaaaaaaaaaaaaaaa'
+    };
+    const objectValidString12Bytes = {
+      id: 'abcdefghijkl'
+    };
+    const buf24Hex = Buffer.from('aaaaaaaaaaaaaaaaaaaaaaaa', 'hex');
+    const buf12Bytes = Buffer.from('abcdefghijkl');
+    expect(new ObjectId(objectValidString24Hex).id).to.deep.equal(buf24Hex);
+    expect(new ObjectId(objectValidString12Bytes).id).to.deep.equal(buf12Bytes);
+  });
+
+  it('should correctly create ObjectId from object with valid string id and toHexString method', function () {
+    function new24HexToHexString() {
+      return 'BBBBBBBBBBBBBBBBBBBBBBBB';
+    }
+    const buf24hex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    const objectValidString24Hex = {
+      id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+      toHexString: new24HexToHexString
+    };
+    const objectValidString12Bytes = {
+      id: 'abcdefghijkl',
+      toHexString: new24HexToHexString
+    };
+    expect(new ObjectId(objectValidString24Hex).id).to.deep.equal(buf24hex);
+    expect(new ObjectId(objectValidString12Bytes).id).to.deep.equal(buf24hex);
+  });
+
+  it('should correctly create ObjectId from object with valid Buffer id', function () {
+    const validBuffer24Hex = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex');
+    const validBuffer12Array = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const objectBufferId = {
+      id: validBuffer24Hex
+    };
+    const objectBufferFromArray = {
+      id: validBuffer12Array
+    };
+    expect(new ObjectId(objectBufferId).id).to.deep.equals(validBuffer24Hex);
+    expect(new ObjectId(objectBufferFromArray).id).to.deep.equals(validBuffer12Array);
+  });
+
+  it('should correctly create ObjectId from object with valid Buffer id and toHexString method', function () {
+    const validBuffer24Hex = Buffer.from('AAAAAAAAAAAAAAAAAAAAAAAA', 'hex');
+    const validBuffer12Array = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const bufferNew24Hex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    function newToHexString() {
+      return 'BBBBBBBBBBBBBBBBBBBBBBBB';
+    }
+    const objectBufferHex = {
+      id: validBuffer24Hex,
+      toHexString: newToHexString
+    };
+    const objectBufferArray = {
+      id: validBuffer12Array,
+      toHexString: newToHexString
+    };
+    expect(new ObjectId(objectBufferHex).id).to.deep.equal(bufferNew24Hex);
+    expect(new ObjectId(objectBufferArray).id).to.deep.equal(bufferNew24Hex);
+  });
+
+  it('should throw error if object with non-Buffer non-string id is passed in', function () {
+    const objectNumId = {
+      id: 5
+    };
+    const objectNullId = {
+      id: null
+    };
+    expect(() => new ObjectId(objectNumId)).to.throw(TypeError);
+    expect(() => new ObjectId(objectNullId)).to.throw(TypeError);
+  });
+
+  it('should throw an error if object with invalid string id is passed in', function () {
+    const objectInvalid24HexStr = {
+      id: 'FFFFFFFFFFFFFFFFFFFFFFFG'
+    };
+    expect(() => new ObjectId(objectInvalid24HexStr)).to.throw(TypeError);
+  });
+
+  it('should correctly create ObjectId from object with invalid string id and toHexString method', function () {
+    function newToHexString() {
+      return 'BBBBBBBBBBBBBBBBBBBBBBBB';
+    }
+    const objectInvalid24HexStr = {
+      id: 'FFFFFFFFFFFFFFFFFFFFFFFG',
+      toHexString: newToHexString
+    };
+    const bufferNew24Hex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    expect(new ObjectId(objectInvalid24HexStr).id).to.deep.equal(bufferNew24Hex);
+  });
+
+  it('should throw an error if object with invalid Buffer id is passed in', function () {
+    const objectInvalidBuffer = {
+      id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+    };
+    expect(() => new ObjectId(objectInvalidBuffer)).to.throw(TypeError);
+  });
+
+  it('should correctly create ObjectId from object with invalid Buffer id and toHexString method', function () {
+    function newToHexString() {
+      return 'BBBBBBBBBBBBBBBBBBBBBBBB';
+    }
+    const objectInvalidBuffer = {
+      id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+      toHexString: newToHexString
+    };
+    const bufferNew24Hex = Buffer.from('BBBBBBBBBBBBBBBBBBBBBBBB', 'hex');
+    expect(new ObjectId(objectInvalidBuffer).id).to.deep.equal(bufferNew24Hex);
+  });
+
+  const numericIO = [
+    { input: 42, output: 42, description: '42' },
+    { input: 0x2a, output: 0x2a, description: '0x2a' },
+    { input: 4.2, output: 4, description: '4.2' },
+    { input: NaN, output: 0, description: 'NaN' }
+  ];
+
+  for (const { input, output } of numericIO) {
+    it(`should correctly create ObjectId from ${input} and result in ${output}`, function () {
+      const objId = new ObjectId(input);
+      expect(objId).to.have.property('id');
+      expect(objId.id).to.be.instanceOf(Buffer);
+      expect(objId.id.readUInt32BE(0)).to.equal(output);
+    });
+  }
+
+  it('should correctly create ObjectId undefined or null', function () {
+    const objNull = new ObjectId(null);
+    const objNoArg = new ObjectId();
+    const objUndef = new ObjectId(undefined);
+    expect(objNull.id).to.be.instanceOf(Buffer);
+    expect(objNoArg.id).to.be.instanceOf(Buffer);
+    expect(objUndef.id).to.be.instanceOf(Buffer);
+  });
+
+  it('should throw error if non-12 byte non-24 hex string passed in', function () {
+    expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFG')).to.throw(TypeError);
+    expect(() => new ObjectId('thisstringisdefinitelytoolong')).to.throw(TypeError);
+    expect(() => new ObjectId('tooshort')).to.throw(TypeError);
+    expect(() => new ObjectId('101010')).to.throw(TypeError);
+    expect(() => new ObjectId('')).to.throw(TypeError);
+  });
+
+  it('should correctly create ObjectId from 24 hex string', function () {
+    const validStr24Hex = 'FFFFFFFFFFFFFFFFFFFFFFFF';
+    expect(new ObjectId(validStr24Hex).id).to.deep.equal(Buffer.from(validStr24Hex, 'hex'));
+  });
+
+  it('should correctly create ObjectId from 12 byte sequence', function () {
+    const byteSequence12 = '111111111111';
+    expect(new ObjectId(byteSequence12).id).to.deep.equal(Buffer.from(byteSequence12, 'latin1'));
+  });
+
   it('should correctly create ObjectId from uppercase hexstring', function (done) {
-    var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
-    var b = new ObjectId(a);
-    var c = b.equals(a); // => false
+    let a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
+    let b = new ObjectId(a);
+    let c = b.equals(a); // => false
     expect(true).to.equal(c);
 
     a = 'aaaaaaaaaaaaaaaaaaaaaaaa';
@@ -42,14 +217,11 @@ describe('ObjectId', function () {
     done();
   });
 
-  /**
-   * @ignore
-   */
-  it('should correctly create ObjectId from Buffer', function (done) {
+  it('should correctly create ObjectId from valid Buffer', function (done) {
     if (!Buffer.from) return done();
-    var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
-    var b = new ObjectId(Buffer.from(a, 'hex'));
-    var c = b.equals(a); // => false
+    let a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
+    let b = new ObjectId(Buffer.from(a, 'hex'));
+    let c = b.equals(a); // => false
     expect(true).to.equal(c);
 
     a = 'aaaaaaaaaaaaaaaaaaaaaaaa';
@@ -60,24 +232,23 @@ describe('ObjectId', function () {
     done();
   });
 
-  /**
-   * @ignore
-   */
+  it('should throw an error if invalid Buffer passed in', function () {
+    const a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    expect(() => new ObjectId(a)).to.throw(TypeError);
+  });
+
   it('should correctly allow for node.js inspect to work with ObjectId', function (done) {
-    var a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
-    var b = new ObjectId(a);
+    const a = 'AAAAAAAAAAAAAAAAAAAAAAAA';
+    const b = new ObjectId(a);
     expect(util.inspect(b)).to.equal('new ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")');
 
     done();
   });
 
-  /**
-   * @ignore
-   */
   it('should isValid check input Buffer length', function (done) {
-    var buffTooShort = Buffer.from([]);
-    var buffTooLong = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-    var buff12Bytes = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const buffTooShort = Buffer.from([]);
+    const buffTooLong = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    const buff12Bytes = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 
     expect(ObjectId.isValid(buffTooShort)).to.be.false;
     expect(ObjectId.isValid(buffTooLong)).to.be.false;
@@ -85,13 +256,21 @@ describe('ObjectId', function () {
     done();
   });
 
-  it('should throw if a 12-char string is passed in with character codes greater than 256', function () {
-    expect(() => new ObjectId('abcdefghijkl').toHexString()).to.not.throw();
-    expect(() => new ObjectId('abcdefŽhijkl').toHexString()).to.throw(TypeError);
+  it('should throw if a 12-char length but non-12 byte string is passed in', function () {
+    const characterCodesLargerThan256 = 'abcdefŽhijkl';
+    const length12Not12Bytes = '🐶🐶🐶🐶🐶🐶';
+    expect(() => new ObjectId(characterCodesLargerThan256).toHexString()).to.throw(
+      TypeError,
+      'Argument passed in must be a string of 12 bytes'
+    );
+    expect(() => new ObjectId(length12Not12Bytes).id).to.throw(
+      TypeError,
+      'Argument passed in must be a string of 12 bytes'
+    );
   });
 
   it('should correctly interpret timestamps beyond 2038', function () {
-    var farFuture = new Date('2040-01-01T00:00:00.000Z').getTime();
+    const farFuture = new Date('2040-01-01T00:00:00.000Z').getTime();
     expect(
       new BSON.ObjectId(BSON.ObjectId.generate(farFuture / 1000)).getTimestamp().getTime()
     ).to.equal(farFuture);

--- a/test/node/object_id_tests.js
+++ b/test/node/object_id_tests.js
@@ -2,6 +2,7 @@
 
 const Buffer = require('buffer').Buffer;
 const BSON = require('../register-bson');
+const BSONTypeError = BSON.BSONTypeError;
 const util = require('util');
 const ObjectId = BSON.ObjectId;
 
@@ -33,7 +34,7 @@ describe('ObjectId', function () {
 
   for (const { input, description } of invalidInputs) {
     it(`should throw error if ${description} is passed in`, function () {
-      expect(() => new ObjectId(input)).to.throw(TypeError);
+      expect(() => new ObjectId(input)).to.throw(BSONTypeError);
     });
   }
 
@@ -45,7 +46,7 @@ describe('ObjectId', function () {
       }
     };
 
-    expect(() => new ObjectId(objectIdLike)).to.throw(TypeError);
+    expect(() => new ObjectId(objectIdLike)).to.throw(BSONTypeError);
   });
 
   it('should correctly create ObjectId from object with valid string id', function () {
@@ -117,15 +118,15 @@ describe('ObjectId', function () {
     const objectNullId = {
       id: null
     };
-    expect(() => new ObjectId(objectNumId)).to.throw(TypeError);
-    expect(() => new ObjectId(objectNullId)).to.throw(TypeError);
+    expect(() => new ObjectId(objectNumId)).to.throw(BSONTypeError);
+    expect(() => new ObjectId(objectNullId)).to.throw(BSONTypeError);
   });
 
   it('should throw an error if object with invalid string id is passed in', function () {
     const objectInvalid24HexStr = {
       id: 'FFFFFFFFFFFFFFFFFFFFFFFG'
     };
-    expect(() => new ObjectId(objectInvalid24HexStr)).to.throw(TypeError);
+    expect(() => new ObjectId(objectInvalid24HexStr)).to.throw(BSONTypeError);
   });
 
   it('should correctly create ObjectId from object with invalid string id and toHexString method', function () {
@@ -144,7 +145,7 @@ describe('ObjectId', function () {
     const objectInvalidBuffer = {
       id: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
     };
-    expect(() => new ObjectId(objectInvalidBuffer)).to.throw(TypeError);
+    expect(() => new ObjectId(objectInvalidBuffer)).to.throw(BSONTypeError);
   });
 
   it('should correctly create ObjectId from object with invalid Buffer id and toHexString method', function () {
@@ -185,11 +186,11 @@ describe('ObjectId', function () {
   });
 
   it('should throw error if non-12 byte non-24 hex string passed in', function () {
-    expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFG')).to.throw(TypeError);
-    expect(() => new ObjectId('thisstringisdefinitelytoolong')).to.throw(TypeError);
-    expect(() => new ObjectId('tooshort')).to.throw(TypeError);
-    expect(() => new ObjectId('101010')).to.throw(TypeError);
-    expect(() => new ObjectId('')).to.throw(TypeError);
+    expect(() => new ObjectId('FFFFFFFFFFFFFFFFFFFFFFFG')).to.throw(BSONTypeError);
+    expect(() => new ObjectId('thisstringisdefinitelytoolong')).to.throw(BSONTypeError);
+    expect(() => new ObjectId('tooshort')).to.throw(BSONTypeError);
+    expect(() => new ObjectId('101010')).to.throw(BSONTypeError);
+    expect(() => new ObjectId('')).to.throw(BSONTypeError);
   });
 
   it('should correctly create ObjectId from 24 hex string', function () {
@@ -234,7 +235,7 @@ describe('ObjectId', function () {
 
   it('should throw an error if invalid Buffer passed in', function () {
     const a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-    expect(() => new ObjectId(a)).to.throw(TypeError);
+    expect(() => new ObjectId(a)).to.throw(BSONTypeError);
   });
 
   it('should correctly allow for node.js inspect to work with ObjectId', function (done) {
@@ -260,11 +261,11 @@ describe('ObjectId', function () {
     const characterCodesLargerThan256 = 'abcdefŽhijkl';
     const length12Not12Bytes = '🐶🐶🐶🐶🐶🐶';
     expect(() => new ObjectId(characterCodesLargerThan256).toHexString()).to.throw(
-      TypeError,
+      BSONTypeError,
       'Argument passed in must be a string of 12 bytes'
     );
     expect(() => new ObjectId(length12Not12Bytes).id).to.throw(
-      TypeError,
+      BSONTypeError,
       'Argument passed in must be a string of 12 bytes'
     );
   });

--- a/test/node/uuid_tests.js
+++ b/test/node/uuid_tests.js
@@ -4,6 +4,8 @@ const { Buffer } = require('buffer');
 const { Binary, UUID } = require('../register-bson');
 const { inspect } = require('util');
 const { validate: uuidStringValidate, version: uuidStringVersion } = require('uuid');
+const BSON = require('../register-bson');
+const BSONTypeError = BSON.BSONTypeError;
 
 // Test values
 const UPPERCASE_DASH_SEPARATED_UUID_STRING = 'AAAAAAAA-AAAA-4AAA-AAAA-AAAAAAAAAAAA';
@@ -76,7 +78,7 @@ describe('UUID', () => {
    */
   it('should throw if passed invalid 36-char uuid hex string', () => {
     expect(() => new UUID(LOWERCASE_DASH_SEPARATED_UUID_STRING)).to.not.throw();
-    expect(() => new UUID('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')).to.throw(TypeError);
+    expect(() => new UUID('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')).to.throw(BSONTypeError);
     // Note: The version is missing here ^
   });
 
@@ -85,7 +87,7 @@ describe('UUID', () => {
    */
   it('should throw if passed unsupported argument', () => {
     expect(() => new UUID(LOWERCASE_DASH_SEPARATED_UUID_STRING)).to.not.throw();
-    expect(() => new UUID({})).to.throw(TypeError);
+    expect(() => new UUID({})).to.throw(BSONTypeError);
   });
 
   /**

--- a/test/register-bson.js
+++ b/test/register-bson.js
@@ -14,25 +14,4 @@ require('object.entries/auto');
 const BSON = require('../lib/bson');
 const { ensureBuffer } = require('../lib/ensure_buffer');
 BSON.ensureBuffer = ensureBuffer;
-
-const { Assertion, util } = require('chai');
-Assertion.overwriteMethod('throw', function (original) {
-  return function assertThrow(...args) {
-    if (args.length === 0 || args.includes(BSON.BSONError) || args.includes(BSON.BSONTypeError)) {
-      // By default, lets check for BSONError or BSONTypeError
-      // Since we compile to es5 instanceof is broken???
-      const assertion = original.apply(this, args);
-      const object = util.flag(assertion, 'object');
-      return this.assert(
-        object && /BSONError|BSONTypeError/.test(object.stack),
-        'expected #{this} to be a BSONError or a BSONTypeError but got #{act}',
-        'expected #{this} to not be a BSONError nor a BSONTypeError but got #{act}',
-        (object && object.stack) || '<error undefined>'
-      );
-    } else {
-      return original.apply(this, args);
-    }
-  };
-});
-
 module.exports = BSON;


### PR DESCRIPTION
Fixes the constructors for BSONTypeError and TypeError with Object.setPrototypeOf so that instanceof checks pass with both error types. The assertion override for `throw` in `register-bson.ts` is removed since it is no longer necessary with the fix. Tests making sure the errors respond properly to instanceof checks, show up with the correct names in the stack trace, and pass in input error messages correctly are added. 