### PR TITLE
fix(NODE-3760): Add regex check to 12 length string in isValid

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -298,7 +298,7 @@ export class ObjectId {
     }
 
     if (typeof id === 'string') {
-      return id.length === 12 || (id.length === 24 && checkForHexRegExp.test(id));
+      return (id.length === 12 || id.length === 24) && checkForHexRegExp.test(id));
     }
 
     if (id instanceof ObjectId) {


### PR DESCRIPTION
Issue with description filed here.
https://jira.mongodb.org/browse/DRIVERS-1989

### Description
Check the validity of strings with length 12 in the same way as is done for 24 length strings.

#### What is changing?
Added regex check to 12 length strings in ObjectId.isValid()

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
Object.isValid() returns true for strings that it shoudn't. For example the string: ´Value with é`

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
