### PR TITLE
fix(NODE-3821): nullish check before using toBSON override function

### DIFF
--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -24,7 +24,7 @@ export function calculateObjectSize(
   } else {
     // If we have toBSON defined, override the current object
 
-    if (object.toBSON) {
+    if (typeof object?.toBSON === 'function') {
       object = object.toBSON();
     }
 
@@ -47,7 +47,7 @@ function calculateElement(
   ignoreUndefined = false
 ) {
   // If we have toBSON defined, override the current object
-  if (value && value.toBSON) {
+  if (typeof value?.toBSON === 'function') {
     value = value.toBSON();
   }
 

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -958,8 +958,7 @@ export function serializeInto(
     for (const key in object) {
       let value = object[key];
       // Is there an override value
-      if (value !== null && value !== undefined && value.toBSON) {
-        if (typeof value.toBSON !== 'function') throw new BSONTypeError('toBSON is not a function');
+      if (typeof value?.toBSON === 'function') {
         value = value.toBSON();
       }
 

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -767,8 +767,7 @@ export function serializeInto(
       let value = object[i];
 
       // Is there an override value
-      if (value !== null && value !== undefined && value.toBSON) {
-        if (typeof value.toBSON !== 'function') throw new BSONTypeError('toBSON is not a function');
+      if (typeof value?.toBSON === 'function') {
         value = value.toBSON();
       }
 

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -946,12 +946,12 @@ export function serializeInto(
       }
     }
   } else {
-    // Did we provide a custom serialization method
-    if (object.toBSON) {
-      if (typeof object.toBSON !== 'function') throw new BSONTypeError('toBSON is not a function');
+    if (typeof object?.toBSON === 'function') {
+      // Provided a custom serialization method
       object = object.toBSON();
-      if (object != null && typeof object !== 'object')
+      if (object != null && typeof object !== 'object') {
         throw new BSONTypeError('toBSON function did not return an object');
+      }
     }
 
     // Iterate over all the keys

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -767,7 +767,7 @@ export function serializeInto(
       let value = object[i];
 
       // Is there an override value
-      if (value && value.toBSON) {
+      if (value !== null && value !== undefined && value.toBSON) {
         if (typeof value.toBSON !== 'function') throw new BSONTypeError('toBSON is not a function');
         value = value.toBSON();
       }
@@ -959,7 +959,7 @@ export function serializeInto(
     for (const key in object) {
       let value = object[key];
       // Is there an override value
-      if (value && value.toBSON) {
+      if (value !== null && value !== undefined && value.toBSON) {
         if (typeof value.toBSON !== 'function') throw new BSONTypeError('toBSON is not a function');
         value = value.toBSON();
       }

--- a/test/node/to_bson_test.js
+++ b/test/node/to_bson_test.js
@@ -129,4 +129,44 @@ describe('toBSON', function () {
     expect(true).to.equal(test2);
     done();
   });
+
+  it('Should not fail with properly extended BigInt prototype', function (done) {
+    // extend BigInt prototype
+    BigInt.prototype.toBSON = function(){
+      return 'hello';
+    }
+
+    // test with 0n
+    var doc = {
+      a: BigInt(0)
+    }
+
+    // serialize / deserialize
+    var serialized_data = BSON.serialize(doc, false, true);
+    var deserialized_doc = BSON.deserialize(serialized_data);
+    expect('hello').to.deep.equal(deserialized_doc.a);
+
+    // remove prototype extension intended for test
+    delete BigInt.prototype.toBSON;
+
+    done();
+  });
+
+  // by default, bigint is not supported
+  it('Should fail with unsupported primitive bigint', function (done) {
+    var doc = {
+      a: BigInt(0)
+    };
+
+    var test = false;
+
+    try{
+      BSON.serialize(doc, false, true);
+    } catch (err) {
+      test = true;
+    }
+
+    expect(true).to.equal(test);
+    done();
+  });
 });

--- a/test/node/to_bson_test.js
+++ b/test/node/to_bson_test.js
@@ -131,7 +131,7 @@ describe('toBSON', function () {
   });
 
   it('Should not fail with properly extended primitive wrapper object', function (done) {
-    // extend BigInt prototype
+    // extend Number prototype
     Number.prototype.toBSON = function () {
       return 'hello';
     };

--- a/test/node/to_bson_test.js
+++ b/test/node/to_bson_test.js
@@ -1,3 +1,4 @@
+/* globals BigInt */
 'use strict';
 
 const BSON = require('../register-bson');
@@ -132,14 +133,14 @@ describe('toBSON', function () {
 
   it('Should not fail with properly extended BigInt prototype', function (done) {
     // extend BigInt prototype
-    BigInt.prototype.toBSON = function(){
+    BigInt.prototype.toBSON = function () {
       return 'hello';
-    }
+    };
 
     // test with 0n
     var doc = {
       a: BigInt(0)
-    }
+    };
 
     // serialize / deserialize
     var serialized_data = BSON.serialize(doc, false, true);
@@ -160,7 +161,7 @@ describe('toBSON', function () {
 
     var test = false;
 
-    try{
+    try {
       BSON.serialize(doc, false, true);
     } catch (err) {
       test = true;

--- a/test/node/to_bson_test.js
+++ b/test/node/to_bson_test.js
@@ -3,6 +3,8 @@
 const BSON = require('../register-bson');
 const ObjectId = BSON.ObjectId;
 
+const BigInt = global.BigInt;
+
 describe('toBSON', function () {
   /**
    * @ignore
@@ -130,22 +132,82 @@ describe('toBSON', function () {
     done();
   });
 
-  it('Should not fail with properly extended primitive wrapper object', function (done) {
-    // extend Number prototype
-    Number.prototype.toBSON = function () {
-      return 'hello';
+  describe('when used on global existing types', () => {
+    beforeEach(() => {
+      Number.prototype.toBSON = () => 'hello';
+      String.prototype.toBSON = () => 'hello';
+      Boolean.prototype.toBSON = () => 'hello';
+      if (BigInt) BigInt.prototype.toBSON = () => 'hello';
+    });
+
+    afterEach(() => {
+      // remove prototype extension intended for test
+      delete Number.prototype.toBSON;
+      delete String.prototype.toBSON;
+      delete Boolean.prototype.toBSON;
+      if (BigInt) delete BigInt.prototype.toBSON;
+    });
+
+    const testToBSONFor = value => {
+      it(`should use toBSON on false-y ${typeof value} ${value === '' ? "''" : value}`, () => {
+        const serialized_data = BSON.serialize({ a: value });
+        expect(serialized_data.indexOf(Buffer.from('hello\0', 'utf8'))).to.be.greaterThan(0);
+
+        const deserialized_doc = BSON.deserialize(serialized_data);
+        expect(deserialized_doc).to.have.property('a', 'hello');
+      });
     };
 
-    // test with 0
-    var doc = {
-      a: 0
-    };
+    testToBSONFor(0);
+    testToBSONFor(NaN);
+    testToBSONFor('');
+    testToBSONFor(false);
+    if (BigInt) {
+      testToBSONFor(BigInt(0));
+    }
 
-    // serialize / deserialize
-    var serialized_data = BSON.serialize(doc, false, true);
-    var deserialized_doc = BSON.deserialize(serialized_data);
-    expect('hello').to.deep.equal(deserialized_doc.a);
+    it('should use toBSON on false-y number in calculateObjectSize', () => {
+      // Normally is 20 bytes
+      // int32 0x04 'a\x00'
+      //   int32 0x10 '0\x00' int32 \0
+      // \0
+      // ---------
+      // with toBSON is 26 bytes (hello + null)
+      // int32 0x04 'a\x00'
+      //   int32 0x02 '0\x00' int32 'hello\0' \0
+      // \0
+      const sizeNestedToBSON = BSON.calculateObjectSize({ a: [0] });
+      expect(sizeNestedToBSON).to.equal(26);
+    });
+  });
 
-    done();
+  it('should use toBSON in calculateObjectSize', () => {
+    const sizeTopLvlToBSON = BSON.calculateObjectSize({ toBSON: () => ({ a: 1 }) });
+    const sizeOfWhatToBSONReturns = BSON.calculateObjectSize({ a: 1 });
+    expect(sizeOfWhatToBSONReturns).to.equal(12);
+    expect(sizeTopLvlToBSON).to.equal(12);
+
+    const toBSONAsAKeySize = BSON.calculateObjectSize({ toBSON: { a: 1 } });
+    expect(toBSONAsAKeySize).to.equal(25);
+  });
+
+  it('should serialize to a key for non-function values', () => {
+    // int32 0x10 'toBSON\x00' int32 \0
+    const size = BSON.calculateObjectSize({ toBSON: 1 });
+    expect(size).to.equal(17);
+
+    const bytes = BSON.serialize({ toBSON: 1 });
+    expect(bytes.indexOf(Buffer.from('toBSON\0', 'utf8'))).to.be.greaterThan(0);
+  });
+
+  it('should still be omitted if serializeFunctions is true', () => {
+    const bytes = BSON.serialize(
+      { toBSON: () => ({ a: 1, fn: () => ({ a: 1 }) }) },
+      { serializeFunctions: true }
+    );
+    expect(bytes.indexOf(Buffer.from('a\0', 'utf8'))).to.be.greaterThan(0);
+    const doc = BSON.deserialize(bytes);
+    expect(doc).to.have.property('a', 1);
+    expect(doc).to.have.property('fn').that.is.instanceOf(BSON.Code);
   });
 });

--- a/test/node/to_bson_test.js
+++ b/test/node/to_bson_test.js
@@ -1,4 +1,3 @@
-/* globals BigInt */
 'use strict';
 
 const BSON = require('../register-bson');
@@ -131,15 +130,15 @@ describe('toBSON', function () {
     done();
   });
 
-  it('Should not fail with properly extended BigInt prototype', function (done) {
+  it('Should not fail with properly extended primitive wrapper object', function (done) {
     // extend BigInt prototype
-    BigInt.prototype.toBSON = function () {
+    Number.prototype.toBSON = function () {
       return 'hello';
     };
 
-    // test with 0n
+    // test with 0
     var doc = {
-      a: BigInt(0)
+      a: 0
     };
 
     // serialize / deserialize
@@ -147,27 +146,6 @@ describe('toBSON', function () {
     var deserialized_doc = BSON.deserialize(serialized_data);
     expect('hello').to.deep.equal(deserialized_doc.a);
 
-    // remove prototype extension intended for test
-    delete BigInt.prototype.toBSON;
-
-    done();
-  });
-
-  // by default, bigint is not supported
-  it('Should fail with unsupported primitive bigint', function (done) {
-    var doc = {
-      a: BigInt(0)
-    };
-
-    var test = false;
-
-    try {
-      BSON.serialize(doc, false, true);
-    } catch (err) {
-      test = true;
-    }
-
-    expect(true).to.equal(test);
     done();
   });
 });


### PR DESCRIPTION
### Description
In the serializer, when it comes to check for an override value (`toBSON`), changing  the `value` check to compare with `null` and `undefined` instead of relying on the truthiness of `value`.

#### What is the motivation for this change?
Cannot extend BigInt prototype with`.toBSON()` since `0n === false`

trying to make this work
```ts
BigInt.prototype.toBSON = function() {
    return Long.fromBits(Number(this.valueOf() & BigInt(0xffffffff)),
        Number(this.valueOf() >> BigInt(32)))
}

// src/parser/serializer.ts:769
// Is there an override value
if(value && value.toBSON){
    // this won't go through if value === 0n
    ...
}

...

// then trows error here since value hasn't been overidden
// src/parser/serializer.ts:779
else if (typeof value === 'bigint') {
    throw new BSONTypeError('Unsupported type BigInt, please use Decimal128');
}
```
