### PR TITLE
fix(NODE-3962): correct type for ObjectiId._bsontype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bson",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^5.6.0"

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -28,7 +28,7 @@ const kId = Symbol('id');
  * @public
  */
 export class ObjectId {
-  _bsontype!: 'ObjectId';
+  _bsontype!: 'ObjectID';
 
   /** @internal */
   static index = Math.floor(Math.random() * 0xffffff);

--- a/test/node/type_identifier_tests.js
+++ b/test/node/type_identifier_tests.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const {
+  Binary,
+  Code,
+  DBRef,
+  Decimal128,
+  Double,
+  Int32,
+  Long,
+  MaxKey,
+  MinKey,
+  ObjectId,
+  BSONRegExp,
+  BSONSymbol,
+  Timestamp,
+  UUID
+} = require('../register-bson');
+
+describe('_bsontype identifier', () => {
+  // The two out of the norm types:
+  it('should be equal to ObjectID for ObjectId', () => {
+    expect(ObjectId.prototype._bsontype).to.equal('ObjectID');
+  });
+  it('should be equal to Symbol for BSONSymbol', () => {
+    expect(BSONSymbol.prototype._bsontype).to.equal('Symbol');
+  });
+  it('should be equal to Timestamp for Timestamp', () => {
+    // TODO(NODE-2624): Make Timestamp hold its long value on a property rather than be a subclass
+    // Timestamp overrides the value in its constructor
+    const timestamp = new Timestamp({ i: 0, t: 0 });
+    expect(timestamp._bsontype).to.equal('Timestamp');
+    expect(Object.getPrototypeOf(timestamp)._bsontype).to.equal('Long');
+  });
+
+  // All equal to their constructor names
+  it('should be equal to Binary for Binary', () => {
+    expect(Binary.prototype._bsontype).to.equal('Binary');
+  });
+  it('should be equal to Code for Code', () => {
+    expect(Code.prototype._bsontype).to.equal('Code');
+  });
+  it('should be equal to DBRef for DBRef', () => {
+    expect(DBRef.prototype._bsontype).to.equal('DBRef');
+  });
+  it('should be equal to Decimal128 for Decimal128', () => {
+    expect(Decimal128.prototype._bsontype).to.equal('Decimal128');
+  });
+  it('should be equal to Double for Double', () => {
+    expect(Double.prototype._bsontype).to.equal('Double');
+  });
+  it('should be equal to Int32 for Int32', () => {
+    expect(Int32.prototype._bsontype).to.equal('Int32');
+  });
+  it('should be equal to Long for Long', () => {
+    expect(Long.prototype._bsontype).to.equal('Long');
+  });
+  it('should be equal to MaxKey for MaxKey', () => {
+    expect(MaxKey.prototype._bsontype).to.equal('MaxKey');
+  });
+  it('should be equal to MinKey for MinKey', () => {
+    expect(MinKey.prototype._bsontype).to.equal('MinKey');
+  });
+  it('should be equal to BSONRegExp for BSONRegExp', () => {
+    expect(BSONRegExp.prototype._bsontype).to.equal('BSONRegExp');
+  });
+  it('should be equal to UUID for UUID', () => {
+    expect(UUID.prototype._bsontype).to.equal('UUID');
+  });
+});

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -50,3 +50,27 @@ expectError(MaxKey.prototype.toJSON);
 expectError(MinKey.prototype.toJSON);
 expectError(Long.prototype.toJSON);
 expectError(BSONRegExp.prototype.toJSON);
+
+// ObjectID uses a capital for backwards compatibility
+expectType<'ObjectID'>(ObjectId.prototype._bsontype)
+// BSONSymbol was renamed to not conflict with the global JS Symbol
+// but its _bsontype is still 'Symbol'
+expectType<'Symbol'>(BSONSymbol.prototype._bsontype)
+
+// We hack TS to say that the prototype has _bsontype='Timestamp'
+// but it actually is _bsontype='Long', inside the Timestamp constructor
+// we override the property on the instance
+// TODO(NODE-2624): Make Timestamp hold its long value on a property rather than be a subclass
+expectType<'Timestamp'>(Timestamp.prototype._bsontype)
+
+expectType<'Binary'>(Binary.prototype._bsontype)
+expectType<'Code'>(Code.prototype._bsontype)
+expectType<'DBRef'>(DBRef.prototype._bsontype)
+expectType<'Decimal128'>(Decimal128.prototype._bsontype)
+expectType<'Double'>(Double.prototype._bsontype)
+expectType<'Int32'>(Int32.prototype._bsontype)
+expectType<'Long'>(Long.prototype._bsontype)
+expectType<'MaxKey'>(MaxKey.prototype._bsontype)
+expectType<'MinKey'>(MinKey.prototype._bsontype)
+expectType<'BSONRegExp'>(BSONRegExp.prototype._bsontype)
+expectType<'UUID'>(UUID.prototype._bsontype)


### PR DESCRIPTION
### Description

#### What is changing?

The type information for ObjectId._bsontype had the wrong capitalization. Runtime value is still correct.

Also added runtime and type tests to prevent regressions.

#### What is the motivation for this change?

It's a bug 🐛

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
