### PR TITLE
fix(MONGOSH-1155): update error message in ObjectId class

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -84,7 +84,7 @@ export class ObjectId {
         this[kId] = Buffer.from(workingId, 'hex');
       } else {
         throw new BSONTypeError(
-          'Argument passed in must be a string of 12 bytes or a string of 24 hex characters'
+          'Argument passed in must be a string of 12 bytes or a string of 24 hex characters or an integer'
         );
       }
     } else {


### PR DESCRIPTION
#### What is changing?
The error message when creating a new `ObjectId()` object with bad parameter.

#### What is the motivation for this change?
https://jira.mongodb.org/browse/MONGOSH-1155

### Double check the following

- [X] Ran `npm run lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [X] Changes are covered by tests
