### PR TITLE
chore: add typesversion to package.json && bump downlevel-dts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bson",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^5.6.0"
@@ -26,7 +26,7 @@
         "array-includes": "^3.1.3",
         "benchmark": "^2.1.4",
         "chai": "^4.2.0",
-        "downlevel-dts": "^0.7.0",
+        "downlevel-dts": "^0.9.0",
         "eslint": "^7.7.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.4",
@@ -3718,14 +3718,14 @@
       }
     },
     "node_modules/downlevel-dts": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.7.0.tgz",
-      "integrity": "sha512-tcjGqElN0/oad/LJBlaxmZ3zOYEQOBbGuirKzif8s1jeRiWBdNX9H6OBFlRjOQkosXgV+qSjs4osuGCivyZ4Jw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.9.0.tgz",
+      "integrity": "sha512-XDYaZ7yY4yPLlNx3txbYRzUF6WiElAgMJQ/ACIaZnKISwuWw2eAHD7Ecp3u60ntej6i1yaMtjsN02hhA4FakFw==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.2",
         "shelljs": "^0.8.3",
-        "typescript": "^4.1.0-dev.20201026"
+        "typescript": "^4.5.5"
       },
       "bin": {
         "downlevel-dts": "index.js"
@@ -3744,6 +3744,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/downlevel-dts/node_modules/typescript": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/ee-first": {
@@ -12235,14 +12248,14 @@
       }
     },
     "downlevel-dts": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.7.0.tgz",
-      "integrity": "sha512-tcjGqElN0/oad/LJBlaxmZ3zOYEQOBbGuirKzif8s1jeRiWBdNX9H6OBFlRjOQkosXgV+qSjs4osuGCivyZ4Jw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.9.0.tgz",
+      "integrity": "sha512-XDYaZ7yY4yPLlNx3txbYRzUF6WiElAgMJQ/ACIaZnKISwuWw2eAHD7Ecp3u60ntej6i1yaMtjsN02hhA4FakFw==",
       "dev": true,
       "requires": {
         "semver": "^7.3.2",
         "shelljs": "^0.8.3",
-        "typescript": "^4.1.0-dev.20201026"
+        "typescript": "^4.5.5"
       },
       "dependencies": {
         "semver": {
@@ -12253,6 +12266,12 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "typescript": {
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+          "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,13 @@
     "bower.json"
   ],
   "types": "bson.d.ts",
+  "typesVersions": {
+    "<=4.0.2": {
+      "bson.d.ts": [
+        "bson.ts34.d.ts"
+      ]
+    }
+  },
   "version": "4.6.2",
   "author": {
     "name": "The MongoDB NodeJS Team",
@@ -41,7 +48,7 @@
     "array-includes": "^3.1.3",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",
-    "downlevel-dts": "^0.7.0",
+    "downlevel-dts": "^0.9.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
@@ -99,7 +106,7 @@
     "test-tsd": "npm run build:dts && tsd",
     "test-browser": "node --max-old-space-size=4096 ./node_modules/.bin/karma start karma.conf.js",
     "build:ts": "tsc",
-    "build:dts": "npm run build:ts && api-extractor run --typescript-compiler-folder node_modules/typescript --local && rimraf 'lib/**/*.d.ts*' && downlevel-dts bson.d.ts bson.d.ts",
+    "build:dts": "npm run build:ts && api-extractor run --typescript-compiler-folder node_modules/typescript --local && rimraf 'lib/**/*.d.ts*' && downlevel-dts bson.d.ts bson-ts34.d.ts",
     "build:bundle": "rollup -c rollup.config.js",
     "build": "npm run build:dts && npm run build:bundle",
     "lint": "eslint -v && eslint --ext '.js,.ts' --max-warnings=0 src test && tsc -v && tsc --noEmit && npm run test-tsd",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dist",
     "bson.d.ts",
     "etc/prepare.js",
-    "bower.json"
+    "bower.json",
+    "bson.ts34.d.ts"
   ],
   "types": "bson.d.ts",
   "typesVersions": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "src",
     "dist",
     "bson.d.ts",
+    "bson-ts34.d.ts",
     "etc/prepare.js",
-    "bower.json",
-    "bson.ts34.d.ts"
+    "bower.json"
   ],
   "types": "bson.d.ts",
   "typesVersions": {


### PR DESCRIPTION
### Description

#### What is changing?

- downlevel-dts is bumped to the newest version
- a `typesVersion` is added to the package.json, so users on newer versions of TS are not using the output of downlevel-dts

##### Is there new documentation needed for these changes?

No.
