### PR TITLE
fix(NODE-4302): typo in typesVersions filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "typesVersions": {
     "<=4.0.2": {
       "bson.d.ts": [
-        "bson.ts34.d.ts"
+        "bson-ts34.d.ts"
       ]
     }
   },


### PR DESCRIPTION
### Description

Older versions of TypeScript aren't working since https://github.com/mongodb/js-bson/pull/494#issue-1178148345 (BSON parser >= 4.6.3):
```
error TS7016: Could not find a declaration file for module 'bson'. 'node_modules/bson/lib/bson.js' implicitly has an 'any' type.
```

Looks like one instance was missed in https://github.com/mongodb/js-bson/pull/494/commits/740ce301ad77bfd6924b8e447907b92a40953783.

#### What is changing?

The `typesVersions` filename, so older versions of TypeScript can find the declaration file.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

I ran into this editing unrelated types on DefinitelyTyped that have a transitive dependency on BSON parser and are automatically tested on older versions of TypeScript. This typo causes that automation to complain, blocking edits to those transitively-dependent types.