### PR TITLE
fix(NODE-4211): Do not require crypto in browser builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bson",
-      "version": "4.6.3",
+      "version": "4.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^5.6.0"
@@ -20,6 +20,7 @@
         "@rollup/plugin-commonjs": "^15.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^9.0.0",
+        "@rollup/plugin-replace": "^4.0.0",
         "@rollup/plugin-typescript": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^3.10.1",
         "@typescript-eslint/parser": "^3.10.1",
@@ -1943,6 +1944,19 @@
       },
       "peerDependencies": {
         "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -10896,6 +10910,16 @@
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
       }
     },
     "@rollup/plugin-typescript": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
+    "@rollup/plugin-replace": "^4.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,7 +43,7 @@ const plugins = (options = { browser: false }) => {
     replace({
       preventAssignment: true,
       values: {
-        'rollupProcess.browser': options.browser
+        'process.browser': options.browser
       }
     }),
     commonjs({ extensions: ['.js', '.ts'] }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { babel } from '@rollup/plugin-babel';
 import typescript from '@rollup/plugin-typescript';
 import nodeGlobals from 'rollup-plugin-node-globals';
+import replace from '@rollup/plugin-replace';
 
 const tsConfig = {
   allowJs: false,
@@ -33,18 +34,26 @@ const tsConfig = {
 };
 const input = 'src/bson.ts';
 
-const plugins = [
-  typescript(tsConfig),
-  nodeResolve({ preferBuiltins: false }),
-  nodeBuiltins(),
-  nodeGlobals(),
-  commonjs({ extensions: ['.js', '.ts'] }),
-  babel({
-    babelHelpers: 'external',
-    plugins: ['@babel/plugin-external-helpers'],
-    presets: [['@babel/env', { modules: false }]]
-  })
-];
+const plugins = ({ browser = false }) => {
+  return [
+    typescript(tsConfig),
+    nodeResolve({ preferBuiltins: false }),
+    nodeBuiltins(),
+    nodeGlobals(),
+    replace({
+      preventAssignment: true,
+      values: {
+        'process.browser': browser
+      }
+    }),
+    commonjs({ extensions: ['.js', '.ts'] }),
+    babel({
+      babelHelpers: 'external',
+      plugins: ['@babel/plugin-external-helpers'],
+      presets: [['@babel/env', { modules: false }]]
+    })
+  ];
+};
 
 const external = Object.keys(pkg.dependencies || {});
 
@@ -60,7 +69,7 @@ module.exports = [
       exports: 'named',
       sourcemap: true
     },
-    plugins,
+    plugins: plugins({ browser: false }),
     external
   },
   {
@@ -88,6 +97,6 @@ module.exports = [
         sourcemap: true
       }
     ],
-    plugins
+    plugins: plugins({ browser: true })
   }
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,7 @@ const tsConfig = {
 };
 const input = 'src/bson.ts';
 
-const plugins = ({ browser = false }) => {
+const plugins = (options = { browser: false }) => {
   return [
     typescript(tsConfig),
     nodeResolve({ preferBuiltins: false }),
@@ -43,7 +43,7 @@ const plugins = ({ browser = false }) => {
     replace({
       preventAssignment: true,
       values: {
-        'rollupProcess.browser': browser
+        'rollupProcess.browser': options.browser
       }
     }),
     commonjs({ extensions: ['.js', '.ts'] }),
@@ -69,7 +69,7 @@ module.exports = [
       exports: 'named',
       sourcemap: true
     },
-    plugins: plugins({ browser: false }),
+    plugins: plugins(),
     external
   },
   {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,7 +43,7 @@ const plugins = ({ browser = false }) => {
     replace({
       preventAssignment: true,
       values: {
-        'process.browser': browser
+        'rollupProcess.browser': browser
       }
     }),
     commonjs({ extensions: ['.js', '.ts'] }),

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -35,10 +35,10 @@ declare let require: Function;
 declare let global: any;
 declare const self: unknown;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare let rollupProcess: any; // Used by @rollup/plugin-replace
+declare let process: any; // Used by @rollup/plugin-replace
 
 const detectRandomBytes = (): RandomBytesFunction => {
-  if (rollupProcess.browser) {
+  if (process.browser) {
     if (typeof window !== 'undefined') {
       // browser crypto implementation(s)
       const target = window.crypto || window.msCrypto; // allow for IE11

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -35,10 +35,10 @@ declare let require: Function;
 declare let global: any;
 declare const self: unknown;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare let process: any; // Used by @rollup/plugin-replace
+declare let rollupProcess: any; // Used by @rollup/plugin-replace
 
 const detectRandomBytes = (): RandomBytesFunction => {
-  if (process.browser) {
+  if (rollupProcess.browser) {
     if (typeof window !== 'undefined') {
       // browser crypto implementation(s)
       const target = window.crypto || window.msCrypto; // allow for IE11


### PR DESCRIPTION
### Description

#### What is changing?

This adds the `@rollup/plugin-replace` plugin, which is used to set a `process.browser` variable, to allow Rollup to create different builds for Node.js and browsers.

The check for `process.browser` was added to the `detectRandomBytes` function, which should now only require `crypto` in the js bundle, when `process.browser` was set to false while Rollup was running.

##### Is there new documentation needed for these changes?

I don't think so.

#### What is the motivation for this change?

The issue fixed by this change is described over here: https://jira.mongodb.org/browse/NODE-4211

```
WARNING in ./node_modules/bson/dist/bson.browser.esm.js 2196:26-55
Module not found: Error: Can't resolve 'crypto' in '/Users/rvanmil/Development/ctac-web-app-e2e-monitoring/node_modules/bson/dist'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.
```
