### PR TITLE
fix(NODE-4302): remove downlevel ts and typesVersions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -80,6 +80,19 @@ functions:
           ${PREPARE_SHELL}
           echo "NODE_VERSION=${NODE_VERSION} TEST_TARGET=${TEST_TARGET}"
           bash ${PROJECT_DIRECTORY}/.evergreen/run-checks.sh
+  run typescript:
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src
+        timeout_secs: 60
+        env:
+          PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+          TS_VERSION: "${TS_VERSION}"
+          TRY_COMPILING_LIBRARY: "${TRY_COMPILING_DRIVER}"
+        binary: bash
+        args:
+          - ${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh
 
 tasks:
   - name: node-tests-v6
@@ -161,6 +174,36 @@ tasks:
           NODE_MAJOR_VERSION: 16
       - func: install dependencies
       - func: run checks
+  - name: check-typescript-oldest
+    commands:
+      - func: fetch source
+        vars:
+          NODE_MAJOR_VERSION: 16
+      - func: install dependencies
+      - func: "run typescript"
+        vars:
+          TS_VERSION: "4.0.2"
+          TRY_COMPILING_LIBRARY: "true"
+  - name: check-typescript-current
+    commands:
+      - func: fetch source
+        vars:
+          NODE_MAJOR_VERSION: 16
+      - func: install dependencies
+      - func: "run typescript"
+        vars:
+          TS_VERSION: ""
+          TRY_COMPILING_LIBRARY: "true"
+  - name: check-typescript-next
+    commands:
+      - func: fetch source
+        vars:
+          NODE_MAJOR_VERSION: 16
+      - func: install dependencies
+      - func: "run typescript"
+        vars:
+          TS_VERSION: "next"
+          TRY_COMPILING_LIBRARY: "false"
 
 buildvariants:
   - name: linux
@@ -180,3 +223,6 @@ buildvariants:
     run_on: rhel70
     tasks:
       - run-checks
+      - check-typescript-oldest
+      - check-typescript-current
+      - check-typescript-next

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -89,7 +89,7 @@ functions:
         env:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           TS_VERSION: "${TS_VERSION}"
-          TRY_COMPILING_LIBRARY: "${TRY_COMPILING_DRIVER}"
+          TRY_COMPILING_LIBRARY: "${TRY_COMPILING_LIBRARY}"
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh

--- a/.evergreen/init-nvm.sh
+++ b/.evergreen/init-nvm.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
+NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
+export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+
+if [[ "$OS" == "Windows_NT" ]]; then
+    NVM_HOME=$(cygpath -w "$NVM_DIR")
+    export NVM_HOME
+    NVM_SYMLINK=$(cygpath -w "$NODE_ARTIFACTS_PATH/bin")
+    export NVM_SYMLINK
+    NVM_ARTIFACTS_PATH=$(cygpath -w "$NODE_ARTIFACTS_PATH/bin")
+    export NVM_ARTIFACTS_PATH
+    PATH=$(cygpath $NVM_SYMLINK):$(cygpath $NVM_HOME):$PATH
+    export PATH
+    echo "updated path on windows PATH=$PATH"
+else
+    [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+fi
+
+export NODE_OPTIONS="--trace-deprecation --trace-warnings"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -4,7 +4,6 @@ if [ -z "$NODE_VERSION" ]; then
   exit 1
 fi
 
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"

--- a/.evergreen/run-typescript.sh
+++ b/.evergreen/run-typescript.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -o errexit # Exit the script with error if any of the commands fail
+
+# source "${PROJECT_DIRECTORY}/.evergreen/init-nvm.sh"
+
+set -o xtrace
+
+function get_current_ts_version {
+    node -e "console.log(require('./package-lock.json').dependencies.typescript.version)"
+}
+
+CURRENT_TS_VERSION=$(get_current_ts_version)
+
+export TSC="./node_modules/typescript/bin/tsc"
+export TS_VERSION=${TS_VERSION:=$CURRENT_TS_VERSION}
+
+npm install --no-save --force typescript@"$TS_VERSION"
+
+echo "Typescript $($TSC -v)"
+
+# check resolution uses the default latest types
+echo "import * as BSON from '.'" > file.ts && node $TSC --noEmit --traceResolution file.ts | grep 'bson.d.ts' && rm file.ts
+
+# check compilation
+rm -rf node_modules/@types/eslint # not a dependency we use, but breaks the build :(
+node $TSC bson.d.ts
+
+if [[ $TRY_COMPILING_LIBRARY != "false" ]]; then
+    npm run build:ts
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bson",
-      "version": "4.6.3",
+      "version": "4.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^5.6.0"
@@ -26,7 +26,6 @@
         "array-includes": "^3.1.3",
         "benchmark": "^2.1.4",
         "chai": "^4.2.0",
-        "downlevel-dts": "^0.9.0",
         "eslint": "^7.7.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.4",
@@ -50,7 +49,7 @@
         "rollup-plugin-polyfill-node": "^0.7.0",
         "standard-version": "^9.3.0",
         "ts-node": "^9.0.0",
-        "tsd": "^0.17.0",
+        "tsd": "^0.20.0",
         "typedoc": "^0.21.2",
         "typescript": "^4.0.2",
         "typescript-cached-transpile": "0.0.6",
@@ -2059,9 +2058,9 @@
       }
     },
     "node_modules/@tsd/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-Xwxv8bIwyI3ggPz9bwoWEoiaz79MJs+VGf27S1N2tapfDVo60Lz741j5diL9RwszZSXt6IkTAuw7Lai7jSXRJg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-+9o716aWbcjKLbV4bCrGlJKJbS0UZNogfVk9U7ffooYSf/9GOJ6wwahTSrRjW7mWQdywQ/sIg9xxbuPLnkmhwg==",
       "dev": true,
       "bin": {
         "tsc": "typescript/bin/tsc",
@@ -3717,48 +3716,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/downlevel-dts": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.9.0.tgz",
-      "integrity": "sha512-XDYaZ7yY4yPLlNx3txbYRzUF6WiElAgMJQ/ACIaZnKISwuWw2eAHD7Ecp3u60ntej6i1yaMtjsN02hhA4FakFw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.3.2",
-        "shelljs": "^0.8.3",
-        "typescript": "^4.5.5"
-      },
-      "bin": {
-        "downlevel-dts": "index.js"
-      }
-    },
-    "node_modules/downlevel-dts/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/downlevel-dts/node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5352,15 +5309,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/irregular-plurals": {
@@ -7542,18 +7490,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7956,23 +7892,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/shiki": {
@@ -8831,13 +8750,13 @@
       }
     },
     "node_modules/tsd": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.17.0.tgz",
-      "integrity": "sha512-+HUwya2NgoP/g9t2gRCC3I8VtGu65NgG9Lv75vNzMaxjMFo+0VXF9c4sj3remSzJYeBHLNKzWMbFOinPqrL20Q==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.20.0.tgz",
+      "integrity": "sha512-iba/JlyT3qtnA9t8VrX2Fipu3L31U48oRIf1PNs+lIwQ7n63GTkt9eQlB5bLtfb7nYfy9t8oZzs+K4QEoEIS8Q==",
       "dev": true,
       "dependencies": {
-        "@tsd/typescript": "~4.3.2",
-        "eslint-formatter-pretty": "^4.0.0",
+        "@tsd/typescript": "~4.6.3",
+        "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
         "meow": "^9.0.0",
         "path-exists": "^4.0.0",
@@ -10990,9 +10909,9 @@
       }
     },
     "@tsd/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-Xwxv8bIwyI3ggPz9bwoWEoiaz79MJs+VGf27S1N2tapfDVo60Lz741j5diL9RwszZSXt6IkTAuw7Lai7jSXRJg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-+9o716aWbcjKLbV4bCrGlJKJbS0UZNogfVk9U7ffooYSf/9GOJ6wwahTSrRjW7mWQdywQ/sIg9xxbuPLnkmhwg==",
       "dev": true
     },
     "@types/argparse": {
@@ -12247,34 +12166,6 @@
         }
       }
     },
-    "downlevel-dts": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.9.0.tgz",
-      "integrity": "sha512-XDYaZ7yY4yPLlNx3txbYRzUF6WiElAgMJQ/ACIaZnKISwuWw2eAHD7Ecp3u60ntej6i1yaMtjsN02hhA4FakFw==",
-      "dev": true,
-      "requires": {
-        "semver": "^7.3.2",
-        "shelljs": "^0.8.3",
-        "typescript": "^4.5.5"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "typescript": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-          "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-          "dev": true
-        }
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -13456,12 +13347,6 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
-    },
-    "interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
     },
     "irregular-plurals": {
       "version": "3.3.0",
@@ -15130,15 +15015,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -15466,17 +15342,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
     },
     "shiki": {
       "version": "0.9.5",
@@ -16150,13 +16015,13 @@
       }
     },
     "tsd": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.17.0.tgz",
-      "integrity": "sha512-+HUwya2NgoP/g9t2gRCC3I8VtGu65NgG9Lv75vNzMaxjMFo+0VXF9c4sj3remSzJYeBHLNKzWMbFOinPqrL20Q==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.20.0.tgz",
+      "integrity": "sha512-iba/JlyT3qtnA9t8VrX2Fipu3L31U48oRIf1PNs+lIwQ7n63GTkt9eQlB5bLtfb7nYfy9t8oZzs+K4QEoEIS8Q==",
       "dev": true,
       "requires": {
-        "@tsd/typescript": "~4.3.2",
-        "eslint-formatter-pretty": "^4.0.0",
+        "@tsd/typescript": "~4.6.3",
+        "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
         "meow": "^9.0.0",
         "path-exists": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,6 @@
     "bower.json"
   ],
   "types": "bson.d.ts",
-  "typesVersions": {
-    "<=4.0.2": {
-      "bson.d.ts": [
-        "bson.ts34.d.ts"
-      ]
-    }
-  },
   "version": "4.6.4",
   "author": {
     "name": "The MongoDB NodeJS Team",
@@ -49,7 +42,6 @@
     "array-includes": "^3.1.3",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",
-    "downlevel-dts": "^0.9.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
@@ -73,7 +65,7 @@
     "rollup-plugin-polyfill-node": "^0.7.0",
     "standard-version": "^9.3.0",
     "ts-node": "^9.0.0",
-    "tsd": "^0.17.0",
+    "tsd": "^0.20.0",
     "typedoc": "^0.21.2",
     "typescript": "^4.0.2",
     "typescript-cached-transpile": "0.0.6",
@@ -107,7 +99,7 @@
     "test-tsd": "npm run build:dts && tsd",
     "test-browser": "node --max-old-space-size=4096 ./node_modules/.bin/karma start karma.conf.js",
     "build:ts": "tsc",
-    "build:dts": "npm run build:ts && api-extractor run --typescript-compiler-folder node_modules/typescript --local && rimraf 'lib/**/*.d.ts*' && downlevel-dts bson.d.ts bson-ts34.d.ts",
+    "build:dts": "npm run build:ts && api-extractor run --typescript-compiler-folder node_modules/typescript --local && rimraf 'lib/**/*.d.ts*'",
     "build:bundle": "rollup -c rollup.config.js",
     "build": "npm run build:dts && npm run build:bundle",
     "lint": "eslint -v && eslint --ext '.js,.ts' --max-warnings=0 src test && tsc -v && tsc --noEmit && npm run test-tsd",


### PR DESCRIPTION
### Description

#### What is changing?

Remove downlevel-dts and test public types / compiling src against old/current/next TS versions

oldest version is set to TS v4.0.2 (there is no 4.0.0)

#### What is the motivation for this change?

downlevel-dts isn't providing any needed changes to the types

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
