### PR TITLE
docs(NODE-4349): add note about Binary(string) behavior

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -64,13 +64,13 @@ export class Binary {
   /**
    * Create a new Binary instance.
    *
+   * This constructor can accept a string as its first argument. In this case,
+   * this string will be encoded using ISO-8859-1, **not** using UTF-8.
+   * This is almost certainly not what you want. Use `new Binary(Buffer.from(string))`
+   * instead to convert the string to a Buffer using UTF-8 first.
+   *
    * @param buffer - a buffer object containing the binary data.
    * @param subType - the option binary type.
-   *
-   * @note This constructor can accept a string as its first argument. In this case,
-   *       this string will be encoded using ISO-8859-1, **not** using UTF-8.
-   *       This is almost certainly not what you want. Use `new Binary(Buffer.from(string))`
-   *       instead to convert the string to a Buffer using UTF-8 first.
    */
   constructor(buffer?: string | BinarySequence, subType?: number) {
     if (!(this instanceof Binary)) return new Binary(buffer, subType);

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -62,8 +62,15 @@ export class Binary {
   position!: number;
 
   /**
+   * Create a new Binary instance.
+   *
    * @param buffer - a buffer object containing the binary data.
    * @param subType - the option binary type.
+   *
+   * @note This constructor can accept a string as its first argument. In this case,
+   *       this string will be encoded using ISO-8859-1, **not** using UTF-8.
+   *       This is almost certainly not what you want. Use `new Binary(Buffer.from(string))`
+   *       instead to convert the string to a Buffer using UTF-8 first.
    */
   constructor(buffer?: string | BinarySequence, subType?: number) {
     if (!(this instanceof Binary)) return new Binary(buffer, subType);


### PR DESCRIPTION
### Description

#### What is changing?

Adds a note that Binary(string) is probably not what you want unless you really know what you’re doing.

(This was inspired by old Compass code getting this wrong in at least one place.)

##### Is there new documentation needed for these changes?

This is a doc change.

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
