### PR TITLE
fix(NODE-4381): handle `__proto__` well in EJSON

### DIFF
--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -285,7 +285,17 @@ function serializeDocument(doc: any, options: EJSONSerializeOptions) {
     for (const name in doc) {
       options.seenObjects.push({ propertyName: name, obj: null });
       try {
-        _doc[name] = serializeValue(doc[name], options);
+        const value = serializeValue(doc[name], options);
+        if (name === '__proto__') {
+          Object.defineProperty(_doc, name, {
+            value,
+            writable: true,
+            enumerable: true,
+            configurable: true
+          });
+        } else {
+          _doc[name] = value;
+        }
       } finally {
         options.seenObjects.pop();
       }

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1776,7 +1776,12 @@ describe('BSON', function () {
     assertBuffersEqual(done, serialized_data, serialized_data2, 0);
 
     var doc1 = BSON.deserialize(serialized_data);
-    expect(Object.getOwnPropertyDescriptor(doc1, '__proto__').enumerable).to.equal(true);
+    expect(doc1).to.have.deep.ownPropertyDescriptor('__proto__', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: { a: 42 }
+    });
     expect(doc1.__proto__.a).to.equal(42);
     done();
   });

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -509,7 +509,7 @@ describe('Extended JSON', function () {
     // expect(() => EJSON.serialize(badMap)).to.throw(); // uncomment when EJSON supports ES6 Map
   });
 
-  it('should correctly deserialize objects containing __proto__ keys', function (done) {
+  it('should correctly deserialize objects containing __proto__ keys', function () {
     const original = { ['__proto__']: { a: 42 } };
     const serialized = EJSON.stringify(original);
     expect(serialized).to.equal('{"__proto__":{"a":42}}');
@@ -521,7 +521,6 @@ describe('Extended JSON', function () {
       value: { a: 42 }
     });
     expect(deserialized.__proto__.a).to.equal(42);
-    done();
   });
 
   context('circular references', () => {

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -509,6 +509,16 @@ describe('Extended JSON', function () {
     // expect(() => EJSON.serialize(badMap)).to.throw(); // uncomment when EJSON supports ES6 Map
   });
 
+  it('should correctly deserialize objects containing __proto__ keys', function (done) {
+    const original = { ['__proto__']: { a: 42 } };
+    const serialized = EJSON.stringify(original);
+    expect(serialized).to.equal('{"__proto__":{"a":42}}');
+    const deserialized = EJSON.parse(serialized);
+    expect(Object.getOwnPropertyDescriptor(deserialized, '__proto__').enumerable).to.equal(true);
+    expect(deserialized.__proto__.a).to.equal(42);
+    done();
+  });
+
   context('circular references', () => {
     it('should throw a helpful error message for input with circular references', function () {
       const obj = {

--- a/test/node/extended_json_tests.js
+++ b/test/node/extended_json_tests.js
@@ -514,7 +514,12 @@ describe('Extended JSON', function () {
     const serialized = EJSON.stringify(original);
     expect(serialized).to.equal('{"__proto__":{"a":42}}');
     const deserialized = EJSON.parse(serialized);
-    expect(Object.getOwnPropertyDescriptor(deserialized, '__proto__').enumerable).to.equal(true);
+    expect(deserialized).to.have.deep.ownPropertyDescriptor('__proto__', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: { a: 42 }
+    });
     expect(deserialized.__proto__.a).to.equal(42);
     done();
   });


### PR DESCRIPTION
### Description

#### What is changing?

Similar fix and similar test as f34cabc31e66, just for
EJSON serialization instead of BSON deserialization.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Aligning behavior with regular JSON.
<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
