### PR TITLE
chore(NODE-4401): enable isolatedModules tsc compiler option

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -21,8 +21,8 @@ import { BSONRegExp } from './regexp';
 import { BSONSymbol } from './symbol';
 import { Timestamp } from './timestamp';
 import { UUID } from './uuid';
-export { BinaryExtended, BinaryExtendedLegacy, BinarySequence } from './binary';
-export { CodeExtended } from './code';
+export type { BinaryExtended, BinaryExtendedLegacy, BinarySequence } from './binary';
+export type { CodeExtended } from './code';
 export {
   BSON_BINARY_SUBTYPE_BYTE_ARRAY,
   BSON_BINARY_SUBTYPE_DEFAULT,
@@ -59,25 +59,21 @@ export {
   BSON_INT64_MAX,
   BSON_INT64_MIN
 } from './constants';
-export { DBRefLike } from './db_ref';
-export { Decimal128Extended } from './decimal128';
-export { DoubleExtended } from './double';
-export { EJSON, EJSONOptions } from './extended_json';
-export { Int32Extended } from './int_32';
-export { LongExtended } from './long';
-export { MaxKeyExtended } from './max_key';
-export { MinKeyExtended } from './min_key';
-export { ObjectIdExtended, ObjectIdLike } from './objectid';
-export { BSONRegExpExtended, BSONRegExpExtendedLegacy } from './regexp';
-export { BSONSymbolExtended } from './symbol';
-export {
-  LongWithoutOverrides,
-  LongWithoutOverridesClass,
-  TimestampExtended,
-  TimestampOverrides
-} from './timestamp';
-export { UUIDExtended } from './uuid';
-export { SerializeOptions, DeserializeOptions };
+export type { DBRefLike } from './db_ref';
+export type { Decimal128Extended } from './decimal128';
+export type { DoubleExtended } from './double';
+export type { EJSON, EJSONOptions } from './extended_json';
+export type { Int32Extended } from './int_32';
+export type { LongExtended } from './long';
+export type { MaxKeyExtended } from './max_key';
+export type { MinKeyExtended } from './min_key';
+export type { ObjectIdExtended, ObjectIdLike } from './objectid';
+export type { BSONRegExpExtended, BSONRegExpExtendedLegacy } from './regexp';
+export type { BSONSymbolExtended } from './symbol';
+export type { LongWithoutOverrides, TimestampExtended, TimestampOverrides } from './timestamp';
+export { LongWithoutOverridesClass } from './timestamp';
+export type { UUIDExtended } from './uuid';
+export type { SerializeOptions, DeserializeOptions };
 export {
   Code,
   Map,

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -62,7 +62,8 @@ export {
 export type { DBRefLike } from './db_ref';
 export type { Decimal128Extended } from './decimal128';
 export type { DoubleExtended } from './double';
-export type { EJSON, EJSONOptions } from './extended_json';
+export type { EJSONOptions } from './extended_json';
+export { EJSON } from './extended_json';
 export type { Int32Extended } from './int_32';
 export type { LongExtended } from './long';
 export type { MaxKeyExtended } from './max_key';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     // API-extractor makes use of the declarations, npm script should be cleaning these up
     "declaration": true,
     "declarationMap": true,
-    "types": []
+    "types": [],
+    "isolatedModules": true
   },
   "ts-node": {
     "transpileOnly": true,


### PR DESCRIPTION
### Description

#### What is changing?

compiling `js-bson` with `isolatedModules` set to `true`

##### Is there new documentation needed for these changes?

no, as per https://www.typescriptlang.org/tsconfig#isolatedModules the behaviour of the code does not change

#### What is the motivation for this change?

I'm working on a feature complete port of `js-bson` for deno. Idea is to "compile" this library automatically for deno, into `bson-deno`

Current state of `bson-deno` can be reviewed here: https://github.com/thekorn/bson-deno
The "build" script is maintained in this repository: https://github.com/thekorn/deno-build-mongodb-native

The overall goal is to provide an up-to-date, feature complete version of the mongodb-native client library for deno

For tracking purposes I also created a jira ticket: https://jira.mongodb.org/browse/NODE-4401

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
