### PR TITLE
feat(NODE-4405): support serializing UUID class

### DIFF
--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -837,6 +837,8 @@ export function serializeInto(
         );
       } else if (value['_bsontype'] === 'Binary') {
         index = serializeBinary(buffer, key, value, index, true);
+      } else if (value['_bsontype'] === 'UUID') {
+        index = serializeBinary(buffer, key, value.toBinary(), index);
       } else if (value['_bsontype'] === 'Symbol') {
         index = serializeSymbol(buffer, key, value, index, true);
       } else if (value['_bsontype'] === 'DBRef') {
@@ -938,6 +940,8 @@ export function serializeInto(
         index = serializeFunction(buffer, key, value, index, checkKeys, depth, serializeFunctions);
       } else if (value['_bsontype'] === 'Binary') {
         index = serializeBinary(buffer, key, value, index);
+      } else if (value['_bsontype'] === 'UUID') {
+        index = serializeBinary(buffer, key, value.toBinary(), index);
       } else if (value['_bsontype'] === 'Symbol') {
         index = serializeSymbol(buffer, key, value, index);
       } else if (value['_bsontype'] === 'DBRef') {
@@ -1043,6 +1047,8 @@ export function serializeInto(
         index = serializeFunction(buffer, key, value, index, checkKeys, depth, serializeFunctions);
       } else if (value['_bsontype'] === 'Binary') {
         index = serializeBinary(buffer, key, value, index);
+      } else if (value['_bsontype'] === 'UUID') {
+        index = serializeBinary(buffer, key, value.toBinary(), index);
       } else if (value['_bsontype'] === 'Symbol') {
         index = serializeSymbol(buffer, key, value, index);
       } else if (value['_bsontype'] === 'DBRef') {

--- a/test/node/uuid_tests.js
+++ b/test/node/uuid_tests.js
@@ -165,21 +165,29 @@ describe('UUID', () => {
     expect(inspect(uuid)).to.equal(`new UUID("${LOWERCASE_DASH_SEPARATED_UUID_STRING}")`);
   });
 
-  it(`should serialize as a valid UUID _bsontype with Object input without error`, () => {
-    const output = BSON.serialize({ uuid: new BSON.UUID() });
-    expect(output[4]).to.equal(BSON_DATA_BINARY);
-    expect(output[14]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
-  });
+  describe('serialize', () => {
+    it('should have a valid UUID _bsontype with Object input without error', () => {
+      const output = BSON.serialize({ uuid: new BSON.UUID() });
+      expect(output[4]).to.equal(BSON_DATA_BINARY);
+      expect(output[14]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
+    });
 
-  it(`should serialize as a valid UUID _bsontype with Map input without error`, () => {
-    const output = BSON.serialize(new Map([['uuid', new BSON.UUID()]]));
-    expect(output[4]).to.equal(BSON_DATA_BINARY);
-    expect(output[14]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
-  });
+    it('should have a valid UUID _bsontype with Map input without error', () => {
+      const output = BSON.serialize(new Map([['uuid', new BSON.UUID()]]));
+      expect(output[4]).to.equal(BSON_DATA_BINARY);
+      expect(output[14]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
+    });
 
-  it(`should serialize as a valid UUID _bsontype with Array input without error`, () => {
-    const output = BSON.serialize({ a: [new BSON.UUID()] });
-    expect(output[11]).to.equal(BSON_DATA_BINARY);
-    expect(output[18]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
+    it('should have as a valid UUID _bsontype with Array input without error', () => {
+      const output = BSON.serialize({ a: [new BSON.UUID()] });
+      expect(output[11]).to.equal(BSON_DATA_BINARY);
+      expect(output[18]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
+    });
+
+    it('should serialize BSON.UUID() input the same as BSON.UUID().toBinary()', () => {
+      const toBinarySerialization = BSON.serialize({ uuid: new BSON.UUID().toBinary() });
+      const plainUUIDSerialization = BSON.serialize({ uuid: new BSON.UUID() });
+      expect(plainUUIDSerialization).to.deep.equal(toBinarySerialization);
+    }); 
   });
 });

--- a/test/node/uuid_tests.js
+++ b/test/node/uuid_tests.js
@@ -185,9 +185,10 @@ describe('UUID', () => {
     });
 
     it('should serialize BSON.UUID() input the same as BSON.UUID().toBinary()', () => {
-      const toBinarySerialization = BSON.serialize({ uuid: new BSON.UUID().toBinary() });
-      const plainUUIDSerialization = BSON.serialize({ uuid: new BSON.UUID() });
+      const exampleUUID = new BSON.UUID();
+      const toBinarySerialization = BSON.serialize({ uuid: exampleUUID.toBinary() });
+      const plainUUIDSerialization = BSON.serialize({ uuid: exampleUUID });
       expect(plainUUIDSerialization).to.deep.equal(toBinarySerialization);
-    }); 
+    });
   });
 });

--- a/test/node/uuid_tests.js
+++ b/test/node/uuid_tests.js
@@ -6,6 +6,8 @@ const { inspect } = require('util');
 const { validate: uuidStringValidate, version: uuidStringVersion } = require('uuid');
 const BSON = require('../register-bson');
 const BSONTypeError = BSON.BSONTypeError;
+const BSON_DATA_BINARY = BSON.BSON_DATA_BINARY;
+const BSON_BINARY_SUBTYPE_UUID_NEW = BSON.BSON_BINARY_SUBTYPE_UUID_NEW;
 
 // Test values
 const UPPERCASE_DASH_SEPARATED_UUID_STRING = 'AAAAAAAA-AAAA-4AAA-AAAA-AAAAAAAAAAAA';
@@ -161,5 +163,23 @@ describe('UUID', () => {
   it('should correctly allow for node.js inspect to work with UUID', () => {
     const uuid = new UUID(UPPERCASE_DASH_SEPARATED_UUID_STRING);
     expect(inspect(uuid)).to.equal(`new UUID("${LOWERCASE_DASH_SEPARATED_UUID_STRING}")`);
+  });
+
+  it(`should serialize as a valid UUID _bsontype with Object input without error`, () => {
+    const output = BSON.serialize({ uuid: new BSON.UUID() });
+    expect(output[4]).to.equal(BSON_DATA_BINARY);
+    expect(output[14]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
+  });
+
+  it(`should serialize as a valid UUID _bsontype with Map input without error`, () => {
+    const output = BSON.serialize(new Map([['uuid', new BSON.UUID()]]));
+    expect(output[4]).to.equal(BSON_DATA_BINARY);
+    expect(output[14]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
+  });
+
+  it(`should serialize as a valid UUID _bsontype with Array input without error`, () => {
+    const output = BSON.serialize({ a: [new BSON.UUID()] });
+    expect(output[11]).to.equal(BSON_DATA_BINARY);
+    expect(output[18]).to.equal(BSON_BINARY_SUBTYPE_UUID_NEW);
   });
 });


### PR DESCRIPTION
### Description


#### What is changing?
BSON.serialize() now supports new BSON.UUID() as input directly, users don't need to call new BSON.UUID().toBinary(), while that option is still supported.

##### Is there new documentation needed for these changes?
Yes, we'll need to add that uuid: new BSON.UUID() is a valid input to BSON.serialize

#### What is the motivation for this change?
This is part of a larger project looking to better integrate the UUID type into BSON.

<!-- If this is a feature, it helps to describe the new use case enabled by this change -->
There are three new use cases possible:
| Type  | Example |
| ------------- | ------------- | 
| Object |  BSON.serialize({ uuid: new BSON.UUID() });  |
| Map | BSON.serialize(new Map([['uuid', new BSON.UUID()]])); | 
| Array  | BSON.serialize({ uuid: [new BSON.UUID()] });  | 

*Note, we can also have multiple UUIDs passed in at once for all cases. For example, BSON.serialize({ uuid: new BSON.UUID(), uuid2: new BSON.UUID() }); 

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
