### PR TITLE
test(NODE-4357): delete windows tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -30,9 +30,6 @@ functions:
              CURRENT_VERSION=latest
           fi
           export PROJECT_DIRECTORY="$(pwd)"
-          if [ "Windows_NT" = "$OS" ]; then
-             export PROJECT_DIRECTORY=$(cygpath -m $PROJECT_DIRECTORY)
-          fi
 
           # get the latest version of node for given major version
           NODE_VERSION=$(curl -sL nodejs.org/download/release/latest-v${NODE_MAJOR_VERSION}.x/SHASUMS256.txt -o - | head -n 1 | tr -s ' ' | cut -d' ' -f2 | cut -d- -f2 | cut -dv -f2)
@@ -213,10 +210,6 @@ buildvariants:
   - name: mac
     display_name: MacOS 10.14
     run_on: macos-1014
-    tasks: [".node"]
-  - name: windows
-    display_name: Windows 64
-    run_on: windows-64-vsMulti-small
     tasks: [".node"]
   - name: lint
     display_name: lint

--- a/.evergreen/init-nvm.sh
+++ b/.evergreen/init-nvm.sh
@@ -4,18 +4,6 @@ export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
 
-if [[ "$OS" == "Windows_NT" ]]; then
-    NVM_HOME=$(cygpath -w "$NVM_DIR")
-    export NVM_HOME
-    NVM_SYMLINK=$(cygpath -w "$NODE_ARTIFACTS_PATH/bin")
-    export NVM_SYMLINK
-    NVM_ARTIFACTS_PATH=$(cygpath -w "$NODE_ARTIFACTS_PATH/bin")
-    export NVM_ARTIFACTS_PATH
-    PATH=$(cygpath $NVM_SYMLINK):$(cygpath $NVM_HOME):$PATH
-    export PATH
-    echo "updated path on windows PATH=$PATH"
-else
-    [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
-fi
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
 
 export NODE_OPTIONS="--trace-deprecation --trace-warnings"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -10,7 +10,6 @@ NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
 NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 BIN_DIR="$(pwd)/bin"
-NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.9/nvm-noinstall.zip"
 NVM_URL="https://raw.githubusercontent.com/creationix/nvm/v0.38.0/install.sh"
 
 # this needs to be explicitly exported for the nvm install below
@@ -28,51 +27,21 @@ export PATH="${BIN_DIR}:${PATH}"
 
 # install Node.js
 echo "Installing Node ${NODE_LTS_NAME}"
-if [ "$OS" == "Windows_NT" ]; then
-  set +o xtrace
 
-  export NVM_HOME=`cygpath -w "$NVM_DIR"`
-  export NVM_SYMLINK=`cygpath -w "$NODE_ARTIFACTS_PATH/bin"`
-  export PATH=`cygpath $NVM_SYMLINK`:`cygpath $NVM_HOME`:$PATH
+set +o xtrace
 
-  # download and install nvm
-  curl -L $NVM_WINDOWS_URL -o nvm.zip
-  unzip -d $NVM_DIR nvm.zip
-  rm nvm.zip
+echo "  Downloading nvm"
+curl -o- $NVM_URL | bash
+[ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
 
-  chmod 777 $NVM_DIR
-  chmod -R a+rx $NVM_DIR
+echo "Running: nvm install --lts --latest-npm"
+nvm install --lts --latest-npm
+echo "Running: nvm install ${NODE_VERSION}"
+nvm install "${NODE_VERSION}"
+echo "Running: nvm use --lts"
+nvm use --lts
 
-  cat <<EOT > $NVM_DIR/settings.txt
-root: $NVM_HOME
-path: $NVM_SYMLINK
-EOT
-
-  echo "Running: nvm install lts"
-  nvm install lts
-  echo "Running: nvm install ${NODE_VERSION}"
-  nvm install "${NODE_VERSION}"
-  echo "Running: nvm use lts"
-  nvm use lts
-  echo "Running: npm install -g npm@8.3.1"
-  npm install -g npm@8.3.1 # https://github.com/npm/cli/issues/4341
-  set -o xtrace
-else
-  set +o xtrace
-
-  echo "  Downloading nvm"
-  curl -o- $NVM_URL | bash
-  [ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
-
-  echo "Running: nvm install --lts --latest-npm"
-  nvm install --lts --latest-npm
-  echo "Running: nvm install ${NODE_VERSION}"
-  nvm install "${NODE_VERSION}"
-  echo "Running: nvm use --lts"
-  nvm use --lts
-
-  set -o xtrace
-fi
+set -o xtrace
 
 
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -6,15 +6,10 @@ fi
 
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 
-if [ "$OS" == "Windows_NT" ]; then
-    export NVM_HOME=`cygpath -w "$NODE_ARTIFACTS_PATH/nvm"`
-    export NVM_SYMLINK=`cygpath -w "$NODE_ARTIFACTS_PATH/bin"`
-    export PATH=`cygpath $NVM_SYMLINK`:`cygpath $NVM_HOME`:$PATH
-else
-    export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-    export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
-    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-fi
+export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
+export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
 
 case $1 in
   "node")

--- a/test/bson_older_versions_tests.js
+++ b/test/bson_older_versions_tests.js
@@ -181,7 +181,7 @@ describe('Mutual version and distribution compatibility', function () {
                 fromObjects = makeObjects(fromBSON);
               },
               err => {
-                if (+process.version.slice(1).split('.')[0] >= 12 && process.platform !== 'win32') {
+                if (+process.version.slice(1).split('.')[0] >= 12) {
                   throw err; // On Node.js 12+, all loading is expected to work.
                 } else {
                   this.skip(); // Otherwise, e.g. ESM can't be loaded, so just skip.


### PR DESCRIPTION
### Description
Deleting windows tests from evergreen. 

#### What is changing?
Evergreen no longer tests on Windows.

##### Is there new documentation needed for these changes?
There is no new documentation needed for these changes.

#### What is the motivation for this change?
The CI fails on windows since it can't properly setup nvm, which is unrelated to js-bson. Since node is consistent across all OS, there is no need to test on multiple OS. 

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
