### PR TITLE
ci(NODE-4655): add 18 to CI matrix

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -152,6 +152,16 @@ tasks:
       - func: run tests
         vars:
           TEST_TARGET: node
+  - name: node-tests-v18
+    tags: ["node"]
+    commands:
+      - func: fetch source
+        vars:
+          NODE_MAJOR_VERSION: 18
+      - func: install dependencies
+      - func: run tests
+        vars:
+          TEST_TARGET: node
   - name: browser-tests
     tags: ["browser"]
     commands:
@@ -168,14 +178,14 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_MAJOR_VERSION: 16
+          NODE_MAJOR_VERSION: 18
       - func: install dependencies
       - func: run checks
   - name: check-typescript-oldest
     commands:
       - func: fetch source
         vars:
-          NODE_MAJOR_VERSION: 16
+          NODE_MAJOR_VERSION: 18
       - func: install dependencies
       - func: "run typescript"
         vars:
@@ -185,7 +195,7 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_MAJOR_VERSION: 16
+          NODE_MAJOR_VERSION: 18
       - func: install dependencies
       - func: "run typescript"
         vars:
@@ -195,7 +205,7 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_MAJOR_VERSION: 16
+          NODE_MAJOR_VERSION: 18
       - func: install dependencies
       - func: "run typescript"
         vars:
@@ -204,8 +214,8 @@ tasks:
 
 buildvariants:
   - name: linux
-    display_name: Ubuntu 18.04
-    run_on: ubuntu1804-test
+    display_name: Ubuntu 22.04
+    run_on: ubuntu2004-small
     tasks: [".node", ".browser"]
   - name: mac
     display_name: MacOS 10.14
@@ -213,7 +223,7 @@ buildvariants:
     tasks: [".node"]
   - name: lint
     display_name: lint
-    run_on: rhel70
+    run_on: ubuntu2004-small
     tasks:
       - run-checks
       - check-typescript-oldest

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@rollup/plugin-node-resolve": "^9.0.0",
         "@rollup/plugin-replace": "^4.0.0",
         "@rollup/plugin-typescript": "^6.0.0",
-        "@types/node": "^18.0.0",
+        "@types/node": "^18.7.22",
         "@typescript-eslint/eslint-plugin": "^5.30.0",
         "@typescript-eslint/parser": "^5.30.0",
         "array-includes": "^3.1.3",
@@ -2184,9 +2184,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+      "version": "18.7.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.22.tgz",
+      "integrity": "sha512-TsmoXYd4zrkkKjJB0URF/mTIKPl+kVcbqClB2F/ykU7vil1BfWZVndOnpEIozPv4fURD28gyPFeIkW2G+KXOvw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -10976,9 +10976,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+      "version": "18.7.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.22.tgz",
+      "integrity": "sha512-TsmoXYd4zrkkKjJB0URF/mTIKPl+kVcbqClB2F/ykU7vil1BfWZVndOnpEIozPv4fURD28gyPFeIkW2G+KXOvw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-replace": "^4.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.7.22",
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "array-includes": "^3.1.3",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
 --require ts-node/register
---require chai/register-expect
 --require source-map-support/register
 --timeout 10000

--- a/test/register-bson.js
+++ b/test/register-bson.js
@@ -7,7 +7,7 @@
 // and make sure you run mocha using our .mocharc.json or with --require ts-node/register
 
 // This should be done by mocha --require, but that isn't supported until mocha version 7+
-require('chai/register-expect');
+global.expect = require('chai').expect;
 require('array-includes/auto');
 require('object.entries/auto');
 require('array.prototype.flatmap/auto');


### PR DESCRIPTION
### Description

#### What is changing?

- a new task is added to CI that runs our tests on Node18
- tasks now run on ubuntu20
- @types/node is bumped to the latest version to resolve a Typescript failure (on typescript@next)
- register-expect was removed in favor of registering expect globally ourselves.   it's been a while since I made the change but it was necessary to fix a CI failure when I upgraded to Node18 or ubuntu20

##### Is there new documentation needed for these changes?

No.

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
