### PR TITLE
feat(NODE-4819): add custom inspect support for other js runtimes

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -4,6 +4,7 @@ import type { EJSONOptions } from './extended_json';
 import { BSONError, BSONTypeError } from './error';
 import { BSON_BINARY_SUBTYPE_UUID_NEW } from './constants';
 import { ByteUtils } from './utils/byte_utils';
+import { kInspect } from './utils/custom_inspect';
 
 /** @public */
 export type BinarySequence = Uint8Array | number[];
@@ -285,7 +286,7 @@ export class Binary {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 
@@ -475,7 +476,7 @@ export class UUID extends Binary {
    * @returns return the 36 character hex string representation.
    * @internal
    */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,4 +1,5 @@
 import type { Document } from './bson';
+import { kInspect } from './utils/custom_inspect';
 
 /** @public */
 export interface CodeExtended {
@@ -46,7 +47,7 @@ export class Code {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/db_ref.ts
+++ b/src/db_ref.ts
@@ -2,6 +2,7 @@ import type { Document } from './bson';
 import type { EJSONOptions } from './extended_json';
 import type { ObjectId } from './objectid';
 import { isObjectLike } from './parser/utils';
+import { kInspect } from './utils/custom_inspect';
 
 /** @public */
 export interface DBRefLike {
@@ -107,7 +108,7 @@ export class DBRef {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -2,6 +2,7 @@ import { BSONTypeError } from './error';
 import { Long } from './long';
 import { isUint8Array } from './parser/utils';
 import { ByteUtils } from './utils/byte_utils';
+import { kInspect } from './utils/custom_inspect';
 
 const PARSE_STRING_REGEXP = /^(\+|-)?(\d+|(\d*\.\d*))?(E|e)?([-+])?(\d+)?$/;
 const PARSE_INF_REGEXP = /^(\+|-)?(Infinity|inf)$/i;
@@ -765,7 +766,7 @@ export class Decimal128 {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/double.ts
+++ b/src/double.ts
@@ -1,4 +1,5 @@
 import type { EJSONOptions } from './extended_json';
+import { kInspect } from './utils/custom_inspect';
 
 /** @public */
 export interface DoubleExtended {
@@ -78,7 +79,7 @@ export class Double {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -1,4 +1,5 @@
 import type { EJSONOptions } from './extended_json';
+import { kInspect } from './utils/custom_inspect';
 
 /** @public */
 export interface Int32Extended {
@@ -58,7 +59,7 @@ export class Int32 {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/long.ts
+++ b/src/long.ts
@@ -1,6 +1,7 @@
 import type { EJSONOptions } from './extended_json';
 import { isObjectLike } from './parser/utils';
 import type { Timestamp } from './timestamp';
+import { kInspect } from './utils/custom_inspect';
 
 interface LongWASMHelpers {
   /** Gets the high bits of the last operation performed */
@@ -1027,7 +1028,7 @@ export class Long {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/max_key.ts
+++ b/src/max_key.ts
@@ -1,3 +1,5 @@
+import { kInspect } from './utils/custom_inspect';
+
 /** @public */
 export interface MaxKeyExtended {
   $maxKey: 1;
@@ -26,7 +28,7 @@ export class MaxKey {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/min_key.ts
+++ b/src/min_key.ts
@@ -1,3 +1,5 @@
+import { kInspect } from './utils/custom_inspect';
+
 /** @public */
 export interface MinKeyExtended {
   $minKey: 1;
@@ -26,7 +28,7 @@ export class MinKey {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -1,6 +1,7 @@
 import { BSONTypeError } from './error';
 import { deprecate, isUint8Array, randomBytes } from './parser/utils';
 import { BSONDataView, ByteUtils } from './utils/byte_utils';
+import { kInspect } from './utils/custom_inspect';
 
 // Regular expression that checks for hex value
 const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
@@ -322,7 +323,7 @@ export class ObjectId {
    * @returns return the 24 character hex string representation.
    * @internal
    */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,3 +1,5 @@
+import { kInspect } from './utils/custom_inspect';
+
 /** @public */
 export interface BSONSymbolExtended {
   $symbol: string;
@@ -50,7 +52,7 @@ export class BSONSymbol {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 }

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -1,5 +1,6 @@
 import { Long } from './long';
 import { isObjectLike } from './parser/utils';
+import { kInspect } from './utils/custom_inspect';
 
 /** @public */
 export type TimestampOverrides = '_bsontype' | 'toExtendedJSON' | 'fromExtendedJSON' | 'inspect';
@@ -109,7 +110,7 @@ export class Timestamp extends LongWithoutOverridesClass {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
+  [kInspect](): string {
     return this.inspect();
   }
 

--- a/src/utils/custom_inspect.ts
+++ b/src/utils/custom_inspect.ts
@@ -1,0 +1,12 @@
+function getSymbol() {
+  if ('Deno' in globalThis) {
+    // Deno
+    return Symbol.for('Deno.customInspect');
+  }
+
+  // Node.js as Default
+  return Symbol.for('nodejs.util.inspect.custom');
+}
+
+/** @internal */
+export const kInspect = getSymbol();


### PR DESCRIPTION
### Description

Due to lack of standard, every js runtime uses their own custom inspect. in this PR i've added support for Deno custom inspect symbol. (new runtimes can be added as well in future)

As #518 have been merged, this library aims to work on other js platforms as well

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
