### PR TITLE
feat!(NODE-4440): bump TS target version to es2020

### DIFF
--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -44,3 +44,9 @@ new TextDecoder('utf-16le').decode(bin.value(true));
 > **TL;DR**: TODO
 
 TODO(NODE-4771): serializeFunctions bug fix makes function names outside the ascii range get serialized correctly
+
+### TS "target" set to es2020
+
+We have set our typescript compilation target to `es2020` which aligns with our minimum supported Node.js version 14+. The following is from the typescript release notes on es2020 support, so it's some of the syntax that can be expected to be preserved after compilation:
+
+> This will preserve newer ECMAScript 2020 features like optional chaining, nullish coalescing, export * as ns, and dynamic import(...) syntax. It also means bigint literals now have a stable target below esnext.

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,10 +12,10 @@ const tsConfig = {
   checkJs: false,
   strict: true,
   alwaysStrict: true,
-  target: 'es5',
+  target: 'es2020',
   module: 'esnext',
   moduleResolution: 'node',
-  lib: ['ES2017', 'ES2020.BigInt', 'ES2017.TypedArrays'],
+  lib: ['es2020'],
   // We don't make use of tslib helpers
   importHelpers: true,
   noEmitHelpers: false,

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -73,8 +73,6 @@ export class Binary {
    * @param subType - the option binary type.
    */
   constructor(buffer?: string | BinarySequence, subType?: number) {
-    if (!(this instanceof Binary)) return new Binary(buffer, subType);
-
     if (
       !(buffer == null) &&
       !(typeof buffer === 'string') &&

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -28,7 +28,9 @@ export interface BinaryExtended {
  * @category BSONType
  */
 export class Binary {
-  _bsontype!: 'Binary';
+  get _bsontype(): 'Binary' {
+    return 'Binary';
+  }
 
   /**
    * Binary default subtype
@@ -291,8 +293,6 @@ export class Binary {
     return `new Binary(Buffer.from("${ByteUtils.toHex(this.buffer)}", "hex"), ${this.sub_type})`;
   }
 }
-
-Object.defineProperty(Binary.prototype, '_bsontype', { value: 'Binary' });
 
 /** @public */
 export type UUIDExtended = {

--- a/src/code.ts
+++ b/src/code.ts
@@ -21,8 +21,6 @@ export class Code {
    * @param scope - an optional scope for the function.
    */
   constructor(code: string | Function, scope?: Document) {
-    if (!(this instanceof Code)) return new Code(code, scope);
-
     this.code = code;
     this.scope = scope;
   }

--- a/src/code.ts
+++ b/src/code.ts
@@ -12,7 +12,9 @@ export interface CodeExtended {
  * @category BSONType
  */
 export class Code {
-  _bsontype!: 'Code';
+  get _bsontype(): 'Code' {
+    return 'Code';
+  }
 
   code!: string | Function;
   scope?: Document;
@@ -55,5 +57,3 @@ export class Code {
     })`;
   }
 }
-
-Object.defineProperty(Code.prototype, '_bsontype', { value: 'Code' });

--- a/src/db_ref.ts
+++ b/src/db_ref.ts
@@ -26,7 +26,9 @@ export function isDBRefLike(value: unknown): value is DBRefLike {
  * @category BSONType
  */
 export class DBRef {
-  _bsontype!: 'DBRef';
+  get _bsontype(): 'DBRef' {
+    return 'DBRef';
+  }
 
   collection!: string;
   oid!: ObjectId;
@@ -118,5 +120,3 @@ export class DBRef {
     })`;
   }
 }
-
-Object.defineProperty(DBRef.prototype, '_bsontype', { value: 'DBRef' });

--- a/src/db_ref.ts
+++ b/src/db_ref.ts
@@ -39,8 +39,6 @@ export class DBRef {
    * @param db - optional db name, if omitted the reference is local to the current db.
    */
   constructor(collection: string, oid: ObjectId, db?: string, fields?: Document) {
-    if (!(this instanceof DBRef)) return new DBRef(collection, oid, db, fields);
-
     // check if namespace has been provided
     const parts = collection.split('.');
     if (parts.length === 2) {

--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -136,8 +136,6 @@ export class Decimal128 {
    *                or a string representation as returned by .toString()
    */
   constructor(bytes: Uint8Array | string) {
-    if (!(this instanceof Decimal128)) return new Decimal128(bytes);
-
     if (typeof bytes === 'string') {
       this.bytes = Decimal128.fromString(bytes).bytes;
     } else if (isUint8Array(bytes)) {

--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -127,7 +127,9 @@ export interface Decimal128Extended {
  * @category BSONType
  */
 export class Decimal128 {
-  _bsontype!: 'Decimal128';
+  get _bsontype(): 'Decimal128' {
+    return 'Decimal128';
+  }
 
   readonly bytes!: Uint8Array;
 
@@ -771,5 +773,3 @@ export class Decimal128 {
     return `new Decimal128("${this.toString()}")`;
   }
 }
-
-Object.defineProperty(Decimal128.prototype, '_bsontype', { value: 'Decimal128' });

--- a/src/double.ts
+++ b/src/double.ts
@@ -11,7 +11,9 @@ export interface DoubleExtended {
  * @category BSONType
  */
 export class Double {
-  _bsontype!: 'Double';
+  get _bsontype(): 'Double' {
+    return 'Double';
+  }
 
   value!: number;
   /**
@@ -85,5 +87,3 @@ export class Double {
     return `new Double(${eJSON.$numberDouble})`;
   }
 }
-
-Object.defineProperty(Double.prototype, '_bsontype', { value: 'Double' });

--- a/src/double.ts
+++ b/src/double.ts
@@ -20,8 +20,6 @@ export class Double {
    * @param value - the number we want to represent as a double.
    */
   constructor(value: number) {
-    if (!(this instanceof Double)) return new Double(value);
-
     if ((value as unknown) instanceof Number) {
       value = value.valueOf();
     }

--- a/src/error.ts
+++ b/src/error.ts
@@ -2,7 +2,6 @@
 export class BSONError extends Error {
   constructor(message: string) {
     super(message);
-    Object.setPrototypeOf(this, BSONError.prototype);
   }
 
   get name(): string {
@@ -14,7 +13,6 @@ export class BSONError extends Error {
 export class BSONTypeError extends TypeError {
   constructor(message: string) {
     super(message);
-    Object.setPrototypeOf(this, BSONTypeError.prototype);
   }
 
   get name(): string {

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -11,7 +11,9 @@ export interface Int32Extended {
  * @category BSONType
  */
 export class Int32 {
-  _bsontype!: 'Int32';
+  get _bsontype(): 'Int32' {
+    return 'Int32';
+  }
 
   value!: number;
   /**
@@ -64,5 +66,3 @@ export class Int32 {
     return `new Int32(${this.valueOf()})`;
   }
 }
-
-Object.defineProperty(Int32.prototype, '_bsontype', { value: 'Int32' });

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -20,8 +20,6 @@ export class Int32 {
    * @param value - the number we want to represent as an int32.
    */
   constructor(value: number | string) {
-    if (!(this instanceof Int32)) return new Int32(value);
-
     if ((value as unknown) instanceof Number) {
       value = value.valueOf();
     }

--- a/src/long.ts
+++ b/src/long.ts
@@ -100,10 +100,14 @@ export interface LongExtended {
  * Common constant values ZERO, ONE, NEG_ONE, etc. are found as static properties on this class.
  */
 export class Long {
-  _bsontype!: 'Long';
+  get _bsontype(): 'Long' {
+    return 'Long';
+  }
 
   /** An indicator used to reliably determine if an object is a Long or not. */
-  __isLong__!: true;
+  get __isLong__(): boolean {
+    return true;
+  }
 
   /**
    * The high 32 bits as a signed value.
@@ -143,13 +147,6 @@ export class Long {
       this.high = (high as number) | 0;
       this.unsigned = !!unsigned;
     }
-
-    Object.defineProperty(this, '__isLong__', {
-      value: true,
-      configurable: false,
-      writable: false,
-      enumerable: false
-    });
   }
 
   static TWO_PWR_24 = Long.fromInt(TWO_PWR_24_DBL);
@@ -1033,6 +1030,3 @@ export class Long {
     return `new Long("${this.toString()}"${this.unsigned ? ', true' : ''})`;
   }
 }
-
-Object.defineProperty(Long.prototype, '__isLong__', { value: true });
-Object.defineProperty(Long.prototype, '_bsontype', { value: 'Long' });

--- a/src/long.ts
+++ b/src/long.ts
@@ -134,8 +134,6 @@ export class Long {
    * @param unsigned - Whether unsigned or not, defaults to signed
    */
   constructor(low: number | bigint | string = 0, high?: number | boolean, unsigned?: boolean) {
-    if (!(this instanceof Long)) return new Long(low, high, unsigned);
-
     if (typeof low === 'bigint') {
       Object.assign(this, Long.fromBigInt(low, !!high));
     } else if (typeof low === 'string') {

--- a/src/max_key.ts
+++ b/src/max_key.ts
@@ -9,7 +9,9 @@ export interface MaxKeyExtended {
  * @category BSONType
  */
 export class MaxKey {
-  _bsontype!: 'MaxKey';
+  get _bsontype(): 'MaxKey' {
+    return 'MaxKey';
+  }
 
   /** @internal */
   toExtendedJSON(): MaxKeyExtended {
@@ -30,5 +32,3 @@ export class MaxKey {
     return 'new MaxKey()';
   }
 }
-
-Object.defineProperty(MaxKey.prototype, '_bsontype', { value: 'MaxKey' });

--- a/src/max_key.ts
+++ b/src/max_key.ts
@@ -11,10 +11,6 @@ export interface MaxKeyExtended {
 export class MaxKey {
   _bsontype!: 'MaxKey';
 
-  constructor() {
-    if (!(this instanceof MaxKey)) return new MaxKey();
-  }
-
   /** @internal */
   toExtendedJSON(): MaxKeyExtended {
     return { $maxKey: 1 };

--- a/src/min_key.ts
+++ b/src/min_key.ts
@@ -11,10 +11,6 @@ export interface MinKeyExtended {
 export class MinKey {
   _bsontype!: 'MinKey';
 
-  constructor() {
-    if (!(this instanceof MinKey)) return new MinKey();
-  }
-
   /** @internal */
   toExtendedJSON(): MinKeyExtended {
     return { $minKey: 1 };

--- a/src/min_key.ts
+++ b/src/min_key.ts
@@ -9,7 +9,9 @@ export interface MinKeyExtended {
  * @category BSONType
  */
 export class MinKey {
-  _bsontype!: 'MinKey';
+  get _bsontype(): 'MinKey' {
+    return 'MinKey';
+  }
 
   /** @internal */
   toExtendedJSON(): MinKeyExtended {
@@ -30,5 +32,3 @@ export class MinKey {
     return 'new MinKey()';
   }
 }
-
-Object.defineProperty(MinKey.prototype, '_bsontype', { value: 'MinKey' });

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -46,8 +46,6 @@ export class ObjectId {
    * @param inputId - Can be a 24 character hex string, 12 byte binary Buffer, or a number.
    */
   constructor(inputId?: string | number | ObjectId | ObjectIdLike | Uint8Array) {
-    if (!(this instanceof ObjectId)) return new ObjectId(inputId);
-
     // workingId is set based on type of input and whether valid id exists for the input
     let workingId;
     if (typeof inputId === 'object' && inputId && 'id' in inputId) {

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -28,7 +28,9 @@ const kId = Symbol('id');
  * @category BSONType
  */
 export class ObjectId {
-  _bsontype!: 'ObjectID';
+  get _bsontype(): 'ObjectID' {
+    return 'ObjectID';
+  }
 
   /** @internal */
   static index = Math.floor(Math.random() * 0xffffff);
@@ -348,5 +350,3 @@ Object.defineProperty(ObjectId.prototype, 'get_inc', {
 Object.defineProperty(ObjectId, 'get_inc', {
   value: deprecate(() => ObjectId.getInc(), 'Please use the static `ObjectId.getInc()` instead')
 });
-
-Object.defineProperty(ObjectId.prototype, '_bsontype', { value: 'ObjectID' });

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -25,7 +25,9 @@ export interface BSONRegExpExtended {
  * @category BSONType
  */
 export class BSONRegExp {
-  _bsontype!: 'BSONRegExp';
+  get _bsontype(): 'BSONRegExp' {
+    return 'BSONRegExp';
+  }
 
   pattern!: string;
   options!: string;
@@ -99,5 +101,3 @@ export class BSONRegExp {
     throw new BSONTypeError(`Unexpected BSONRegExp EJSON object form: ${JSON.stringify(doc)}`);
   }
 }
-
-Object.defineProperty(BSONRegExp.prototype, '_bsontype', { value: 'BSONRegExp' });

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -34,8 +34,6 @@ export class BSONRegExp {
    * @param options - The regular expression options
    */
   constructor(pattern: string, options?: string) {
-    if (!(this instanceof BSONRegExp)) return new BSONRegExp(pattern, options);
-
     this.pattern = pattern;
     this.options = alphabetize(options ?? '');
 

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -9,7 +9,9 @@ export interface BSONSymbolExtended {
  * @category BSONType
  */
 export class BSONSymbol {
-  _bsontype!: 'Symbol';
+  get _bsontype(): 'Symbol' {
+    return 'Symbol';
+  }
 
   value!: string;
   /**
@@ -52,5 +54,3 @@ export class BSONSymbol {
     return this.inspect();
   }
 }
-
-Object.defineProperty(BSONSymbol.prototype, '_bsontype', { value: 'Symbol' });

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -16,8 +16,6 @@ export class BSONSymbol {
    * @param value - the string representing the symbol.
    */
   constructor(value: string) {
-    if (!(this instanceof BSONSymbol)) return new BSONSymbol(value);
-
     this.value = value;
   }
 

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -24,7 +24,9 @@ export interface TimestampExtended {
  * @category BSONType
  * */
 export class Timestamp extends LongWithoutOverridesClass {
-  _bsontype!: 'Timestamp';
+  get _bsontype(): 'Timestamp' {
+    return 'Timestamp';
+  }
 
   static readonly MAX_VALUE = Long.MAX_UNSIGNED_VALUE;
 
@@ -50,12 +52,6 @@ export class Timestamp extends LongWithoutOverridesClass {
     } else {
       super(low, high, true);
     }
-    Object.defineProperty(this, '_bsontype', {
-      value: 'Timestamp',
-      writable: false,
-      configurable: false,
-      enumerable: false
-    });
   }
 
   toJSON(): { $timestamp: string } {

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -43,10 +43,6 @@ export class Timestamp extends LongWithoutOverridesClass {
    */
   constructor(low: number, high: number);
   constructor(low: number | Long | { t: number; i: number }, high?: number) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    if (!(this instanceof Timestamp)) return new Timestamp(low, high);
-
     if (Long.isLong(low)) {
       super(low.low, low.high, true);
     } else if (isObjectLike(low) && typeof low.t !== 'undefined' && typeof low.i !== 'undefined') {

--- a/test/node/bson_types_construction_tests.js
+++ b/test/node/bson_types_construction_tests.js
@@ -2,34 +2,39 @@
 const BSON = require('../register-bson');
 
 describe('Constructing BSON types', function () {
-  it('with new keyword should work', function () {
+  it('with new keyword should not throw', function () {
+    expect(() => new BSON.ObjectId()).to.not.throw();
+    expect(() => new BSON.BSONRegExp('aaa')).to.not.throw();
+    expect(() => new BSON.BSONSymbol('aaa')).to.not.throw();
+    expect(() => new BSON.Binary('aaa')).to.not.throw();
+    expect(() => new BSON.Code(function () {})).to.not.throw();
+    expect(() => new BSON.Decimal128('123')).to.not.throw();
+    expect(() => new BSON.Double(2.3)).to.not.throw();
+    expect(() => new BSON.Int32(1)).to.not.throw();
+    expect(() => new BSON.Long(0, 0)).to.not.throw();
+    expect(() => new BSON.Timestamp(0, 0)).to.not.throw();
+    expect(() => new BSON.MaxKey()).to.not.throw();
+    expect(() => new BSON.MinKey()).to.not.throw();
+
     const oid = new BSON.ObjectId();
-    new BSON.DBRef('test', oid);
-    new BSON.BSONRegExp('aaa');
-    new BSON.BSONSymbol('aaa');
-    new BSON.Binary('aaa');
-    new BSON.Code(function () {});
-    new BSON.Decimal128('123');
-    new BSON.Double(2.3);
-    new BSON.Int32(1);
-    new BSON.Long(0, 0);
-    new BSON.Timestamp(0, 0);
-    new BSON.MaxKey();
-    new BSON.MinKey();
+    expect(() => BSON.DBRef('test', oid)).to.throw(TypeError, /cannot be invoked/);
   });
-  it('as a function call should work', function () {
-    const oid = BSON.ObjectId();
-    BSON.DBRef('test', oid);
-    BSON.BSONRegExp('aaa');
-    BSON.BSONSymbol('aaa');
-    BSON.Binary('aaa');
-    BSON.Code(function () {});
-    BSON.Decimal128('123');
-    BSON.Double(2.3);
-    BSON.Int32(1);
-    BSON.Long(0, 0);
-    BSON.Timestamp(0, 0);
-    BSON.MaxKey();
-    BSON.MinKey();
+
+  it('without new keyword should throw a TypeError', function () {
+    expect(() => BSON.ObjectId()).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.BSONRegExp('aaa')).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.BSONSymbol('aaa')).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.Binary('aaa')).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.Code(function () {})).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.Decimal128('123')).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.Double(2.3)).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.Int32(1)).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.Long(0, 0)).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.Timestamp(0, 0)).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.MaxKey()).to.throw(TypeError, /cannot be invoked/);
+    expect(() => BSON.MinKey()).to.throw(TypeError, /cannot be invoked/);
+
+    const oid = new BSON.ObjectId();
+    expect(() => BSON.DBRef('test', oid)).to.throw(TypeError, /cannot be invoked/);
   });
 });

--- a/test/node/type_identifier_tests.js
+++ b/test/node/type_identifier_tests.js
@@ -30,7 +30,7 @@ describe('_bsontype identifier', () => {
     // Timestamp overrides the value in its constructor
     const timestamp = new Timestamp({ i: 0, t: 0 });
     expect(timestamp._bsontype).to.equal('Timestamp');
-    expect(Object.getPrototypeOf(timestamp)._bsontype).to.equal('Long');
+    expect(Object.getPrototypeOf(Object.getPrototypeOf(timestamp))._bsontype).to.equal('Long');
   });
 
   // All equal to their constructor names

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,11 @@
     "checkJs": false,
     "strict": true,
     "alwaysStrict": true,
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": [
-      "ES2017",
-      "ES2020.BigInt",
-      "ES2017.TypedArrays"
+      "es2020",
     ],
     "outDir": "lib",
     // We don't make use of tslib helpers
@@ -32,9 +30,6 @@
   "ts-node": {
     "transpileOnly": true,
     "compiler": "typescript-cached-transpile",
-    "compilerOptions": {
-      "downlevelIteration": true
-    }
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
### Description

#### What is changing?

Bump TS target from es5 to es2020. Fixes related to syntax changes.

##### Is there new documentation needed for these changes?

Yes, see migration guide updates.

#### What is the motivation for this change?

Modern syntax allows for better control over what we publish (class sytax adds error handling for constructors etc.) 

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
