### PR TITLE
feat!(NODE-4461): remove Decimal128 toObject transformer

### DIFF
--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -85,6 +85,6 @@ TODO(NODE-4771): serializeFunctions bug fix makes function names outside the asc
 
 This library no longer polyfills [ES Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and the export "Map" was removed. Users should migrate to using the global Map constructor available in all supported JS environments.
 
-### Decimal128 toObject mapper support removed
+### `Decimal128` `toObject()` mapper support removed
 
-Decimal128 can no longer have a toObject static method added on to it for mapping to a custom value. This feature was undocumented an inconsistent with the rest of our BSON types. At this time there is no direct migration. If you are using a cursor in the driver it supports transformations via `.map` and if you are just using BSON directly you will need to find your Decimal128 instances and transform them manually. There is a plan to provide a better mechanism for consistently transforming BSON values tracked here: https://jira.mongodb.org/browse/NODE-4680, please feel free to add a vote or comment a use case to help us land the feature in the most useful form.
+`Decimal128` can no longer have a `toObject()` method added on to its prototype for mapping to a custom value. This feature was undocumented and inconsistent with the rest of our BSON types. At this time there is no direct migration: cursors in the driver support transformations via `.map`, otherwise the `Decimal128` instances will require manual transformation. There is a plan to provide a better mechanism for consistently transforming BSON values tracked in [NODE-4680](https://jira.mongodb.org/browse/NODE-4680), please feel free to add a vote or comment with a use case to help us land the feature in the most useful form.

--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -79,7 +79,6 @@ We have set our typescript compilation target to `es2020` which aligns with our 
 > **TL;DR**: TODO
 
 TODO(NODE-4771): serializeFunctions bug fix makes function names outside the ascii range get serialized correctly
-> This will preserve newer ECMAScript 2020 features like optional chaining, nullish coalescing, export * as ns, and dynamic import(...) syntax. It also means bigint literals now have a stable target below esnext.
 
 ### Remove `Map` export
 

--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -84,3 +84,7 @@ TODO(NODE-4771): serializeFunctions bug fix makes function names outside the asc
 ### Remove `Map` export
 
 This library no longer polyfills [ES Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) and the export "Map" was removed. Users should migrate to using the global Map constructor available in all supported JS environments.
+
+### Decimal128 toObject mapper support removed
+
+Decimal128 can no longer have a toObject static method added on to it for mapping to a custom value. This feature was undocumented an inconsistent with the rest of our BSON types. At this time there is no direct migration. If you are using a cursor in the driver it supports transformations via `.map` and if you are just using BSON directly you will need to find your Decimal128 instances and transform them manually. There is a plan to provide a better mechanism for consistently transforming BSON values tracked here: https://jira.mongodb.org/browse/NODE-4680, please feel free to add a vote or comment a use case to help us land the feature in the most useful form.

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -373,13 +373,7 @@ function deserializeObject(
       // Update index
       index = index + 16;
       // Assign the new Decimal128 value
-      const decimal128 = new Decimal128(bytes) as Decimal128 | { toObject(): unknown };
-      // If we have an alternative mapper use that
-      if ('toObject' in decimal128 && typeof decimal128.toObject === 'function') {
-        value = decimal128.toObject();
-      } else {
-        value = decimal128;
-      }
+      value = new Decimal128(bytes);
     } else if (elementType === constants.BSON_DATA_BINARY) {
       let binarySize =
         buffer[index++] |

--- a/test/node/decimal128_tests.js
+++ b/test/node/decimal128_tests.js
@@ -1174,37 +1174,6 @@ describe('Decimal128', function () {
     done();
   });
 
-  it('Support toBSON and toObject methods for custom mapping', function (done) {
-    // Create a custom object
-    var MyCustomDecimal = function (value) {
-      this.value = value instanceof Decimal128 ? value.toString() : value;
-    };
-
-    MyCustomDecimal.prototype.toBSON = function () {
-      return Decimal128.fromString(this.value);
-    };
-
-    // Add a custom mapper for the type
-    const saveToObject = Decimal128.prototype.toObject;
-    try {
-      Decimal128.prototype.toObject = function () {
-        return new MyCustomDecimal(this);
-      };
-
-      // Test all methods around a simple serialization at object top level
-      var doc = { value: new MyCustomDecimal('1') };
-      var buffer = BSON.serialize(doc);
-      var back = BSON.deserialize(buffer);
-      expect(back.value instanceof MyCustomDecimal).to.be.ok;
-      expect('1').to.equal(back.value.value);
-    } finally {
-      // prevent this test from breaking later tests which may re-use the same class
-      Decimal128.prototype.toObject = saveToObject;
-    }
-
-    done();
-  });
-
   it('accepts strings in the constructor', () => {
     expect(new Decimal128('0').toString()).to.equal('0');
     expect(new Decimal128('00').toString()).to.equal('0');


### PR DESCRIPTION
### Description

#### What is changing?

Remove toObject transformer for d128

#### What is the motivation for this change?

Difficult maintenance, and unexpected results from serializer when defined (toObject's return type isn't constrained)

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
