### PR TITLE
fix(NODE-4771): serializeFunctions breaks function names outside of basic latin

### DIFF
--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -76,9 +76,7 @@ We have set our typescript compilation target to `es2020` which aligns with our 
 
 ### serializeFunctions bug fix
 
-> **TL;DR**: TODO
-
-TODO(NODE-4771): serializeFunctions bug fix makes function names outside the ascii range get serialized correctly
+If serializeFunctions was enabled and the functions being serialized had a name that is outside of [Controls and Basic Latin](https://en.wikibooks.org/wiki/Unicode/Character_reference/0000-0FFF) character ranges (a.k.a utf8 bytes: 0x00-0x7F) they would be incorrectly serialized.
 
 ### Remove `Map` export
 


### PR DESCRIPTION
### Description

#### What is changing?

- Making a note in the migration guide
- this commit will add to the changelog
- Bug was fixed in #518

#### What is the motivation for this change?

We want the bug to appear in the changelog.

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
