### PR TITLE
feat(NODE-4873): support EJSON stringify from BigInt to $numberLong

### DIFF
--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -194,8 +194,8 @@ function serializeValue(value: any, options: EJSONSerializeOptions): any {
 
       throw new BSONError(
         'Converting circular structure to EJSON:\n' +
-        `    ${leadingPart}${alreadySeen}${circularPart}${current}\n` +
-        `    ${leadingSpace}\\${dashes}/`
+          `    ${leadingPart}${alreadySeen}${circularPart}${current}\n` +
+          `    ${leadingSpace}\\${dashes}/`
       );
     }
     options.seenObjects[options.seenObjects.length - 1].obj = value;
@@ -236,17 +236,9 @@ function serializeValue(value: any, options: EJSONSerializeOptions): any {
 
   if (typeof value === 'bigint') {
     if (!options.relaxed) {
-      // Interpret as smallest BSON integer type that can represent the number exactly
-      if (value >= BSON_INT32_MIN && value <= BSON_INT32_MAX) {
-        return { $numberInt: value.toString() };
-      }
-      if (value >= BSON_INT64_MIN && value <= BSON_INT64_MAX) {
-        return { $numberLong: value.toString() };
-      }
-      // Fallback to double if number is out of signed-64-bit int range
-      return { $numberDouble: value.toString() };
+      return { $numberLong: BigInt.asIntN(64, value).toString() };
     }
-    return Number(BigInt.asIntN(64, value)); 
+    return Number(BigInt.asIntN(64, value));
   }
 
   if (value instanceof RegExp || isRegExp(value)) {

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -194,8 +194,8 @@ function serializeValue(value: any, options: EJSONSerializeOptions): any {
 
       throw new BSONError(
         'Converting circular structure to EJSON:\n' +
-          `    ${leadingPart}${alreadySeen}${circularPart}${current}\n` +
-          `    ${leadingSpace}\\${dashes}/`
+        `    ${leadingPart}${alreadySeen}${circularPart}${current}\n` +
+        `    ${leadingSpace}\\${dashes}/`
       );
     }
     options.seenObjects[options.seenObjects.length - 1].obj = value;
@@ -232,6 +232,10 @@ function serializeValue(value: any, options: EJSONSerializeOptions): any {
       }
     }
     return { $numberDouble: Object.is(value, -0) ? '-0.0' : value.toString() };
+  }
+
+  if (typeof value === 'bigint' && (!options.relaxed)) {
+    return { $numberLong: value.toString() };
   }
 
   if (value instanceof RegExp || isRegExp(value)) {

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -234,8 +234,11 @@ function serializeValue(value: any, options: EJSONSerializeOptions): any {
     return { $numberDouble: Object.is(value, -0) ? '-0.0' : value.toString() };
   }
 
-  if (typeof value === 'bigint' && (!options.relaxed)) {
-    return { $numberLong: value.toString() };
+  if (typeof value === 'bigint') {
+    if (!options.relaxed) {
+      return { $numberLong: value.toString() };
+    }
+    return Number(BigInt.asIntN(64, value)); // FIXME(NODE-4873): This is yucky
   }
 
   if (value instanceof RegExp || isRegExp(value)) {

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -236,9 +236,17 @@ function serializeValue(value: any, options: EJSONSerializeOptions): any {
 
   if (typeof value === 'bigint') {
     if (!options.relaxed) {
-      return { $numberLong: value.toString() };
+      // Interpret as smallest BSON integer type that can represent the number exactly
+      if (value >= BSON_INT32_MIN && value <= BSON_INT32_MAX) {
+        return { $numberInt: value.toString() };
+      }
+      if (value >= BSON_INT64_MIN && value <= BSON_INT64_MAX) {
+        return { $numberLong: value.toString() };
+      }
+      // Fallback to double if number is out of signed-64-bit int range
+      return { $numberDouble: value.toString() };
     }
-    return Number(BigInt.asIntN(64, value)); // FIXME(NODE-4873): This is yucky
+    return Number(BigInt.asIntN(64, value)); 
   }
 
   if (value instanceof RegExp || isRegExp(value)) {

--- a/test/node/bigint.test.ts
+++ b/test/node/bigint.test.ts
@@ -1,4 +1,4 @@
-import { BSON, BSONError } from '../register-bson';
+import { BSON, EJSON, BSONError } from '../register-bson';
 import { bufferFromHexArray } from './tools/utils';
 import { expect } from 'chai';
 import { BSON_DATA_LONG } from '../../src/constants';
@@ -261,6 +261,94 @@ describe('BSON BigInt support', function () {
         ])
       );
       expect(serializedMap).to.deep.equal(expectedSerialization);
+    });
+  });
+
+  describe('EJSON.stringify()', function () {
+    it('truncates bigint values when they are outside the range [BSON_INT64_MIN, BSON_INT64_MAX] in canonical mode', function () {
+      const numbers = { a: 2n ** 64n + 1n, b: -(2n ** 64n) - 1n };
+      const serialized = EJSON.stringify(numbers, { relaxed: false });
+      expect(serialized).to.equal('{"a":{"$numberLong":"1"},"b":{"$numberLong":"-1"}}');
+    });
+
+    it('truncates bigint values in the same way as BSON.serialize in canonical mode', function () {
+      const number = { a: 0x1234_5678_1234_5678_9999n };
+      const stringified = EJSON.stringify(number, { relaxed: false });
+      const serialized = BSON.serialize(number);
+
+      const VALUE_OFFSET = 7;
+      const dataView = BSONDataView.fromUint8Array(serialized);
+      const serializedValue = dataView.getBigInt64(VALUE_OFFSET, true);
+      const parsed = JSON.parse(stringified);
+
+      expect(parsed).to.have.property('a');
+      expect(parsed['a']).to.have.property('$numberLong');
+      expect(parsed.a.$numberLong).to.equal(0x5678_1234_5678_9999n.toString());
+
+      expect(parsed.a.$numberLong).to.equal(serializedValue.toString());
+    });
+
+    it('truncates bigint values in the same way as BSON.serialize in relaxed mode', function () {
+      const number = { a: 0x1234_0000_1234_5678_9999n }; // Ensure that the truncated number can be exactly represented as a JS number
+      const stringified = EJSON.stringify(number, { relaxed: true });
+      const serializedDoc = BSON.serialize(number);
+
+      const VALUE_OFFSET = 7;
+      const dataView = BSONDataView.fromUint8Array(serializedDoc);
+      const parsed = JSON.parse(stringified);
+
+      expect(parsed).to.have.property('a');
+      expect(parsed.a).to.equal(0x0000_1234_5678_9999);
+
+      expect(parsed.a).to.equal(Number(dataView.getBigInt64(VALUE_OFFSET, true)));
+    });
+
+    it('serializes bigint values to numberLong in canonical mode', function () {
+      const number = { a: 2n };
+      const serialized = EJSON.stringify(number, { relaxed: false });
+      expect(serialized).to.equal('{"a":{"$numberLong":"2"}}');
+    });
+
+    it('serializes bigint values to Number in relaxed mode', function () {
+      const number = { a: 10000n };
+      const serialized = EJSON.stringify(number, { relaxed: true });
+      expect(serialized).to.equal('{"a":10000}');
+    });
+
+    it('loses precision when serializing bigint values outside of range [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER] in relaxed mode', function () {
+      const numbers = { a: -(2n ** 53n) - 1n, b: 2n ** 53n + 2n };
+      const serialized = EJSON.stringify(numbers, { relaxed: true });
+      expect(serialized).to.equal('{"a":-9007199254740992,"b":9007199254740994}');
+    });
+
+    it('produces bigint strings that pass loose equality checks with native bigint values that are are 64 bits wide or less', function () {
+      const number = { a: 12345n };
+      const serialized = EJSON.stringify(number, { relaxed: false });
+      const parsed = JSON.parse(serialized);
+      // eslint-disable-next-line eqeqeq
+      expect(parsed.a.$numberLong == 12345n).true;
+    });
+
+    it('produces bigint strings that are equal to the strings generated when using BigInt.toString when the bigint values used are 64 bits wide or less', function () {
+      const number = { a: 12345n };
+      const serialized = EJSON.stringify(number, { relaxed: false });
+      const parsed = JSON.parse(serialized);
+      expect(parsed.a.$numberLong).to.equal(12345n.toString());
+    });
+
+    it('produces bigint strings that fail loose equality checks with native bigint values that are more than 64 bits wide', function () {
+      const number = { a: 0x1234_5678_1234_5678_9999n };
+      const serialized = EJSON.stringify(number, { relaxed: false });
+      const parsed = JSON.parse(serialized);
+      // eslint-disable-next-line eqeqeq
+      expect(parsed.a.$numberLong == 0x1234_5678_1234_5678_9999n).false;
+    });
+
+    it('produces bigint strings that are not equal to the strings generated when using BigInt.toString when the bigint values used are more than 64 bits wide', function () {
+      const number = { a: 0x1234_5678_1234_5678_9999n };
+      const serialized = EJSON.stringify(number, { relaxed: false });
+      const parsed = JSON.parse(serialized);
+      expect(parsed.a.$numberLong).to.not.equal(0x1234_5678_1234_5678_9999n.toString());
     });
   });
 });

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -180,22 +180,35 @@ describe('Extended JSON', function() {
     expect(EJSON.parse(serialized)).to.deep.equal(numbers);
   });
 
-  it.only('should correctly serialize bigint values in canonical mode', function() {
+  it.only('serializes bigint values to Int32 when they are >= -2^32 and <= 2^32 -1', function() {
+    const number = {a: 100n};
+    const serialized = EJSON.stringify(number, {relaxed: false});
+    expect(serialized).to.equal('{"a":{"$numberInt":"100"}}');
+  });
+
+  it.only('serializes bigint values to Int64 when they are < -2^32, > 2^32 -1, > 2^64 -1, and < -2^64', function() {
+    const number = {a: 2n ** 33n};
+    const serialized = EJSON.stringify(number, {relaxed: false});
+    expect(serialized).to.equal('');
+  });
+
+  it('serializes bigint values to Double when they are > 2^64 - 1 and < -2^64);
+  it.only('correctly serializes bigint values in canonical mode', function() {
     const numbers = { a: 100n, b: (2n ** 54n) };
     const serialized = EJSON.stringify(numbers, { relaxed: false });
     expect(serialized).to.equal('{"a":{"$numberLong":"100"},"b":{"$numberLong":"18014398509481984"}}');
   });
 
-  it.only('should correctly serialize bigint values in relaxed mode', function() {
-    const numbers = { a: 100n, b: (2n ** 54n) };
+  it.only('correctly serializes bigint values in relaxed mode that are safe to represent with a javascript number', function() {
+    const numbers = { a: 100n, b: BigInt(Number.MAX_SAFE_INTEGER) };
     const serialized = EJSON.stringify(numbers);
-    expect(serialized).to.equal('{"a":100,"b":18014398509481984}');
+    expect(serialized).to.equal('{"a":100,"b":9007199254740991}');
   });
 
-  it.only('should correctly serialize bigint values in relaxed mode that are not safe to represent with javascript number', function() {
+  it.only('correctly serializes bigint values in relaxed mode that are not safe to represent with javascript number', function() {
     const numbers = { a: 100n, b: BigInt(Number.MAX_SAFE_INTEGER) + 2n };
     const serialized = EJSON.stringify(numbers);
-    expect(serialized).to.equal('{"a":100,"b":9007199254740993}');
+    expect(serialized).to.equal('{"a":100,"b":9007199254740992}');
   });
 
   it('should correctly parse null values', function() {

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -205,7 +205,7 @@ describe('Extended JSON', function () {
   });
 
   it('truncates bigint values in the same way as BSON.serialize in relaxed mode', function () {
-    const number = { a: 0x1234_0000_1234_5678_9999n }; // Ensure that the serialized number can be exactly represented as a JS number
+    const number = { a: 0x1234_0000_1234_5678_9999n }; // Ensure that the truncated number can be exactly represented as a JS number
     const stringified = EJSON.stringify(number, { relaxed: true });
     const serializedDoc = BSON.serialize(number);
 
@@ -218,6 +218,7 @@ describe('Extended JSON', function () {
 
     expect(parsed.a).to.equal(Number(dataView.getBigInt64(VALUE_OFFSET, true)));
   });
+
 
   it('serializes bigint values to numberLong in canonical mode', function () {
     const number = { a: 2n };

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -44,10 +44,10 @@ const OldBSON = getOldBSON();
 const OldObjectID = OldBSON === BSON ? BSON.ObjectId : OldBSON.ObjectID;
 const usingOldBSON = OldBSON !== BSON;
 
-describe('Extended JSON', function () {
+describe('Extended JSON', function() {
   let doc = {};
 
-  before(function () {
+  before(function() {
     const buffer = Buffer.alloc(64);
     for (let i = 0; i < buffer.length; i++) buffer[i] = i;
     const date = new Date();
@@ -78,7 +78,7 @@ describe('Extended JSON', function () {
     };
   });
 
-  it('should correctly extend an existing mongodb module', function () {
+  it('should correctly extend an existing mongodb module', function() {
     // TODO(NODE-4377): doubleNumberIntFit should be a double not a $numberLong
     const json =
       '{"_id":{"$numberInt":"100"},"gh":{"$numberInt":"1"},"binary":{"$binary":{"base64":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==","subType":"00"}},"date":{"$date":{"$numberLong":"1488372056737"}},"code":{"$code":"function() {}","$scope":{"a":{"$numberInt":"1"}}},"dbRef":{"$ref":"tests","$id":{"$numberInt":"1"},"$db":"test"},"decimal":{"$numberDecimal":"100"},"double":{"$numberDouble":"10.1"},"int32":{"$numberInt":"10"},"long":{"$numberLong":"200"},"maxKey":{"$maxKey":1},"minKey":{"$minKey":1},"objectId":{"$oid":"111111111111111111111111"},"objectID":{"$oid":"111111111111111111111111"},"oldObjectID":{"$oid":"111111111111111111111111"},"regexp":{"$regularExpression":{"pattern":"hello world","options":"i"}},"symbol":{"$symbol":"symbol"},"timestamp":{"$timestamp":{"t":0,"i":1000}},"int32Number":{"$numberInt":"300"},"doubleNumber":{"$numberDouble":"200.2"},"longNumberIntFit":{"$numberLong":"7036874417766400"},"doubleNumberIntFit":{"$numberLong":"19007199250000000"}}';
@@ -86,7 +86,7 @@ describe('Extended JSON', function () {
     expect(json).to.equal(EJSON.stringify(doc, null, 0, { relaxed: false }));
   });
 
-  it('should correctly deserialize using the default relaxed mode (relaxed=true)', function () {
+  it('should correctly deserialize using the default relaxed mode (relaxed=true)', function() {
     // Deserialize the document using relaxed=true mode
     let doc1 = EJSON.parse(EJSON.stringify(doc, null, 0));
 
@@ -107,7 +107,7 @@ describe('Extended JSON', function () {
     expect(doc1.doubleNumberIntFit._bsontype).to.equal('Long');
   });
 
-  it('should correctly serialize, and deserialize using built-in BSON', function () {
+  it('should correctly serialize, and deserialize using built-in BSON', function() {
     // Create a doc
     const doc1 = {
       int32: new Int32(10)
@@ -125,7 +125,7 @@ describe('Extended JSON', function () {
     expect(doc2.int32).to.equal(10);
   });
 
-  it('should correctly serialize bson types when they are values', function () {
+  it('should correctly serialize bson types when they are values', function() {
     let serialized = EJSON.stringify(new ObjectId('591801a468f9e7024b6235ea'), { relaxed: false });
     expect(serialized).to.equal('{"$oid":"591801a468f9e7024b6235ea"}');
     serialized = EJSON.stringify(new ObjectID('591801a468f9e7024b6235ea'), { relaxed: false });
@@ -161,17 +161,17 @@ describe('Extended JSON', function () {
     expect(serialized).to.equal('{"$binary":{"base64":"AQIDBAU=","subType":"00"}}');
   });
 
-  it('should correctly serialize strings', function () {
+  it('should correctly serialize strings', function() {
     const serialized = EJSON.stringify('new string');
     expect(serialized).to.equal('"new string"');
   });
 
-  it('should correctly serialize numbers', function () {
+  it('should correctly serialize numbers', function() {
     const serialized = EJSON.stringify(42);
     expect(serialized).to.equal('42');
   });
 
-  it('should correctly serialize non-finite numbers', function () {
+  it('should correctly serialize non-finite numbers', function() {
     const numbers = { neginf: -Infinity, posinf: Infinity, nan: NaN };
     const serialized = EJSON.stringify(numbers);
     expect(serialized).to.equal(
@@ -180,7 +180,25 @@ describe('Extended JSON', function () {
     expect(EJSON.parse(serialized)).to.deep.equal(numbers);
   });
 
-  it('should correctly parse null values', function () {
+  it.only('should correctly serialize bigint values in canonical mode', function() {
+    const numbers = { a: 100n, b: (2n ** 54n) };
+    const serialized = EJSON.stringify(numbers, { relaxed: false });
+    expect(serialized).to.equal('{"a":{"$numberLong":"100"},"b":{"$numberLong":"18014398509481984"}}');
+  });
+
+  it.only('should correctly serialize bigint values in relaxed mode', function() {
+    const numbers = { a: 100n, b: (2n ** 54n) };
+    const serialized = EJSON.stringify(numbers);
+    expect(serialized).to.equal('{"a":100,"b":18014398509481984}');
+  });
+
+  it.only('should correctly serialize bigint values in relaxed mode that are not safe to represent with javascript number', function() {
+    const numbers = { a: 100n, b: BigInt(Number.MAX_SAFE_INTEGER) + 2n };
+    const serialized = EJSON.stringify(numbers);
+    expect(serialized).to.equal('{"a":100,"b":9007199254740993}');
+  });
+
+  it('should correctly parse null values', function() {
     expect(EJSON.parse('null')).to.be.null;
     expect(EJSON.parse('[null]')[0]).to.be.null;
 
@@ -192,13 +210,13 @@ describe('Extended JSON', function () {
     });
   });
 
-  it('should correctly throw when passed a non-string to parse', function () {
+  it('should correctly throw when passed a non-string to parse', function() {
     expect(() => {
       EJSON.parse({});
     }).to.throw;
   });
 
-  it('should allow relaxed parsing by default', function () {
+  it('should allow relaxed parsing by default', function() {
     const dt = new Date(1452124800000);
     const inputObject = {
       int: { $numberInt: '500' },
@@ -216,7 +234,7 @@ describe('Extended JSON', function () {
     });
   });
 
-  it('should allow regexp', function () {
+  it('should allow regexp', function() {
     const parsedRegExp = EJSON.stringify({ test: /some-regex/i });
     const parsedBSONRegExp = EJSON.stringify(
       { test: new BSONRegExp('some-regex', 'i') },
@@ -225,7 +243,7 @@ describe('Extended JSON', function () {
     expect(parsedRegExp).to.eql(parsedBSONRegExp);
   });
 
-  it('should serialize from BSON object to EJSON object', function () {
+  it('should serialize from BSON object to EJSON object', function() {
     const doc = {
       binary: new Binary(''),
       code: new Code('function() {}'),
@@ -268,7 +286,7 @@ describe('Extended JSON', function () {
     });
   });
 
-  it('should deserialize from EJSON object to BSON object', function () {
+  it('should deserialize from EJSON object to BSON object', function() {
     const doc = {
       binary: { $binary: { base64: '', subType: '00' } },
       code: { $code: 'function() {}' },
@@ -326,13 +344,13 @@ describe('Extended JSON', function () {
     expect(result.timestamp).to.be.an.instanceOf(BSON.Timestamp);
   });
 
-  it('should return a native number for a double in relaxed mode', function () {
+  it('should return a native number for a double in relaxed mode', function() {
     const result = EJSON.deserialize({ test: 34.12 }, { relaxed: true });
     expect(result.test).to.equal(34.12);
     expect(result.test).to.be.a('number');
   });
 
-  it('should work for function-valued and array-valued replacer parameters', function () {
+  it('should work for function-valued and array-valued replacer parameters', function() {
     const doc = { a: new Int32(10), b: new Int32(10) };
 
     const replacerArray = ['a', '$numberInt'];
@@ -342,7 +360,7 @@ describe('Extended JSON', function () {
     serialized = EJSON.stringify(doc, replacerArray);
     expect(serialized).to.equal('{"a":10}');
 
-    const replacerFunc = function (key, value) {
+    const replacerFunc = function(key, value) {
       return key === 'b' ? undefined : value;
     };
     serialized = EJSON.stringify(doc, replacerFunc, 0, { relaxed: false });
@@ -357,7 +375,7 @@ describe('Extended JSON', function () {
       // ignore
     });
   } else {
-    it('should interoperate 4.x with 1.x versions of this library', function () {
+    it('should interoperate 4.x with 1.x versions of this library', function() {
       const buffer = Buffer.alloc(64);
       for (let i = 0; i < buffer.length; i++) {
         buffer[i] = i;
@@ -455,7 +473,7 @@ describe('Extended JSON', function () {
 
     // Must special-case the test for MinKey, because of #310.  When #310 is fixed and is picked up
     // by mongodb-core, then remove this test case and uncomment the MinKey checks in the test case above
-    it('should interop with MinKey 1.x and 4.x, except the case that #310 breaks', function () {
+    it('should interop with MinKey 1.x and 4.x, except the case that #310 breaks', function() {
       if (!usingOldBSON) {
         it.skip('interop tests', () => {
           // ignore
@@ -505,7 +523,7 @@ describe('Extended JSON', function () {
     });
   }
 
-  it('should throw if invalid BSON types are input to EJSON serializer', function () {
+  it('should throw if invalid BSON types are input to EJSON serializer', function() {
     const oid = new ObjectId('111111111111111111111111');
     const badBsonType = Object.assign({}, oid, { _bsontype: 'bogus' });
     const badDoc = { bad: badBsonType };
@@ -516,7 +534,7 @@ describe('Extended JSON', function () {
     // expect(() => EJSON.serialize(badMap)).to.throw(); // uncomment when EJSON supports ES6 Map
   });
 
-  it('should correctly deserialize objects containing __proto__ keys', function () {
+  it('should correctly deserialize objects containing __proto__ keys', function() {
     const original = { ['__proto__']: { a: 42 } };
     const serialized = EJSON.stringify(original);
     expect(serialized).to.equal('{"__proto__":{"a":42}}');
@@ -530,10 +548,10 @@ describe('Extended JSON', function () {
     expect(deserialized.__proto__.a).to.equal(42);
   });
 
-  context('when dealing with legacy extended json', function () {
-    describe('.stringify', function () {
-      context('when serializing binary', function () {
-        it('stringifies $binary and $type', function () {
+  context('when dealing with legacy extended json', function() {
+    describe('.stringify', function() {
+      context('when serializing binary', function() {
+        it('stringifies $binary and $type', function() {
           const binary = new Binary(new Uint8Array([1, 2, 3, 4, 5]));
           const doc = { field: binary };
           const json = EJSON.stringify(doc, { legacy: true });
@@ -541,9 +559,9 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when serializing date', function () {
-        context('when using relaxed=false mode', function () {
-          it('stringifies $date with with ISO-8601 string', function () {
+      context('when serializing date', function() {
+        context('when using relaxed=false mode', function() {
+          it('stringifies $date with with ISO-8601 string', function() {
             const date = new Date(1452124800000);
             const doc = { field: date };
             const json = EJSON.stringify(doc, { legacy: true, relaxed: false });
@@ -551,8 +569,8 @@ describe('Extended JSON', function () {
           });
         });
 
-        context('when using relaxed mode', function () {
-          it('stringifies $date with with millis since epoch', function () {
+        context('when using relaxed mode', function() {
+          it('stringifies $date with with millis since epoch', function() {
             const date = new Date(1452124800000);
             const doc = { field: date };
             const json = EJSON.stringify(doc, { legacy: true, relaxed: true });
@@ -561,8 +579,8 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when serializing regex', function () {
-        it('stringifies $regex and $options', function () {
+      context('when serializing regex', function() {
+        it('stringifies $regex and $options', function() {
           const regexp = new BSONRegExp('hello world', 'i');
           const doc = { field: regexp };
           const json = EJSON.stringify(doc, { legacy: true });
@@ -570,8 +588,8 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when serializing dbref', function () {
-        it('stringifies $ref and $id', function () {
+      context('when serializing dbref', function() {
+        it('stringifies $ref and $id', function() {
           const dbRef = new DBRef('tests', new Int32(1));
           const doc = { field: dbRef };
           const json = EJSON.stringify(doc, { legacy: true });
@@ -579,8 +597,8 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when serializing dbref', function () {
-        it('stringifies $ref and $id', function () {
+      context('when serializing dbref', function() {
+        it('stringifies $ref and $id', function() {
           const dbRef = new DBRef('tests', new Int32(1));
           const doc = { field: dbRef };
           const json = EJSON.stringify(doc, { legacy: true });
@@ -588,8 +606,8 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when serializing int32', function () {
-        it('stringifies the number', function () {
+      context('when serializing int32', function() {
+        it('stringifies the number', function() {
           const int32 = new Int32(1);
           const doc = { field: int32 };
           const json = EJSON.stringify(doc, { legacy: true });
@@ -597,8 +615,8 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when serializing double', function () {
-        it('stringifies the number', function () {
+      context('when serializing double', function() {
+        it('stringifies the number', function() {
           const doub = new Double(1.1);
           const doc = { field: doub };
           const json = EJSON.stringify(doc, { legacy: true });
@@ -607,9 +625,9 @@ describe('Extended JSON', function () {
       });
     });
 
-    describe('.parse', function () {
-      context('when deserializing binary', function () {
-        it('parses $binary and $type', function () {
+    describe('.parse', function() {
+      context('when deserializing binary', function() {
+        it('parses $binary and $type', function() {
           const binary = new Binary(new Uint8Array([1, 2, 3, 4, 5]));
           const doc = { field: binary };
           const bson = EJSON.parse('{"field":{"$binary":"AQIDBAU=","$type":"00"}}', {
@@ -619,9 +637,9 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when deserializing date', function () {
-        context('when using relaxed=false mode', function () {
-          it('parses $date with with ISO-8601 string', function () {
+      context('when deserializing date', function() {
+        context('when using relaxed=false mode', function() {
+          it('parses $date with with ISO-8601 string', function() {
             const date = new Date(1452124800000);
             const doc = { field: date };
             const bson = EJSON.parse('{"field":{"$date":"2016-01-07T00:00:00Z"}}', {
@@ -632,8 +650,8 @@ describe('Extended JSON', function () {
           });
         });
 
-        context('when using relaxed=true mode', function () {
-          it('parses $date number with millis since epoch', function () {
+        context('when using relaxed=true mode', function() {
+          it('parses $date number with millis since epoch', function() {
             const date = new Date(1452124800000);
             const doc = { field: date };
             const bson = EJSON.parse('{"field":{"$date":1452124800000}}', {
@@ -645,8 +663,8 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when deserializing regex', function () {
-        it('parses $regex and $options', function () {
+      context('when deserializing regex', function() {
+        it('parses $regex and $options', function() {
           const regexp = new BSONRegExp('hello world', 'i');
           const doc = { field: regexp };
           const bson = EJSON.parse('{"field":{"$regex":"hello world","$options":"i"}}', {
@@ -656,8 +674,8 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when deserializing dbref', function () {
-        it('parses $ref and $id', function () {
+      context('when deserializing dbref', function() {
+        it('parses $ref and $id', function() {
           const dbRef = new DBRef('tests', 1);
           const doc = { field: dbRef };
           const bson = EJSON.parse('{"field":{"$ref":"tests","$id":1}}', {
@@ -667,34 +685,34 @@ describe('Extended JSON', function () {
         });
       });
 
-      context('when deserializing int32', function () {
-        it('parses the number', function () {
+      context('when deserializing int32', function() {
+        it('parses the number', function() {
           const doc = { field: 1 };
           const bson = EJSON.parse('{"field":1}', { legacy: true });
           expect(bson).to.deep.equal(doc);
         });
 
-        it('parses the numberInt without doc', function () {
+        it('parses the numberInt without doc', function() {
           const value = 1;
           const bson = EJSON.parse('{ "$numberInt": "1" }');
           expect(bson).to.deep.equal(value);
         });
 
-        it('parses the numberInt', function () {
+        it('parses the numberInt', function() {
           const doc = { field: 1 };
           const bson = EJSON.parse('{"field": {"$numberInt": "1"}}');
           expect(bson).to.deep.equal(doc);
         });
 
-        it('parses the numberInt and stringify', function () {
+        it('parses the numberInt and stringify', function() {
           const doc = { field: 1 };
           const bson = EJSON.parse('{"field": {"$numberInt": "1"}}');
           expect(EJSON.stringify(bson)).to.deep.equal(JSON.stringify(doc));
         });
       });
 
-      context('when deserializing double', function () {
-        it('parses the number', function () {
+      context('when deserializing double', function() {
+        it('parses the number', function() {
           const doc = { field: 1.1 };
           const bson = EJSON.parse('{"field":1.1}', { legacy: true });
           expect(bson).to.deep.equal(doc);


### PR DESCRIPTION
### Description

#### What is changing?

Adding capability to stringify BigInt

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Allow users to make use of native Javascript `BigInt`s instead of `BSON.Long`

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
