### PR TITLE
feat(NODE-4927): exports in package.json for react native and document how to polyfill for BSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Finally, import the `BSON` library like so:
 import { BSON, EJSON } from 'bson';
 ```
 
-This will resolve the `node_modules/bson/lib/bson.cjs` bundle per the setting we have in the `"exports"` section of our [package.json](./package.json).
+This will cause React Native to import the `node_modules/bson/lib/bson.cjs` bundle (see the `"react-native"` setting we have in the `"exports"` section of our [package.json](./package.json).)
 
 ### Technical Note about React Native module import
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ import { BSON, EJSON } from 'bson';
 
 This will resolve the `node_modules/bson/lib/bson.cjs` bundle per the setting we have in the `"exports"` section of our [package.json](./package.json).
 
-> *Reasoning:* React Native must use the commonjs syntax version of BSON to avoid the unsupported syntax of a top-level await that is used in the es module build.
+### Technical Note about React Native module import
+
+The `"exports"` definition in our `package.json` will result in BSON's CommonJS bundle being imported in a React Native project instead of the ES module bundle.  Importing the CommonJS bundle is necessary because BSON's ES module bundle of BSON uses top-level await, which is not supported syntax in [React Native's runtime hermes](https://hermesengine.dev/).
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -311,10 +311,7 @@ try {
 
 ## React Native
 
-BSON requires `TextEncoder`, `TextDecoder`, `atob`, `btoa`, and `crypto.getRandomValues` to be available on the global object in browser-like environments.
-
-Since React Native has a different JS engine with different globals than either browser or Node.js has, polyfills of those APIs are required to get React Native projects working with BSON or EJSON.
-
+BSON requires that `TextEncoder`, `TextDecoder`, `atob`, `btoa`, and `crypto.getRandomValues` are available globally.  These are present in most Javascript runtimes but require polyfilling in React Native.  Polyfills for the missing functionality can be installed with the following command:
 ```sh
 npm install --save react-native-get-random-values text-encoding-polyfill base-64
 ```

--- a/README.md
+++ b/README.md
@@ -309,6 +309,41 @@ try {
 }
 ```
 
+## React Native
+
+BSON requires `TextEncoder`, `TextDecoder`, `atob`, `btoa`, and `crypto.getRandomValues` to be available on the global object in browser-like environments.
+
+Since React Native has a different JS engine with different globals than either browser or Node.js has, polyfills of those APIs are required to get React Native projects working with BSON or EJSON.
+
+```sh
+npm install --save react-native-get-random-values text-encoding-polyfill base-64
+```
+
+The following snippet should be placed at the top of your index.js file for React Native projects using the BSON library.
+
+```typescript
+// Required Polyfills For ReactNative
+import {encode, decode} from 'base-64';
+if (global.btoa == null) {
+  global.btoa = encode;
+}
+if (global.atob == null) {
+  global.atob = decode;
+}
+import 'text-encoding-polyfill';
+import 'react-native-get-random-values';
+```
+
+Import the BSON library like so:
+
+```typescript
+import { BSON, EJSON } from 'bson';
+```
+
+This will resolve the `node_modules/bson/lib/bson.cjs` bundle per the setting we have in the `"exports"` section of our [package.json](./package.json).
+
+> *Reasoning:* React Native must use the commonjs syntax version of BSON to avoid the unsupported syntax of a top-level await that is used in the es module build.
+
 ## FAQ
 
 #### Why does `undefined` get converted to `null`?

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ import 'text-encoding-polyfill';
 import 'react-native-get-random-values';
 ```
 
-Import the BSON library like so:
+Finally, import the `BSON` library like so:
 
 ```typescript
 import { BSON, EJSON } from 'bson';

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ BSON requires that `TextEncoder`, `TextDecoder`, `atob`, `btoa`, and `crypto.get
 npm install --save react-native-get-random-values text-encoding-polyfill base-64
 ```
 
-The following snippet should be placed at the top of your index.js file for React Native projects using the BSON library.
+The following snippet should be placed at the top of the entrypoint (by default this is the root `index.js` file) for React Native projects using the BSON library.  These lines must be placed for any code that imports `BSON`.
 
 ```typescript
 // Required Polyfills For ReactNative

--- a/package.json
+++ b/package.json
@@ -75,11 +75,11 @@
   },
   "main": "./lib/bson.cjs",
   "module": "./lib/bson.mjs",
-  "browser": "./lib/bson.mjs",
   "exports": {
-    "browser": "./lib/bson.mjs",
     "import": "./lib/bson.mjs",
-    "require": "./lib/bson.cjs"
+    "require": "./lib/bson.cjs",
+    "react-native": "./lib/bson.cjs",
+    "browser": "./lib/bson.mjs"
   },
   "engines": {
     "node": ">=14.20.1"


### PR DESCRIPTION
### Description

#### What is changing?

Add react-native exports specifier.
Set it to the commonjs bundle.
Document polyfills.

#### What is the motivation for this change?

To support react native.

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
