### PR TITLE
fix(NODE-4887): serializeInto does not check for the presence of a toBSON method for values in Map entries

### DIFF
--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -757,7 +757,11 @@ export function serializeInto(
 
       // Get the entry values
       const key = entry.value[0];
-      const value = entry.value[1];
+      let value = entry.value[1];
+
+      if (typeof value?.toBSON === 'function') {
+        value = value.toBSON();
+      }
 
       // Check the type of the value
       const type = typeof value;

--- a/test/node/to_bson_test.js
+++ b/test/node/to_bson_test.js
@@ -184,7 +184,7 @@ describe('toBSON', function () {
       expect(sizeNestedToBSON).to.equal(33);
     });
 
-    it('uses toBSON on elements of a Map', () => {
+    it('uses toBSON on values contained in a map', () => {
       const map = new Map();
       map.set('a', 100);
 

--- a/test/node/to_bson_test.js
+++ b/test/node/to_bson_test.js
@@ -183,6 +183,15 @@ describe('toBSON', function () {
       const sizeNestedToBSON = BSON.calculateObjectSize({ a: [0] });
       expect(sizeNestedToBSON).to.equal(33);
     });
+
+    it('uses toBSON on elements of a Map', () => {
+      const map = new Map();
+      map.set('a', 100);
+
+      const serializedData = BSON.serialize(map);
+      const deserializedData = BSON.deserialize(serializedData);
+      expect(deserializedData).to.have.property('a', 'hello number');
+    });
   });
 
   it('should use toBSON in calculateObjectSize', () => {


### PR DESCRIPTION
### Description

Adding fix to ensure that values of `Map`s run are replaced by the result of calling their `toBSON` method if it exists.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Ensure that `BSON.serialize` keeps with spec behaviour

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
