### PR TITLE
bug(NODE-5047): fix rounding error

### DIFF
--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -434,6 +434,8 @@ export class Decimal128 extends BSONValue {
                 return new Decimal128(isNegative ? INF_NEGATIVE_BUFFER : INF_POSITIVE_BUFFER);
               }
             }
+          } else {
+            break;
           }
         }
       }

--- a/test/node/decimal128_tests.js
+++ b/test/node/decimal128_tests.js
@@ -477,6 +477,9 @@ describe('Decimal128', function () {
 
     expect(bytes).to.deep.equal(result.bytes);
 
+    result = Decimal128.fromString('37.499999999999999196428571428571375');
+    expect(result.toString()).to.deep.equal('37.49999999999999919642857142857138');
+
     // // Create decimal from string value 15E-6177
     // result = Decimal128.fromString('15E-6177');
     // bytes = Buffer.from(


### PR DESCRIPTION
### Description

input: `37.499999999999999196428571428571375`
output (w/o fix): `48.50000000000000020753968253968248`
output (w/ fix): `37.49999999999999919642857142857138`

#### What is changing?

It needs to break the loop when it finds the first non-9 digit during rounding

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
