### PR TITLE
chore(NODE-5057): add compass:exports fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
     "react-native": "./lib/bson.cjs",
     "browser": "./lib/bson.mjs"
   },
+  "compass:exports": {
+    "import": "./lib/bson.cjs",
+    "require": "./lib/bson.cjs"
+  },
   "engines": {
     "node": ">=14.20.1"
   },


### PR DESCRIPTION
This helps resolve Compass-specific bundling headaches.

### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
