### PR TITLE
fix(NODE-5056): EJSON.parse date handling when useBigInt64=true

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -50,7 +50,7 @@ export {
   Decimal128
 };
 export { BSONValue } from './bson_value';
-export { BSONError, BSONVersionError } from './error';
+export { BSONError, BSONVersionError, BSONRuntimeError } from './error';
 export { BSONType } from './constants';
 export { EJSON } from './extended_json';
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -58,3 +58,14 @@ export class BSONVersionError extends BSONError {
     );
   }
 }
+
+/** @public */
+export class BSONRuntimeError extends BSONError {
+  get name(): 'BSONRuntimeError' {
+    return 'BSONRuntimeError';
+  }
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -6,7 +6,7 @@ import { BSON_MAJOR_VERSION } from './constants';
  *
  * `BSONError` objects are thrown when BSON ecounters an error.
  *
- * This is the parent calss for all the other errors thrown in this library.
+ * This is the parent class for all the other errors thrown by this library.
  */
 export class BSONError extends Error {
   /**

--- a/src/error.ts
+++ b/src/error.ts
@@ -4,7 +4,9 @@ import { BSON_MAJOR_VERSION } from './constants';
  * @public
  * @category Error
  *
- * `BSONError` objects are thrown when runtime errors occur.
+ * `BSONError` objects are thrown when BSON ecounters an error.
+ *
+ * This is the parent calss for all the other errors thrown in this library.
  */
 export class BSONError extends Error {
   /**

--- a/src/error.ts
+++ b/src/error.ts
@@ -2,6 +2,8 @@ import { BSON_MAJOR_VERSION } from './constants';
 
 /**
  * @public
+ * @category Error
+ *
  * `BSONError` objects are thrown when runtime errors occur.
  */
 export class BSONError extends Error {
@@ -46,7 +48,10 @@ export class BSONError extends Error {
   }
 }
 
-/** @public */
+/**
+ * @public
+ * @category Error
+ */
 export class BSONVersionError extends BSONError {
   get name(): 'BSONVersionError' {
     return 'BSONVersionError';
@@ -59,7 +64,14 @@ export class BSONVersionError extends BSONError {
   }
 }
 
-/** @public */
+/**
+ * @public
+ * @category Error
+ *
+ * An error generated when BSON functions encounter an unexpected input
+ * or reaches an unexpected/invalid internal state
+ *
+ */
 export class BSONRuntimeError extends BSONError {
   get name(): 'BSONRuntimeError' {
     return 'BSONRuntimeError';

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -126,13 +126,13 @@ function deserializeValue(value: any, options: EJSONOptions = {}) {
       if (typeof d === 'number') date.setTime(d);
       else if (typeof d === 'string') date.setTime(Date.parse(d));
       else if (typeof d === 'bigint') date.setTime(Number(d));
-      else throw new BSONRuntimeError('Unrecognized type for EJSON date');
+      else throw new BSONRuntimeError(`Unrecognized type for EJSON date: ${typeof d}`);
     } else {
       if (typeof d === 'string') date.setTime(Date.parse(d));
       else if (Long.isLong(d)) date.setTime(d.toNumber());
       else if (typeof d === 'number' && options.relaxed) date.setTime(d);
       else if (typeof d === 'bigint') date.setTime(Number(d));
-      else throw new BSONRuntimeError('Unrecognized type for EJSON date');
+      else throw new BSONRuntimeError(`Unrecognized type for EJSON date: ${typeof d}`);
     }
     return date;
   }

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -11,7 +11,7 @@ import {
 import { DBRef, isDBRefLike } from './db_ref';
 import { Decimal128 } from './decimal128';
 import { Double } from './double';
-import { BSONError, BSONVersionError } from './error';
+import { BSONError, BSONRuntimeError, BSONVersionError } from './error';
 import { Int32 } from './int_32';
 import { Long } from './long';
 import { MaxKey } from './max_key';
@@ -125,10 +125,14 @@ function deserializeValue(value: any, options: EJSONOptions = {}) {
     if (options.legacy) {
       if (typeof d === 'number') date.setTime(d);
       else if (typeof d === 'string') date.setTime(Date.parse(d));
+      else if (typeof d === 'bigint') date.setTime(Number(d));
+      else throw new BSONRuntimeError('Unrecognized type for EJSON date');
     } else {
       if (typeof d === 'string') date.setTime(Date.parse(d));
       else if (Long.isLong(d)) date.setTime(d.toNumber());
       else if (typeof d === 'number' && options.relaxed) date.setTime(d);
+      else if (typeof d === 'bigint') date.setTime(Number(d));
+      else throw new BSONRuntimeError('Unrecognized type for EJSON date');
     }
     return date;
   }

--- a/test/node/error.test.ts
+++ b/test/node/error.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { loadESModuleBSON } from '../load_bson';
 
-import { __isWeb__, BSONError, BSONVersionError } from '../register-bson';
+import { __isWeb__, BSONError, BSONVersionError, BSONRuntimeError } from '../register-bson';
 
 const instanceOfChecksWork = !__isWeb__;
 
@@ -90,6 +90,16 @@ describe('BSONError', function () {
 
     it('has a name property equal to "BSONVersionError"', () => {
       expect(new BSONVersionError()).to.have.property('name', 'BSONVersionError');
+    });
+  });
+
+  describe('class BSONRuntimeError', function () {
+    it('is a BSONError instance', function () {
+      expect(BSONError.isBSONError(new BSONRuntimeError('Oopsie'))).to.be.true;
+    });
+
+    it('has a name property equal to "BSONRuntimeError"', function () {
+      expect(new BSONRuntimeError('Woops!')).to.have.property('name', 'BSONRuntimeError');
     });
   });
 });

--- a/test/node/exports.test.ts
+++ b/test/node/exports.test.ts
@@ -26,6 +26,7 @@ const EXPECTED_EXPORTS = [
   'BSONRegExp',
   'Decimal128',
   'BSONError',
+  'BSONRuntimeError',
   'setInternalBufferSize',
   'serialize',
   'serializeWithBufferAndIndex',


### PR DESCRIPTION
### Description

`EJSON.parse` fails to correctly deserialize cEJSON strings which contain date fields.

#### What is changing?

- `EJSON.parse` now correctly deserializes cEJSON dates
- Added new `BSONError` subclass, `BSONRuntimeError` to cover internal failures

##### Is there new documentation needed for these changes?

No

### Double check the following

- [X] Ran `npm run lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
