### PR TITLE
fix(NODE-5025): no type definitions for es module

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,14 @@
   "main": "./lib/bson.cjs",
   "module": "./lib/bson.mjs",
   "exports": {
-    "import": "./lib/bson.mjs",
-    "require": "./lib/bson.cjs",
+    "import": {
+      "types": "./bson.d.ts",
+      "default": "./lib/bson.mjs"
+    },
+    "require": {
+      "types": "./bson.d.ts",
+      "default": "./lib/bson.cjs"
+    },
     "react-native": "./lib/bson.cjs",
     "browser": "./lib/bson.mjs"
   },


### PR DESCRIPTION
### Description

#### What is changing?

- Updated the package.json to make the typedefs available for mjs users
- Added a test that will prevent the order of keys from changing
- I verified locally with my reproduction that the type defs are picked up now

#### What is the motivation for this change?

TS defs don't show up for module: node16/nodeNext TS users

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
