### PR TITLE
fix(NODE-5048): webpack unable to bundle import with leading 'node:'

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -81,6 +81,17 @@ functions:
         binary: bash
         args:
           - .evergreen/run-eslint-plugin-test.sh
+  run bundling:
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src
+        binary: bash
+        env:
+          NODE_VERSION: ${NODE_VERSION}
+          PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+        args:
+          - .evergreen/run-bundling-test.sh
 
 tasks:
   - name: node-tests-v14
@@ -133,6 +144,13 @@ tasks:
       - func: run tests
         vars:
           TEST_TARGET: web
+  - name: bundling-tests
+    commands:
+      - func: fetch source
+        vars:
+          NODE_MAJOR_VERSION: 18
+      - func: install dependencies
+      - func: run bundling
   - name: no-bigint-web-tests
     tags: ["no-bigint", "web"]
     commands:
@@ -204,3 +222,4 @@ buildvariants:
       - check-typescript-oldest
       - check-typescript-current
       - check-typescript-next
+      - bundling-tests

--- a/.evergreen/run-bundling-test.sh
+++ b/.evergreen/run-bundling-test.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+source "${PROJECT_DIRECTORY}/.evergreen/init-nvm.sh"
+
+set -o xtrace
+set -o errexit
+
+pushd test/bundling/webpack
+
+npm install
+npm run install:bson
+npm run build

--- a/README.md
+++ b/README.md
@@ -309,20 +309,6 @@ try {
 }
 ```
 
-## Webpack
-
-In order to use BSON with webpack the following settings to the config object exported by `webpack.config.js` are required:
-- `experiments: { topLevelAwait: true }`
-- `resolve: { fallback: { crypto: false } }`
-
-See our example webpack project in `test/bundling/webpack`.
-
-> Note: We do not expect these options to be necessary forever.
->
-> Top Level Await is stage 4 so it should eventually become stable in bundlers as well.
->
-> Setting `crypto` to resolve to an empty module is only necessary because our supported versions of Node.js do not yet have a `crypto` global. When we support Node.js 20 or later, both Node.js and web code paths will be able to use the global removing the need for an `import`.
-
 ## React Native
 
 BSON requires that `TextEncoder`, `TextDecoder`, `atob`, `btoa`, and `crypto.getRandomValues` are available globally.  These are present in most Javascript runtimes but require polyfilling in React Native.  Polyfills for the missing functionality can be installed with the following command:

--- a/README.md
+++ b/README.md
@@ -309,6 +309,20 @@ try {
 }
 ```
 
+## Webpack
+
+In order to use BSON with webpack the following settings to the config object exported by `webpack.config.js` are required:
+- `experiments: { topLevelAwait: true }`
+- `resolve: { fallback: { crypto: false } }`
+
+See our example webpack project in `test/bundling/webpack`.
+
+> Note: We do not expect these options to be necessary forever.
+>
+> Top Level Await is stage 4 so it should eventually become stable in bundlers as well.
+>
+> Setting `crypto` to resolve to an empty module is only necessary because our supported versions of Node.js do not yet have a `crypto` global. When we support Node.js 20 or later, both Node.js and web code paths will be able to use the global removing the need for an `import`.
+
 ## React Native
 
 BSON requires that `TextEncoder`, `TextDecoder`, `atob`, `btoa`, and `crypto.getRandomValues` are available globally.  These are present in most Javascript runtimes but require polyfilling in React Native.  Polyfills for the missing functionality can be installed with the following command:

--- a/etc/rollup/rollup-plugin-require-rewriter/require_rewriter.mjs
+++ b/etc/rollup/rollup-plugin-require-rewriter/require_rewriter.mjs
@@ -2,13 +2,13 @@ import MagicString from 'magic-string';
 
 const CRYPTO_IMPORT_ESM_SRC = `const nodejsRandomBytes = await (async () => {
     try {
-        return (await import('node:crypto')).randomBytes;`;
+        return (await import('crypto')).randomBytes;`;
 
 export class RequireRewriter {
   /**
    * Take the compiled source code input; types are expected to already have been removed
    * Look for the function that depends on crypto, replace it with a top-level await
-   * and dynamic import for the node:crypto module.
+   * and dynamic import for the crypto module.
    *
    * @param {string} code - source code of the module being transformed
    * @param {string} id - module id (usually the source file name)
@@ -23,12 +23,12 @@ export class RequireRewriter {
     }
 
     const start = code.indexOf('const nodejsRandomBytes');
-    const endString = `return require('node:crypto').randomBytes;`;
+    const endString = `return require('crypto').randomBytes;`;
     const end = code.indexOf(endString) + endString.length;
 
     if (start < 0 || end < 0) {
       throw new Error(
-        `Unexpected! 'const nodejsRandomBytes' or 'return require('node:crypto').randomBytes;' not found`
+        `Unexpected! 'const nodejsRandomBytes' or 'return require('crypto').randomBytes;' not found`
       );
     }
 

--- a/src/utils/node_byte_utils.ts
+++ b/src/utils/node_byte_utils.ts
@@ -22,7 +22,7 @@ type NodeJsBufferConstructor = Omit<Uint8ArrayConstructor, 'from'> & {
 // This can be nullish, but we gate the nodejs functions on being exported whether or not this exists
 // Node.js global
 declare const Buffer: NodeJsBufferConstructor;
-declare const require: (mod: 'node:crypto') => { randomBytes: (byteLength: number) => Uint8Array };
+declare const require: (mod: 'crypto') => { randomBytes: (byteLength: number) => Uint8Array };
 
 /** @internal */
 export function nodejsMathRandomBytes(byteLength: number) {
@@ -48,7 +48,7 @@ export function nodejsMathRandomBytes(byteLength: number) {
  */
 const nodejsRandomBytes: (byteLength: number) => Uint8Array = (() => {
   try {
-    return require('node:crypto').randomBytes;
+    return require('crypto').randomBytes;
   } catch {
     return nodejsMathRandomBytes;
   }

--- a/test/bundling/webpack/.gitignore
+++ b/test/bundling/webpack/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/test/bundling/webpack/install_bson.cjs
+++ b/test/bundling/webpack/install_bson.cjs
@@ -1,0 +1,24 @@
+'use strict';
+
+const { execSync } = require('node:child_process');
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+const xtrace = (...args) => {
+  console.log(`running: ${args[0]}`);
+  return execSync(...args);
+};
+
+const bsonRoot = resolve(__dirname, '../../..');
+console.log(`bson package root: ${bsonRoot}`);
+
+const bsonVersion = JSON.parse(
+  readFileSync(resolve(bsonRoot, 'package.json'), { encoding: 'utf8' })
+).version;
+console.log(`bsonVersion: ${bsonVersion}`);
+
+xtrace('npm pack --pack-destination test/bundling/webpack', { cwd: bsonRoot });
+
+xtrace(`npm install --no-save bson-${bsonVersion}.tgz`);
+
+console.log('bson installed!');

--- a/test/bundling/webpack/package.json
+++ b/test/bundling/webpack/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "my-webpack-project",
+  "version": "1.0.0",
+  "private": true,
+  "description": "My webpack project",
+  "main": "index.js",
+  "scripts": {
+    "install:bson": "node install_bson.cjs",
+    "test": "webpack",
+    "build": "webpack --mode=production --node-env=production",
+    "build:dev": "webpack --mode=development",
+    "build:prod": "webpack --mode=production --node-env=production",
+    "watch": "webpack --watch"
+  },
+  "devDependencies": {
+    "@webpack-cli/generators": "^3.0.1",
+    "ts-loader": "^9.4.2",
+    "typescript": "^4.9.5",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1"
+  },
+  "dependencies": {}
+}

--- a/test/bundling/webpack/readme.md
+++ b/test/bundling/webpack/readme.md
@@ -1,0 +1,14 @@
+# Webpack BSON setup example
+
+In order to use BSON with webpack there are two changes beyond the default config file needed:
+- Set `experiments: { topLevelAwait: true }` in the top-level config object
+- Set `resolve: { fallback: { crypto: false } }` in the top-level config object
+
+## Testing
+
+To use this bundler test:
+- Make changes to bson
+- run `npm run build` in the root of the repo to rebuild the BSON src
+- in this directory run `npm run install:bson` to install BSON as if it were from npm
+  - We use a `.tgz` install to make sure we're using exactly what will be published to npm
+- run `npm run build` to check that webpack can pull in the changes

--- a/test/bundling/webpack/src/index.ts
+++ b/test/bundling/webpack/src/index.ts
@@ -1,0 +1,3 @@
+import { BSON } from 'bson';
+
+console.log(new BSON.ObjectId());

--- a/test/bundling/webpack/tsconfig.json
+++ b/test/bundling/webpack/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "module": "es6",
+    "target": "es5",
+    "allowJs": true
+  },
+  "files": ["src/index.ts"]
+}

--- a/test/bundling/webpack/webpack.config.js
+++ b/test/bundling/webpack/webpack.config.js
@@ -1,0 +1,47 @@
+// Generated using webpack-cli https://github.com/webpack/webpack-cli
+'use strict';
+
+const path = require('path');
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const config = {
+  entry: './src/index.ts',
+  output: {
+    path: path.resolve(__dirname, 'dist')
+  },
+  plugins: [
+    // Add your plugins here
+    // Learn more about plugins from https://webpack.js.org/configuration/plugins/
+  ],
+  experiments: { topLevelAwait: true },
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)$/i,
+        loader: 'ts-loader',
+        exclude: ['/node_modules/']
+      },
+      {
+        test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
+        type: 'asset'
+      }
+
+      // Add your rules for custom modules here
+      // Learn more about loaders from https://webpack.js.org/loaders/
+    ]
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.jsx', '.js', '...'],
+    fallback: { crypto: false }
+  }
+};
+
+module.exports = () => {
+  if (isProduction) {
+    config.mode = 'production';
+  } else {
+    config.mode = 'development';
+  }
+  return config;
+};


### PR DESCRIPTION
### Description

#### What is changing?

- Remove 'node:' from crypto import
- Change rollup plugin to also remove 'node:'
- Added an example webpack config bundling bson
  - New evergreen task: 
    - takes the current bson src
    - runs rollup and npm pack to get a tgz of lib
    - installs the tgz as a dependency of the webpack project
    - tries to build using webpack
- Added webpack documentation to readme.md

#### What is the motivation for this change?

It may not be immediately clear what the workarounds are for making webpack compatible with BSON. So we're now integration testing and documenting the expected path.

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
