### PR TITLE
feat(NODE-4855): add hex and base64 ctor methods to Binary and ObjectId

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -258,6 +258,36 @@ export class Binary extends BSONValue {
     );
   }
 
+  /** Creates an Binary instance from a hex digit string */
+  static createFromHexString(hex: string, subType?: number): Binary {
+    const bytes = ByteUtils.fromHex(hex);
+    return new Binary(bytes, subType);
+  }
+
+  /** Creates an Binary instance from a base64 string */
+  static createFromBase64(base64: string, subType?: number): Binary {
+    const bytes = ByteUtils.fromBase64(base64);
+    return new Binary(bytes, subType);
+  }
+
+  /**
+   * Creates a new view over sequence and constructs a new Binary instance.
+   *
+   * @param sequence - A sequence of binary data
+   * @param subType - BSON Binary subtype, defaults to zero
+   * @param byteOffset - An offset to start the view from
+   * @param byteLength - A length to set the view to
+   */
+  static createFromBytes(
+    sequence: Uint8Array | ArrayBuffer | SharedArrayBuffer,
+    subType = 0,
+    byteOffset = 0,
+    byteLength = sequence.byteLength
+  ): Binary {
+    const bytes = ByteUtils.toLocalBufferType(sequence).subarray(byteOffset, byteLength);
+    return new Binary(bytes, subType);
+  }
+
   /** @internal */
   static fromExtendedJSON(
     doc: BinaryExtendedLegacy | BinaryExtended | UUIDExtended,
@@ -464,9 +494,31 @@ export class UUID extends Binary {
    * Creates an UUID from a hex string representation of an UUID.
    * @param hexString - 32 or 36 character hex string (dashes excluded/included).
    */
-  static createFromHexString(hexString: string): UUID {
+  static override createFromHexString(hexString: string): UUID {
     const buffer = uuidHexStringToBuffer(hexString);
     return new UUID(buffer);
+  }
+
+  /** Creates an UUID from a base64 string representation of an UUID. */
+  static override createFromBase64(base64: string): UUID {
+    const bytes = ByteUtils.fromBase64(base64);
+    return new UUID(bytes);
+  }
+
+  /**
+   * Creates a new view over sequence and constructs a new UUID instance.
+   *
+   * @param sequence - A sequence of binary data
+   * @param byteOffset - An offset to start the view from
+   * @param byteLength - A length to set the view to
+   */
+  static override createFromBytes(
+    sequence: Uint8Array | ArrayBuffer | SharedArrayBuffer,
+    byteOffset = 0,
+    byteLength = sequence.byteLength
+  ): UUID {
+    const bytes = ByteUtils.toLocalBufferType(sequence).subarray(byteOffset, byteLength);
+    return new UUID(bytes);
   }
 
   /**

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -322,7 +322,13 @@ export class Binary extends BSONValue {
   }
 
   inspect(): string {
-    return `new Binary(Buffer.from("${ByteUtils.toHex(this.buffer)}", "hex"), ${this.sub_type})`;
+    if (this.position === 0) {
+      return this.sub_type !== Binary.BSON_BINARY_SUBTYPE_DEFAULT
+        ? `new Binary(undefined, ${this.sub_type})`
+        : 'new Binary()';
+    }
+    const base64 = ByteUtils.toBase64(this.buffer.subarray(0, this.position));
+    return `Binary.createFromBase64("${base64}", ${this.sub_type})`;
   }
 }
 

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -260,32 +260,12 @@ export class Binary extends BSONValue {
 
   /** Creates an Binary instance from a hex digit string */
   static createFromHexString(hex: string, subType?: number): Binary {
-    const bytes = ByteUtils.fromHex(hex);
-    return new Binary(bytes, subType);
+    return new Binary(ByteUtils.fromHex(hex), subType);
   }
 
   /** Creates an Binary instance from a base64 string */
   static createFromBase64(base64: string, subType?: number): Binary {
-    const bytes = ByteUtils.fromBase64(base64);
-    return new Binary(bytes, subType);
-  }
-
-  /**
-   * Creates a new view over sequence and constructs a new Binary instance.
-   *
-   * @param sequence - A sequence of binary data
-   * @param subType - BSON Binary subtype, defaults to zero
-   * @param byteOffset - An offset to start the view from
-   * @param byteLength - A length to set the view to
-   */
-  static createFromBytes(
-    sequence: Uint8Array | ArrayBuffer | SharedArrayBuffer,
-    subType = 0,
-    byteOffset = 0,
-    byteLength = sequence.byteLength
-  ): Binary {
-    const bytes = ByteUtils.toLocalBufferType(sequence).subarray(byteOffset, byteLength);
-    return new Binary(bytes, subType);
+    return new Binary(ByteUtils.fromBase64(base64), subType);
   }
 
   /** @internal */
@@ -508,22 +488,6 @@ export class UUID extends Binary {
   /** Creates an UUID from a base64 string representation of an UUID. */
   static override createFromBase64(base64: string): UUID {
     const bytes = ByteUtils.fromBase64(base64);
-    return new UUID(bytes);
-  }
-
-  /**
-   * Creates a new view over sequence and constructs a new UUID instance.
-   *
-   * @param sequence - A sequence of binary data
-   * @param byteOffset - An offset to start the view from
-   * @param byteLength - A length to set the view to
-   */
-  static override createFromBytes(
-    sequence: Uint8Array | ArrayBuffer | SharedArrayBuffer,
-    byteOffset = 0,
-    byteLength = sequence.byteLength
-  ): UUID {
-    const bytes = ByteUtils.toLocalBufferType(sequence).subarray(byteOffset, byteLength);
     return new UUID(bytes);
   }
 

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -264,11 +264,8 @@ export class ObjectId extends BSONValue {
    * @param hexString - create a ObjectId from a passed in 24 character hexstring.
    */
   static createFromHexString(hexString: string): ObjectId {
-    // Throw an error if it's not a valid setup
-    if (typeof hexString === 'undefined' || (hexString != null && hexString.length !== 24)) {
-      throw new BSONError(
-        'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
-      );
+    if (hexString?.length !== 24) {
+      throw new BSONError('hex string must be 24 characters');
     }
 
     return new ObjectId(ByteUtils.fromHex(hexString));
@@ -276,24 +273,11 @@ export class ObjectId extends BSONValue {
 
   /** Creates an ObjectId instance from a base64 string */
   static createFromBase64(base64: string): ObjectId {
-    const bytes = ByteUtils.fromBase64(base64);
-    return new ObjectId(bytes);
-  }
+    if (base64?.length !== 16) {
+      throw new BSONError('base64 string must be 16 characters');
+    }
 
-  /**
-   * Creates a new view over sequence and constructs a new ObjectId instance.
-   *
-   * @param sequence - A sequence of binary data
-   * @param byteOffset - An offset to start the view from
-   * @param byteLength - A length to set the view to
-   */
-  static createFromBytes(
-    sequence: Uint8Array | ArrayBuffer | SharedArrayBuffer,
-    byteOffset = 0,
-    byteLength = sequence.byteLength
-  ): ObjectId {
-    const bytes = ByteUtils.toLocalBufferType(sequence).subarray(byteOffset, byteLength);
-    return new ObjectId(bytes);
+    return new ObjectId(ByteUtils.fromBase64(base64));
   }
 
   /**

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -274,6 +274,28 @@ export class ObjectId extends BSONValue {
     return new ObjectId(ByteUtils.fromHex(hexString));
   }
 
+  /** Creates an ObjectId instance from a base64 string */
+  static createFromBase64(base64: string): ObjectId {
+    const bytes = ByteUtils.fromBase64(base64);
+    return new ObjectId(bytes);
+  }
+
+  /**
+   * Creates a new view over sequence and constructs a new ObjectId instance.
+   *
+   * @param sequence - A sequence of binary data
+   * @param byteOffset - An offset to start the view from
+   * @param byteLength - A length to set the view to
+   */
+  static createFromBytes(
+    sequence: Uint8Array | ArrayBuffer | SharedArrayBuffer,
+    byteOffset = 0,
+    byteLength = sequence.byteLength
+  ): ObjectId {
+    const bytes = ByteUtils.toLocalBufferType(sequence).subarray(byteOffset, byteLength);
+    return new ObjectId(bytes);
+  }
+
   /**
    * Checks if a value is a valid bson ObjectId
    *

--- a/test/node/binary.test.ts
+++ b/test/node/binary.test.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { Binary } from '../register-bson';
+
+describe('class Binary', () => {
+  context('constructor()', () => {
+    it('creates an 256 byte Binary with subtype 0 by default', () => {
+      const binary = new Binary();
+      expect(binary).to.have.property('buffer');
+      expect(binary).to.have.property('position', 0);
+      expect(binary).to.have.property('sub_type', 0);
+      expect(binary).to.have.nested.property('buffer.byteLength', 256);
+      const emptyZeroedArray = new Uint8Array(256);
+      emptyZeroedArray.fill(0x00);
+      expect(binary.buffer).to.deep.equal(emptyZeroedArray);
+    });
+  });
+});

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1829,9 +1829,7 @@ describe('BSON', function () {
      */
     it('Binary', function () {
       const binary = new Binary(Buffer.from('0123456789abcdef0123456789abcdef', 'hex'), 4);
-      expect(inspect(binary)).to.equal(
-        'new Binary(Buffer.from("0123456789abcdef0123456789abcdef", "hex"), 4)'
-      );
+      expect(inspect(binary)).to.equal('Binary.createFromBase64("ASNFZ4mrze8BI0VniavN7w==", 4)');
     });
 
     /**

--- a/test/node/bson_type_classes.test.ts
+++ b/test/node/bson_type_classes.test.ts
@@ -15,8 +15,10 @@ import {
   ObjectId,
   Timestamp,
   UUID,
-  BSONValue
+  BSONValue,
+  BSON
 } from '../register-bson';
+import * as vm from 'node:vm';
 
 const BSONTypeClasses = [
   Binary,
@@ -97,4 +99,15 @@ describe('BSON Type classes common interfaces', () => {
           .that.is.a('function'));
     });
   }
+
+  context(`when inspect() is called`, () => {
+    for (const [name, factory] of BSONTypeClassCtors) {
+      it(`${name} returns string that is runnable and has deep equality`, () => {
+        const bsonValue = factory();
+        const ctx = { ...BSON, module: { exports: { result: null } } };
+        vm.runInNewContext(`module.exports.result = ${bsonValue.inspect()}`, ctx);
+        expect(ctx.module.exports.result).to.deep.equal(bsonValue);
+      });
+    }
+  });
 });

--- a/test/node/object_id.test.ts
+++ b/test/node/object_id.test.ts
@@ -1,12 +1,10 @@
-'use strict';
-
-const Buffer = require('buffer').Buffer;
-const { BSON, BSONError, EJSON, ObjectId } = require('../register-bson');
-const util = require('util');
-const { expect } = require('chai');
-const { bufferFromHexArray } = require('./tools/utils');
-const getSymbolFrom = require('./tools/utils').getSymbolFrom;
-const isBufferOrUint8Array = require('./tools/utils').isBufferOrUint8Array;
+import { Buffer } from 'buffer';
+import { BSON, BSONError, EJSON, ObjectId } from '../register-bson';
+import * as util from 'util';
+import { expect } from 'chai';
+import { bufferFromHexArray } from './tools/utils';
+import { getSymbolFrom } from './tools/utils';
+import { isBufferOrUint8Array } from './tools/utils';
 
 describe('ObjectId', function () {
   describe('static createFromTime()', () => {

--- a/test/node/object_id.test.ts
+++ b/test/node/object_id.test.ts
@@ -475,4 +475,36 @@ describe('ObjectId', function () {
     // class method equality
     expect(Buffer.prototype.equals.call(inBuffer, outBuffer.id)).to.be.true;
   });
+
+  context('createFromHexString()', () => {
+    context('when called with a hex sequence', () => {
+      it('returns a ObjectId instance with the decoded bytes', () => {
+        const bytes = Buffer.from('0'.repeat(24), 'hex');
+        const binary = ObjectId.createFromHexString(bytes.toString('hex'));
+        expect(binary).to.have.deep.property('id', bytes);
+      });
+    });
+
+    context('when called with an incorrect length string', () => {
+      it('throws an error indicating the expected length of 24', () => {
+        expect(() => ObjectId.createFromHexString('')).to.throw(/24/);
+      });
+    });
+  });
+
+  context('createFromBase64()', () => {
+    context('when called with a base64 sequence', () => {
+      it('returns a ObjectId instance with the decoded bytes', () => {
+        const bytes = Buffer.from('A'.repeat(16), 'base64');
+        const binary = ObjectId.createFromBase64(bytes.toString('base64'));
+        expect(binary).to.have.deep.property('id', bytes);
+      });
+    });
+
+    context('when called with an incorrect length string', () => {
+      it('throws an error indicating the expected length of 16', () => {
+        expect(() => ObjectId.createFromBase64('')).to.throw(/16/);
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
