### PR TITLE
chore(NODE-5324): update to typescript 5

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -64,6 +64,14 @@
     "@typescript-eslint/no-unsafe-return": "off",
     "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "disallowTypeAnnotations": false,
+        "fixStyle": "inline-type-imports"
+      }
+    ],
     "no-bigint-usage/no-bigint-literals": "error",
     "no-restricted-globals": [
       "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
-        "@microsoft/api-extractor": "^7.34.7",
+        "@microsoft/api-extractor": "^7.35.1",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-typescript": "^11.1.0",
         "@types/chai": "^4.3.5",
@@ -40,7 +40,7 @@
         "standard-version": "^9.5.0",
         "ts-node": "^10.9.1",
         "tsd": "^0.28.1",
-        "typescript": "^4.9.4",
+        "typescript": "^5.0.4",
         "typescript-cached-transpile": "0.0.6",
         "uuid": "^9.0.0",
         "v8-profiler-next": "^1.9.0"
@@ -752,50 +752,37 @@
       "dev": true
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.34.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.7.tgz",
-      "integrity": "sha512-8CrrYyOBWqc4XFviR1KSuHSlmJjlnC5CVpPkcFB8HXiLABUVaVWFTsOzJIwUU6z8mc4BZPZ8tSGAg/mwFDU31Q==",
+      "version": "7.35.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.35.1.tgz",
+      "integrity": "sha512-xGVf1lKCYKEyJsspLzQjo4Oo6PGDPH95Z5/te75xQWpcRHcfemb6zTSPtiFeVDHkg9Tan5HW2QXGLwQRkW199w==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.26.7",
+        "@microsoft/api-extractor-model": "7.27.1",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.58.0",
-        "@rushstack/rig-package": "0.3.18",
-        "@rushstack/ts-command-line": "4.13.2",
+        "@rushstack/node-core-library": "3.59.2",
+        "@rushstack/rig-package": "0.3.19",
+        "@rushstack/ts-command-line": "4.13.3",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.22.1",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
-        "typescript": "~4.8.4"
+        "typescript": "~5.0.4"
       },
       "bin": {
         "api-extractor": "bin/api-extractor"
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.7.tgz",
-      "integrity": "sha512-rx3Tq632VG3ddR74kPuPbv1qmUgO2IuCvn1z16hbNWNS5RhnTQqNPWIm7NVoi6lCh2E7uxzfmdnWXIXiJhM5IQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.27.1.tgz",
+      "integrity": "sha512-WgmuQwElTuRLATQxCx+pqk5FtUeRX3FW8WDo7tSDmrN/7+XAggeVg5t8ItiJt688jEdbiPvagZlvjAcJMpXspg==",
       "dev": true,
       "dependencies": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.58.0"
-      }
-    },
-    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "@rushstack/node-core-library": "3.59.2"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -980,9 +967,9 @@
       }
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.58.0.tgz",
-      "integrity": "sha512-DHAZ3LTOEq2/EGURznpTJDnB3SNE2CKMDXuviQ6afhru6RykE3QoqXkeyjbpLb5ib5cpIRCPE/wykNe0xmQj3w==",
+      "version": "3.59.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.59.2.tgz",
+      "integrity": "sha512-Od8i9ZXiRPHrnkuNOZ9IjEYRQ9JsBLNHlkWJr1wSQZrD2TVIc8APpIB/FnzEcjfpbJMT4XhtcCZaa0pVx+hTXw==",
       "dev": true,
       "dependencies": {
         "colors": "~1.2.1",
@@ -1003,9 +990,9 @@
       }
     },
     "node_modules/@rushstack/rig-package": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.18.tgz",
-      "integrity": "sha512-SGEwNTwNq9bI3pkdd01yCaH+gAsHqs0uxfGvtw9b0LJXH52qooWXnrFTRRLG1aL9pf+M2CARdrA9HLHJys3jiQ==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.19.tgz",
+      "integrity": "sha512-2d0/Gn+qjOYneZbiHjn4SjyDwq9I0WagV37z0F1V71G+yONgH7wlt3K/UoNiDkhA8gTHYPRo2jz3CvttybwSag==",
       "dev": true,
       "dependencies": {
         "resolve": "~1.22.1",
@@ -1013,9 +1000,9 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.13.2.tgz",
-      "integrity": "sha512-bCU8qoL9HyWiciltfzg7GqdfODUeda/JpI0602kbN5YH22rzTxyqYvv7aRLENCM7XCQ1VRs7nMkEqgJUOU8Sag==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.13.3.tgz",
+      "integrity": "sha512-6aQIv/o1EgsC/+SpgUyRmzg2QIAL6sudEzw3sWzJKwWuQTc5XRsyZpyldfE7WAmIqMXDao9QG35/NYORjHm5Zw==",
       "dev": true,
       "dependencies": {
         "@types/argparse": "1.0.38",
@@ -7628,16 +7615,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/typescript-cached-transpile": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
-    "@microsoft/api-extractor": "^7.34.7",
+    "@microsoft/api-extractor": "^7.35.1",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-typescript": "^11.1.0",
     "@types/chai": "^4.3.5",
@@ -56,7 +56,7 @@
     "standard-version": "^9.5.0",
     "ts-node": "^10.9.1",
     "tsd": "^0.28.1",
-    "typescript": "^4.9.4",
+    "typescript": "^5.0.4",
     "typescript-cached-transpile": "0.0.6",
     "uuid": "^9.0.0",
     "v8-profiler-next": "^1.9.0"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,8 +16,6 @@ const tsConfig = {
   importHelpers: false,
   noEmitHelpers: false,
   noEmitOnError: true,
-  // make use of import type where applicable
-  importsNotUsedAsValues: 'error',
   // Generate separate source maps files with sourceContent included
   sourceMap: true,
   inlineSourceMap: false,

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -10,8 +10,8 @@ import { MinKey } from './min_key';
 import { ObjectId } from './objectid';
 import { internalCalculateObjectSize } from './parser/calculate_size';
 // Parts of the parser
-import { internalDeserialize, DeserializeOptions } from './parser/deserializer';
-import { serializeInto, SerializeOptions } from './parser/serializer';
+import { internalDeserialize, type DeserializeOptions } from './parser/deserializer';
+import { serializeInto, type SerializeOptions } from './parser/serializer';
 import { BSONRegExp } from './regexp';
 import { BSONSymbol } from './symbol';
 import { Timestamp } from './timestamp';

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -2,7 +2,7 @@ import { Binary, UUID } from '../binary';
 import type { Document } from '../bson';
 import { Code } from '../code';
 import * as constants from '../constants';
-import { DBRef, DBRefLike, isDBRefLike } from '../db_ref';
+import { DBRef, type DBRefLike, isDBRefLike } from '../db_ref';
 import { Decimal128 } from '../decimal128';
 import { Double } from '../double';
 import { BSONError } from '../error';

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -61,24 +61,26 @@ export class Timestamp extends LongWithoutOverridesClass {
       if (typeof low.i !== 'number' && (typeof low.i !== 'object' || low.i._bsontype !== 'Int32')) {
         throw new BSONError('Timestamp constructed from { t, i } must provide i as a number');
       }
-      if (low.t.valueOf() < 0) {
+      const t = Number(low.t);
+      const i = Number(low.i);
+      if (t < 0 || Number.isNaN(t)) {
         throw new BSONError('Timestamp constructed from { t, i } must provide a positive t');
       }
-      if (low.i.valueOf() < 0) {
+      if (i < 0 || Number.isNaN(i)) {
         throw new BSONError('Timestamp constructed from { t, i } must provide a positive i');
       }
-      if (low.t.valueOf() > 0xffff_ffff) {
+      if (t > 0xffff_ffff) {
         throw new BSONError(
           'Timestamp constructed from { t, i } must provide t equal or less than uint32 max'
         );
       }
-      if (low.i.valueOf() > 0xffff_ffff) {
+      if (i > 0xffff_ffff) {
         throw new BSONError(
           'Timestamp constructed from { t, i } must provide i equal or less than uint32 max'
         );
       }
 
-      super(low.i.valueOf(), low.t.valueOf(), true);
+      super(i, t, true);
     } else {
       throw new BSONError(
         'A Timestamp can only be constructed with: bigint, Long, or { t: number; i: number }'

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -61,18 +61,18 @@ export class Timestamp extends LongWithoutOverridesClass {
       if (typeof low.i !== 'number' && (typeof low.i !== 'object' || low.i._bsontype !== 'Int32')) {
         throw new BSONError('Timestamp constructed from { t, i } must provide i as a number');
       }
-      if (low.t < 0) {
+      if (low.t.valueOf() < 0) {
         throw new BSONError('Timestamp constructed from { t, i } must provide a positive t');
       }
-      if (low.i < 0) {
+      if (low.i.valueOf() < 0) {
         throw new BSONError('Timestamp constructed from { t, i } must provide a positive i');
       }
-      if (low.t > 0xffff_ffff) {
+      if (low.t.valueOf() > 0xffff_ffff) {
         throw new BSONError(
           'Timestamp constructed from { t, i } must provide t equal or less than uint32 max'
         );
       }
-      if (low.i > 0xffff_ffff) {
+      if (low.i.valueOf() > 0xffff_ffff) {
         throw new BSONError(
           'Timestamp constructed from { t, i } must provide i equal or less than uint32 max'
         );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,6 @@
     "noEmitHelpers": false,
     "noEmitOnError": true,
     "emitDeclarationOnly": true,
-    // make use of import type where applicable
-    "importsNotUsedAsValues": "error",
     // Generate separate source maps files with sourceContent included
     "sourceMap": true,
     "inlineSourceMap": false,


### PR DESCRIPTION
### Description

Updates the driver to use Typescript 5.

#### What is changing?
- Updates typescript to ^5.0.4
- Updates api-extractor to ^7.35.1 (to use typescript 5)
- All other typescript dependencies were already further along than the minimum.
- Removes the `importsNotUsedAsValues` config and replaces with eslint rule.
- Updates all the files to adhere to new eslint rule.
- Fixes the number comparison between `number` and `Int32`.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5324

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
