### PR TITLE
feat(NODE-5223)!: remove deprecated cacheHexString

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -321,8 +321,6 @@ const UUID_WITH_DASHES = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A
  * @public
  */
 export class UUID extends Binary {
-  /** @deprecated Hex string is no longer cached, this control will be removed in a future major release */
-  static cacheHexString = false;
   /**
    * Create a UUID type
    *


### PR DESCRIPTION
### Description

Removes the deprecated `UUID.cacheHexString`.

#### What is changing?

Removes the deprecated `UUID.cacheHexString`

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5223

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

#### The deprecated and unused `UUID.cacheHexString` property has been removed.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
