### PR TITLE
ci(NODE-5482): Append node version to evergreen benchmark task

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -209,7 +209,7 @@ tasks:
         vars:
           TS_VERSION: "next"
           TRY_COMPILING_LIBRARY: "false"
-  - name: run-benchmarks-node
+  - name: run-benchmarks-node-18
     commands:
       - func: fetch source
         vars:


### PR DESCRIPTION
### Description

#### What is changing?

Append node version to evergreen benchmark task

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-5482

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [X] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
