### PR TITLE
feat(NODE-4769)!: remove ISO-8859-1 string support from Binary

### DIFF
--- a/test/node/bson_node_only_tests.js
+++ b/test/node/bson_node_only_tests.js
@@ -9,7 +9,7 @@ const Buffer = require('buffer').Buffer;
 
 describe('BSON - Node only', function () {
   it('Should Correctly Serialize and Deserialize a big Binary object', function (done) {
-    var data = fs.readFileSync(path.resolve(__dirname, './data/test_gs_weird_bug.png'), 'binary');
+    var data = fs.readFileSync(path.resolve(__dirname, './data/test_gs_weird_bug.png'));
     var bin = new Binary();
     bin.write(data);
     var doc = { doc: bin };
@@ -26,18 +26,17 @@ describe('BSON - Node only', function () {
 });
 
 describe('Full BSON - Node only', function () {
-  it('Should Correctly Serialize and Deserialize a big Binary object', function (done) {
-    var data = fs.readFileSync(path.resolve(__dirname, './data/test_gs_weird_bug.png'), 'binary');
+  it('Should Correctly Serialize and Deserialize a big Binary object', function () {
+    var data = fs.readFileSync(path.resolve(__dirname, './data/test_gs_weird_bug.png'));
     var bin = new Binary();
     bin.write(data);
     var doc = { doc: bin };
     var serialized_data = BSON.serialize(doc);
     var deserialized_data = BSON.deserialize(serialized_data);
-    expect(doc.doc.value()).to.equal(deserialized_data.doc.value());
-    done();
+    expect(doc.doc.value()).to.deep.equal(deserialized_data.doc.value());
   });
 
-  it('Should Correctly Deserialize bson file from mongodump', function (done) {
+  it('Should Correctly Deserialize bson file from mongodump', function () {
     var data = fs.readFileSync(path.resolve(__dirname, './data/test.bson'), { encoding: null });
     data = Buffer.from(data);
     var docs = [];
@@ -46,6 +45,5 @@ describe('Full BSON - Node only', function () {
       bsonIndex = BSON.deserializeStream(data, bsonIndex, 1, docs, docs.length, { isArray: true });
 
     expect(docs.length).to.equal(1);
-    done();
   });
 });

--- a/test/node/bson_types_construction_tests.js
+++ b/test/node/bson_types_construction_tests.js
@@ -6,7 +6,7 @@ describe('Constructing BSON types', function () {
     expect(() => new BSON.ObjectId()).to.not.throw();
     expect(() => new BSON.BSONRegExp('aaa')).to.not.throw();
     expect(() => new BSON.BSONSymbol('aaa')).to.not.throw();
-    expect(() => new BSON.Binary('aaa')).to.not.throw();
+    expect(() => new BSON.Binary(new Uint8Array())).to.not.throw();
     expect(() => new BSON.Code(function () {})).to.not.throw();
     expect(() => new BSON.Decimal128('123')).to.not.throw();
     expect(() => new BSON.Double(2.3)).to.not.throw();

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -184,7 +184,7 @@ describe('Extended JSON', function () {
 
   it('should serialize from BSON object to EJSON object', function () {
     const doc = {
-      binary: new Binary(''),
+      binary: new Binary(new Uint8Array([0, 0, 0]), 0xef),
       code: new Code('function() {}'),
       dbRef: new DBRef('tests', new Int32(1), 'test'),
       decimal128: new Decimal128('128'),
@@ -203,7 +203,7 @@ describe('Extended JSON', function () {
 
     const result = EJSON.serialize(doc, { relaxed: false });
     expect(result).to.deep.equal({
-      binary: { $binary: { base64: '', subType: '00' } },
+      binary: { $binary: { base64: 'AAAA', subType: 'ef' } },
       code: { $code: 'function() {}' },
       dbRef: { $ref: 'tests', $id: { $numberInt: '1' }, $db: 'test' },
       decimal128: { $numberDecimal: '128' },

--- a/test/node/test_full_bson.js
+++ b/test/node/test_full_bson.js
@@ -260,17 +260,16 @@ describe('Full BSON', function () {
   /**
    * @ignore
    */
-  it('Should Correctly Serialize and Deserialize a Binary object', function (done) {
+  it('Should Correctly Serialize and Deserialize a Binary object', function () {
     var bin = new Binary();
     var string = 'binstring';
     for (var index = 0; index < string.length; index++) {
-      bin.put(string.charAt(index));
+      bin.put(string[index]);
     }
     var doc = { doc: bin };
     var serialized_data = BSON.serialize(doc);
     var deserialized_data = BSON.deserialize(serialized_data);
-    expect(doc.doc.value()).to.equal(deserialized_data.doc.value());
-    done();
+    expect(doc.doc.value()).to.deep.equal(deserialized_data.doc.value());
   });
 
   it('Should Correctly Serialize and Deserialize a ArrayBuffer object', function () {


### PR DESCRIPTION
### Description

#### What is changing?

- Removes legacy ISO-8859-1 format from Binary `constructor`, `.write`, and `.value` methods

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- Unusual string format, see highlight

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Removed ISO-8859-1 string format from `Binary` (a.k.a `'latin1'`, `'binary'`)

The `Binary` BSON type no longer accepts a string as a constructor argument nor can `write()` be invoked with a string argument. Both methods interpreted strings as binary sequences rather than UTF-8 or base64 which are much more common and expected formats. If there is a string representation of your data it is now expected that the logic that interprets the string format exists outside the Binary class to avoid misinterpreting data.

```ts
new Binary(Buffer.from('ÿÿ', 'binary'));
// Binary.createFromBase64("//8=", 0)

new Binary(Buffer.from('ÿÿ', 'utf8'));
// Binary.createFromBase64("w7/Dvw==", 0)

new BSON.Binary(Buffer.from('AAAA', 'base64'))
// Binary.createFromBase64("AAAA", 0)
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
