### PR TITLE
feat(NODE-5504): bump bson major version

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 /** @internal */
-export const BSON_MAJOR_VERSION = 5 as const;
+export const BSON_MAJOR_VERSION = 6 as const;
 
 /** @internal */
 export const BSON_INT32_MAX = 0x7fffffff;

--- a/test/node/constants.test.ts
+++ b/test/node/constants.test.ts
@@ -3,6 +3,12 @@ import { Binary } from '../register-bson';
 import * as constants from '../../src/constants';
 
 describe('BSON Constants', () => {
+  describe('.BSON_MAJOR_VERSION', () => {
+    it('returns the current major version', () => {
+      expect(constants.BSON_MAJOR_VERSION).to.equal(6);
+    });
+  });
+
   context('Binary Subtype', () => {
     /*
      subtype	::=


### PR DESCRIPTION
### Description

Bumps `BSON_MAJOR_VERSION` constant to 6.

#### What is changing?

Bumps `BSON_MAJOR_VERSION` constant to 6 and adds a test.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5504

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

#### `BSON_MAJOR_VERSION` bumped to 6

Only BSON objects that have this major version can be serialized with this version of the library. Mismatched objects will throw a `BSONVersionError` when attempting to serialize.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
