### PR TITLE
feat(NODE-2624)!: remove Long methods from Timestamp class

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -29,8 +29,7 @@ export type { MinKeyExtended } from './min_key';
 export type { ObjectIdExtended, ObjectIdLike } from './objectid';
 export type { BSONRegExpExtended, BSONRegExpExtendedLegacy } from './regexp';
 export type { BSONSymbolExtended } from './symbol';
-export type { LongWithoutOverrides, TimestampExtended, TimestampOverrides } from './timestamp';
-export type { LongWithoutOverridesClass } from './timestamp';
+export type { TimestampExtended, TimestampOverrides } from './timestamp';
 export type { SerializeOptions, DeserializeOptions };
 
 export {

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -324,7 +324,7 @@ const BSON_TYPE_MAPPINGS = {
   ObjectId: (o: ObjectId) => new ObjectId(o),
   BSONRegExp: (o: BSONRegExp) => new BSONRegExp(o.pattern, o.options),
   BSONSymbol: (o: BSONSymbol) => new BSONSymbol(o.value),
-  Timestamp: (o: Timestamp) => Timestamp.fromBits(o.low, o.high)
+  Timestamp: (o: Timestamp) => Timestamp.fromBits(o.i, o.t)
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -324,7 +324,7 @@ const BSON_TYPE_MAPPINGS = {
   ObjectId: (o: ObjectId) => new ObjectId(o),
   BSONRegExp: (o: BSONRegExp) => new BSONRegExp(o.pattern, o.options),
   BSONSymbol: (o: BSONSymbol) => new BSONSymbol(o.value),
-  Timestamp: (o: Timestamp) => Timestamp.fromBits(o.i, o.t)
+  Timestamp: (o: Timestamp) => new Timestamp(o)
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/long.ts
+++ b/src/long.ts
@@ -1,7 +1,6 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import type { EJSONOptions } from './extended_json';
-import type { Timestamp } from './timestamp';
 
 interface LongWASMHelpers {
   /** Gets the high bits of the last operation performed */
@@ -360,7 +359,7 @@ export class Long extends BSONValue {
   }
 
   /** Returns the sum of this and the specified Long. */
-  add(addend: string | number | Long | Timestamp): Long {
+  add(addend: string | number | Long): Long {
     if (!Long.isLong(addend)) addend = Long.fromValue(addend);
 
     // Divide each number into 4 chunks of 16 bits, and then sum the chunks.
@@ -397,7 +396,7 @@ export class Long extends BSONValue {
    * Returns the sum of this and the specified Long.
    * @returns Sum
    */
-  and(other: string | number | Long | Timestamp): Long {
+  and(other: string | number | Long): Long {
     if (!Long.isLong(other)) other = Long.fromValue(other);
     return Long.fromBits(this.low & other.low, this.high & other.high, this.unsigned);
   }
@@ -406,7 +405,7 @@ export class Long extends BSONValue {
    * Compares this Long's value with the specified's.
    * @returns 0 if they are the same, 1 if the this is greater and -1 if the given one is greater
    */
-  compare(other: string | number | Long | Timestamp): 0 | 1 | -1 {
+  compare(other: string | number | Long): 0 | 1 | -1 {
     if (!Long.isLong(other)) other = Long.fromValue(other);
     if (this.eq(other)) return 0;
     const thisNeg = this.isNegative(),
@@ -423,7 +422,7 @@ export class Long extends BSONValue {
   }
 
   /** This is an alias of {@link Long.compare} */
-  comp(other: string | number | Long | Timestamp): 0 | 1 | -1 {
+  comp(other: string | number | Long): 0 | 1 | -1 {
     return this.compare(other);
   }
 
@@ -431,7 +430,7 @@ export class Long extends BSONValue {
    * Returns this Long divided by the specified. The result is signed if this Long is signed or unsigned if this Long is unsigned.
    * @returns Quotient
    */
-  divide(divisor: string | number | Long | Timestamp): Long {
+  divide(divisor: string | number | Long): Long {
     if (!Long.isLong(divisor)) divisor = Long.fromValue(divisor);
     if (divisor.isZero()) throw new BSONError('division by zero');
 
@@ -533,7 +532,7 @@ export class Long extends BSONValue {
   }
 
   /**This is an alias of {@link Long.divide} */
-  div(divisor: string | number | Long | Timestamp): Long {
+  div(divisor: string | number | Long): Long {
     return this.divide(divisor);
   }
 
@@ -541,7 +540,7 @@ export class Long extends BSONValue {
    * Tests if this Long's value equals the specified's.
    * @param other - Other value
    */
-  equals(other: string | number | Long | Timestamp): boolean {
+  equals(other: string | number | Long): boolean {
     if (!Long.isLong(other)) other = Long.fromValue(other);
     if (this.unsigned !== other.unsigned && this.high >>> 31 === 1 && other.high >>> 31 === 1)
       return false;
@@ -549,7 +548,7 @@ export class Long extends BSONValue {
   }
 
   /** This is an alias of {@link Long.equals} */
-  eq(other: string | number | Long | Timestamp): boolean {
+  eq(other: string | number | Long): boolean {
     return this.equals(other);
   }
 
@@ -586,26 +585,26 @@ export class Long extends BSONValue {
   }
 
   /** Tests if this Long's value is greater than the specified's. */
-  greaterThan(other: string | number | Long | Timestamp): boolean {
+  greaterThan(other: string | number | Long): boolean {
     return this.comp(other) > 0;
   }
 
   /** This is an alias of {@link Long.greaterThan} */
-  gt(other: string | number | Long | Timestamp): boolean {
+  gt(other: string | number | Long): boolean {
     return this.greaterThan(other);
   }
 
   /** Tests if this Long's value is greater than or equal the specified's. */
-  greaterThanOrEqual(other: string | number | Long | Timestamp): boolean {
+  greaterThanOrEqual(other: string | number | Long): boolean {
     return this.comp(other) >= 0;
   }
 
   /** This is an alias of {@link Long.greaterThanOrEqual} */
-  gte(other: string | number | Long | Timestamp): boolean {
+  gte(other: string | number | Long): boolean {
     return this.greaterThanOrEqual(other);
   }
   /** This is an alias of {@link Long.greaterThanOrEqual} */
-  ge(other: string | number | Long | Timestamp): boolean {
+  ge(other: string | number | Long): boolean {
     return this.greaterThanOrEqual(other);
   }
 
@@ -635,27 +634,27 @@ export class Long extends BSONValue {
   }
 
   /** Tests if this Long's value is less than the specified's. */
-  lessThan(other: string | number | Long | Timestamp): boolean {
+  lessThan(other: string | number | Long): boolean {
     return this.comp(other) < 0;
   }
 
   /** This is an alias of {@link Long#lessThan}. */
-  lt(other: string | number | Long | Timestamp): boolean {
+  lt(other: string | number | Long): boolean {
     return this.lessThan(other);
   }
 
   /** Tests if this Long's value is less than or equal the specified's. */
-  lessThanOrEqual(other: string | number | Long | Timestamp): boolean {
+  lessThanOrEqual(other: string | number | Long): boolean {
     return this.comp(other) <= 0;
   }
 
   /** This is an alias of {@link Long.lessThanOrEqual} */
-  lte(other: string | number | Long | Timestamp): boolean {
+  lte(other: string | number | Long): boolean {
     return this.lessThanOrEqual(other);
   }
 
   /** Returns this Long modulo the specified. */
-  modulo(divisor: string | number | Long | Timestamp): Long {
+  modulo(divisor: string | number | Long): Long {
     if (!Long.isLong(divisor)) divisor = Long.fromValue(divisor);
 
     // use wasm support if present
@@ -673,11 +672,11 @@ export class Long extends BSONValue {
   }
 
   /** This is an alias of {@link Long.modulo} */
-  mod(divisor: string | number | Long | Timestamp): Long {
+  mod(divisor: string | number | Long): Long {
     return this.modulo(divisor);
   }
   /** This is an alias of {@link Long.modulo} */
-  rem(divisor: string | number | Long | Timestamp): Long {
+  rem(divisor: string | number | Long): Long {
     return this.modulo(divisor);
   }
 
@@ -686,7 +685,7 @@ export class Long extends BSONValue {
    * @param multiplier - Multiplier
    * @returns Product
    */
-  multiply(multiplier: string | number | Long | Timestamp): Long {
+  multiply(multiplier: string | number | Long): Long {
     if (this.isZero()) return Long.ZERO;
     if (!Long.isLong(multiplier)) multiplier = Long.fromValue(multiplier);
 
@@ -750,7 +749,7 @@ export class Long extends BSONValue {
   }
 
   /** This is an alias of {@link Long.multiply} */
-  mul(multiplier: string | number | Long | Timestamp): Long {
+  mul(multiplier: string | number | Long): Long {
     return this.multiply(multiplier);
   }
 
@@ -771,16 +770,16 @@ export class Long extends BSONValue {
   }
 
   /** Tests if this Long's value differs from the specified's. */
-  notEquals(other: string | number | Long | Timestamp): boolean {
+  notEquals(other: string | number | Long): boolean {
     return !this.equals(other);
   }
 
   /** This is an alias of {@link Long.notEquals} */
-  neq(other: string | number | Long | Timestamp): boolean {
+  neq(other: string | number | Long): boolean {
     return this.notEquals(other);
   }
   /** This is an alias of {@link Long.notEquals} */
-  ne(other: string | number | Long | Timestamp): boolean {
+  ne(other: string | number | Long): boolean {
     return this.notEquals(other);
   }
 
@@ -873,13 +872,13 @@ export class Long extends BSONValue {
    * @param subtrahend - Subtrahend
    * @returns Difference
    */
-  subtract(subtrahend: string | number | Long | Timestamp): Long {
+  subtract(subtrahend: string | number | Long): Long {
     if (!Long.isLong(subtrahend)) subtrahend = Long.fromValue(subtrahend);
     return this.add(subtrahend.neg());
   }
 
   /** This is an alias of {@link Long.subtract} */
-  sub(subtrahend: string | number | Long | Timestamp): Long {
+  sub(subtrahend: string | number | Long): Long {
     return this.subtract(subtrahend);
   }
 
@@ -1015,7 +1014,7 @@ export class Long extends BSONValue {
   }
 
   /** This is an alias of {@link Long.lessThanOrEqual} */
-  le(other: string | number | Long | Timestamp): boolean {
+  le(other: string | number | Long): boolean {
     return this.lessThanOrEqual(other);
   }
 

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -23,8 +23,14 @@ export class Timestamp extends BSONValue {
     return 'Timestamp';
   }
 
-  static readonly MAX_VALUE = Long.MAX_UNSIGNED_VALUE;
+  static readonly MAX_VALUE = new Timestamp(Long.MAX_UNSIGNED_VALUE);
+  /**
+   * Upper 4 bytes representing the timestamp value
+   */
   readonly t: number;
+  /**
+   * Lower 4 bytes representing the increment value
+   */
   readonly i: number;
 
   /**
@@ -106,10 +112,10 @@ export class Timestamp extends BSONValue {
   }
 
   /**
-   * Returns a Timestamp for the given high and low bits. Each is assumed to use 32 bits.
+   * Returns a Timestamp for the given increment and numeric timestamp. Each is assumed to use 32 bits.
    *
-   * @param i - the low 32-bits.
-   * @param t - the high 32-bits.
+   * @param i - the increment
+   * @param t - the timestamp
    */
   static fromBits(i: number, t: number): Timestamp {
     return new Timestamp({ i: i, t: t });
@@ -120,8 +126,9 @@ export class Timestamp extends BSONValue {
    *
    * @param str - the textual representation of the Timestamp.
    * @param optRadix - the radix in which the text is written.
+   * @returns The corresponding Timestamp value
    */
-  static fromString(str: string, optRadix: number): Timestamp {
+  static fromString(str: string, optRadix?: number): Timestamp {
     return new Timestamp(Long.fromString(str, true, optRadix));
   }
 
@@ -151,11 +158,14 @@ export class Timestamp extends BSONValue {
     return `new Timestamp({ t: ${this.t}, i: ${this.i} })`;
   }
 
+  /** @internal */
   toString(): string {
     return this.toLong().toString();
   }
 
+  /** @returns Long representation of timestamp where low 4 bytes are increment and high 4 bytes are
+   * timestamp*/
   toLong(): Long {
-    return new Long(this.t, this.i, true);
+    return new Long(this.i, this.t, true);
   }
 }

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -813,7 +813,7 @@ describe('BSON', function () {
     expect(long instanceof Long).to.be.ok;
     expect(!(long instanceof Timestamp)).to.be.ok;
     expect(timestamp instanceof Timestamp).to.be.ok;
-    expect(timestamp instanceof Long).to.be.ok;
+    expect(timestamp instanceof Long).to.be.false;
 
     var test_int = { doc: long, doc2: timestamp };
     var serialized_data = BSON.serialize(test_int);

--- a/test/node/timestamp.test.ts
+++ b/test/node/timestamp.test.ts
@@ -22,9 +22,9 @@ describe('Timestamp', () => {
       // We do expect it to work so that round tripping the Int32 instance inside a Timestamp works
       new BSON.Timestamp({ t: new BSON.Int32(0x7fff_ffff), i: new BSON.Int32(0x7fff_ffff) })
     ];
-
     for (const timestamp of table) {
-      expect(timestamp).to.have.property('unsigned', true);
+      expect(timestamp.t).to.be.gte(0);
+      expect(timestamp.i).to.be.gte(0);
     }
   });
 
@@ -45,6 +45,7 @@ describe('Timestamp', () => {
 
     context('when converting toExtendedJSON', () => {
       it('exports an unsigned number', () => {
+        // @ts-expect-error toExtendedJSON is an internal method
         expect(timestamp.toExtendedJSON()).to.deep.equal({
           $timestamp: { t: 4294967295, i: 4294967295 }
         });
@@ -56,6 +57,7 @@ describe('Timestamp', () => {
     it('accepts { t, i } object as input', () => {
       const input = { t: 89, i: 144 };
       const timestamp = new BSON.Timestamp(input);
+      // @ts-expect-error toExtendedJSON is an internal method
       expect(timestamp.toExtendedJSON()).to.deep.equal({ $timestamp: input });
     });
 
@@ -63,6 +65,7 @@ describe('Timestamp', () => {
       const input = { t: new BSON.Int32(89), i: new BSON.Int32(144) };
       // @ts-expect-error We do not advertise support for Int32 in the constructor of Timestamp
       const timestamp = new BSON.Timestamp(input);
+      // @ts-expect-error toExtendedJSON is an internal method
       expect(timestamp.toExtendedJSON()).to.deep.equal({ $timestamp: { t: 89, i: 144 } });
     });
 

--- a/test/node/type_identifier_tests.js
+++ b/test/node/type_identifier_tests.js
@@ -25,11 +25,8 @@ describe('_bsontype identifier', () => {
     expect(BSONSymbol.prototype._bsontype).to.equal('BSONSymbol');
   });
   it('should be equal to Timestamp for Timestamp', () => {
-    // TODO(NODE-2624): Make Timestamp hold its long value on a property rather than be a subclass
-    // Timestamp overrides the value in its constructor
     const timestamp = new Timestamp({ i: 0, t: 0 });
     expect(timestamp._bsontype).to.equal('Timestamp');
-    expect(Object.getPrototypeOf(Object.getPrototypeOf(timestamp))._bsontype).to.equal('Long');
   });
 
   // All equal to their constructor names

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -55,7 +55,6 @@ expectError(BSONRegExp.prototype.toJSON);
 // We hack TS to say that the prototype has _bsontype='Timestamp'
 // but it actually is _bsontype='Long', inside the Timestamp constructor
 // we override the property on the instance
-// TODO(NODE-2624): Make Timestamp hold its long value on a property rather than be a subclass
 expectType<'Timestamp'>(Timestamp.prototype._bsontype)
 
 expectType<'ObjectId'>(ObjectId.prototype._bsontype)


### PR DESCRIPTION
### Description

#### What is changing?

##### `Timestamp`
- `Timestamp` no longer subclasses from `Long` and instead is now a direct subclass of `BSONValue`
- Deleted `LongWithoutOverrides` and `LongWithoutOverridesClass`
- Updated `MAX_VALUE` to be instance of `Timestamp`
- Expose `i` (increment) and `t` (timestamp) readonly fields directly on the `Timestamp` class
- Added `toLong` method

##### `Long`
- Updated signatures of all `Long` methods to no longer accept a `Timestamp` argument


##### tests
- Added unit tests t
##### Is there new documentation needed for these changes?

#### What is the motivation for this change?
NODE-2624

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `Timestamp` now no longer inherits from `Long`

`Timestamp` no longer supports `Long`'s comparison methods (`gt`, `lt`, `lte`, ...). The `high` and `low` fields have been replaced by `t` and `i` respectively to represent the timestamp and increment fields on the Timestamp object (See [bson spec here](https://bsonspec.org/spec.html)).

If your application relied on the inherited `Long` methods, we have added a `toLong()` method which converts a `Timestamp` to a `Long` and all of the previously available methods can be accessed in this way.

```ts
const ts0 = new Timestamp({t: 100, i: 1});
const ts1 = new Timestamp({t: 101, i: 1)};

// Old behaviour; no longer works
ts1.gt(ts0); // true

// New behaviour
ts1.toLong().greaterThan(ts0.toLong()); // true
```


### `Long` comparison and arithmetic methods no longer accept a `Timestamp` argument

Since `Timestamp` is no longer a subclass of `Long`, it is no longer compatible with
- `Long.add`
- `Long.subtract`
- `Long.and`
- `Long.compare`
- `Long.multiply`
- `Long.divide`
- `Long.notEquals`
- `Long.equals`
- `Long.greaterThan`
- `Long.greaterThanOrEqual`
- `Long.lessThan`
- `Long.lessThanOrEqual`
- `Long.modulo`
- `Long.rem`

And their associated aliases
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
