### PR TITLE
fix(NODE-5452): Allow undefined or null params in ObjectId.equals

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -194,7 +194,7 @@ export class ObjectId extends BSONValue {
    *
    * @param otherId - ObjectId instance to compare against.
    */
-  equals(otherId: string | ObjectId | ObjectIdLike): boolean {
+  equals(otherId: string | ObjectId | ObjectIdLike | undefined | null): boolean {
     if (otherId === undefined || otherId === null) {
       return false;
     }


### PR DESCRIPTION
### Description


#### What is changing?

I've added `null` and `undefined` as new types to the `otherId` type union on `ObjectId.equals`.

##### Is there new documentation needed for these changes?

I don't believe so. Functionally nothing is changing about what the function is doing. We're just making the types more permissive to match the function body.

#### What is the motivation for this change?

We've been migrating away from a custom `idEquals` function in a large codebase towards `ObjectId.equals`. Our custom function allowed for `undefined` ids and it looks like `.equals` allows for them as well when reading the function body, but the Typescript definition doesn't include `undefined` or `null` in the type union. This blocks the ability to pass a potentially undefined `ObjectId` to `.equals` and leads to awkward ternaries or other hacks that shouldn't be necessary from the caller.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
