### PR TITLE
chore(NODE-5543): fix duplicate PR highlights

### DIFF
--- a/.github/scripts/highlights.mjs
+++ b/.github/scripts/highlights.mjs
@@ -70,7 +70,10 @@ async function pullRequestHighlights(prs) {
   if (!highlights.length) return '';
 
   highlights.unshift('## Release Notes\n\n');
-  return highlights.join('\n\n');
+
+  const highlight = highlights.join('\n\n');
+  console.log(`Total highlight is ${highlight.length} characters long`);
+  return highlight;
 }
 
 console.log('List of PRs to collect highlights from:', prs);

--- a/.github/scripts/pr_list.mjs
+++ b/.github/scripts/pr_list.mjs
@@ -13,10 +13,14 @@ const historyFilePath = path.join(__dirname, '..', '..', 'HISTORY.md');
  */
 function parsePRList(history) {
   const prRegexp = /js-bson\/issues\/(?<prNum>\d+)\)/iu;
-  return history
-    .split('\n')
-    .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
-    .filter(prNum => prNum !== '');
+  return Array.from(
+    new Set(
+      history
+        .split('\n')
+        .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
+        .filter(prNum => prNum !== '')
+    )
+  );
 }
 
 const historyContents = await fs.readFile(historyFilePath, { encoding: 'utf8' });


### PR DESCRIPTION
### Description

#### What is changing?

- Use a Set to remove duplicate PR numbers
- Add a log for the entire length of the highlight
- https://github.com/mongodb/node-mongodb-native/pull/3816

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Dedupe release notes.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
