### PR TITLE
fix(NODE-5559): account for quotes when inspecting Code and BSONSymbol

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -62,7 +62,7 @@ export class Code extends BSONValue {
 
   inspect(): string {
     const codeJson = this.toJSON();
-    return `new Code("${String(codeJson.code)}"${
+    return `new Code(${JSON.stringify(String(codeJson.code))}${
       codeJson.scope != null ? `, ${JSON.stringify(codeJson.scope)}` : ''
     })`;
   }

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -34,7 +34,7 @@ export class BSONSymbol extends BSONValue {
   }
 
   inspect(): string {
-    return `new BSONSymbol("${this.value}")`;
+    return `new BSONSymbol(${JSON.stringify(this.value)})`;
   }
 
   toJSON(): string {

--- a/test/node/code.test.ts
+++ b/test/node/code.test.ts
@@ -1,11 +1,19 @@
 import { expect } from 'chai';
 import * as BSON from '../register-bson';
+import { inspect } from 'util';
 
 describe('class Code', () => {
   it('defines a nodejs inspect method', () => {
     expect(BSON.Code.prototype)
       .to.have.property(Symbol.for('nodejs.util.inspect.custom'))
       .that.is.a('function');
+  });
+
+  it('prints re-evaluatable output for Code that contains quotes', () => {
+    const codeStringInput = new BSON.Code('function a(){ return "asdf"; }');
+    expect(inspect(codeStringInput)).to.equal(
+      String.raw`new Code("function a(){ return \"asdf\"; }")`
+    );
   });
 
   describe('new Code()', () => {

--- a/test/node/symbol.test.ts
+++ b/test/node/symbol.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { BSONSymbol, BSON } from '../register-bson';
 import { bufferFromHexArray } from './tools/utils';
+import { inspect } from 'util';
 
 describe('class BSONSymbol', () => {
   it('get _bsontype returns BSONSymbol', () => {
@@ -40,5 +41,10 @@ describe('class BSONSymbol', () => {
 
     const result = BSON.deserialize(bytes, { promoteValues: false });
     expect(result).to.have.nested.property('sym._bsontype', 'BSONSymbol');
+  });
+
+  it('prints re-evaluatable output for BSONSymbol that contains quotes', () => {
+    const input = new BSONSymbol('asdf"ghjk');
+    expect(inspect(input)).to.equal(String.raw`new BSONSymbol("asdf\"ghjk")`);
   });
 });


### PR DESCRIPTION
### Description

#### What is changing?

Accounts for quotes (and other characters that need escaping) when printing Code() or BSONSymbol() inspect output.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

https://jira.mongodb.org/browse/NODE-5559

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
