### PR TITLE
fix(NODE-5578): improve objectId deserialisation by skipping buffer allocation

### DIFF
--- a/etc/benchmarks/main.mjs
+++ b/etc/benchmarks/main.mjs
@@ -25,6 +25,26 @@ await runner({
     bson.lib.deserialize(documents[i], { validation: { utf8: false } });
   }
 });
+
+await runner({
+  skip: false,
+  name: 'deserialize a document with lots of objectId',
+  iterations,
+  setup(libs) {
+    const bson = getCurrentLocalBSON(libs);
+    const entries = Array.from({ length: 100000 }, (_, i) => [
+      `${i}_${'a'.repeat(10)}`,
+      new bson.lib.ObjectId()
+    ]);
+    const document = Object.fromEntries(entries);
+    const bytes = bson.lib.serialize(document);
+    return bytes;
+  },
+  run(i, bson, largeDocument) {
+    new bson.lib.deserialize(largeDocument);
+  }
+});
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 await runner({
   skip: true,
@@ -102,7 +122,7 @@ await runner({
 /// nextBatch simulate
 /// nextBatch: [ { string * 20 } * 1000 ] /// Garbage call
 await runner({
-  skip: false,
+  skip: true,
   name: 'deserialize a large batch of documents each with an array of many strings',
   iterations,
   setup(libs) {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "format": "eslint --ext '.js,.ts' src test --fix",
     "check:coverage": "nyc --check-coverage npm run check:node",
     "prepare": "node etc/prepare.js",
-    "release": "standard-version -i HISTORY.md"
+    "release": "standard-version -i HISTORY.md",
+    "run:benchmark": "node ./etc/benchmarks/main.mjs"
   }
 }

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -269,9 +269,7 @@ function deserializeObject(
       value = getValidatedString(buffer, index, index + stringSize - 1, shouldValidateKey);
       index = index + stringSize;
     } else if (elementType === constants.BSON_DATA_OID) {
-      const oid = ByteUtils.allocate(12);
-      oid.set(buffer.subarray(index, index + 12));
-      value = new ObjectId(oid);
+      value = new ObjectId(buffer.subarray(index, index + 12));
       index = index + 12;
     } else if (elementType === constants.BSON_DATA_INT && promoteValues === false) {
       value = new Int32(


### PR DESCRIPTION
### Description

Improve ObjectId deserialisation by around 20% by skipping one buffer allocation.
Also add a benchmark that deserialise lot's of ObjectIds

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
