### PR TITLE
chore(NODE-5580): add release alpha action

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,0 +1,34 @@
+on:
+  # Allows us to manually trigger an alpha
+  # workflow_dispatch can be given an alternative 'ref' to release from a feature branch
+  workflow_dispatch:
+    inputs:
+      alphaVersion:
+        description: 'Enter alpha version'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+
+name: release-alpha
+
+jobs:
+  release-alpha:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          ALPHA_SEMVER_REGEXP="-alpha(\.([0-9]|[1-9][0-9]+))?$"
+
+          if ! [[ "${{ inputs.alphaVersion }}" =~ $ALPHA_SEMVER_REGEXP ]]; then
+            echo "Invalid alphaVersion string"
+            exit 1
+          fi
+      - uses: actions/checkout@v3
+      - name: actions/setup
+        uses: ./.github/actions/setup
+      - run: npm version "${{ inputs.alphaVersion }}" --git-tag-version=false
+      - run: npm publish --provenance --tag=alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### What is changing?

Pull in release-alpha workflow from driver codebase

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-5580

### Release Highlight
N/A
<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [X] Ran `npm run check:lint` script
- [X] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [X] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
