### PR TITLE
test(NODE-5603): use npm 9 on eol node versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -111,6 +111,8 @@ tasks:
         vars:
           NODE_LTS_VERSION: 16
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: run tests
         vars:
           TEST_TARGET: node
@@ -213,8 +215,11 @@ tasks:
     commands:
       - func: fetch source
         vars:
+          # This needs to stay pinned at Node v18.16.0 for consistency across perf runs.
           NODE_LTS_VERSION: v18.16.0
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: run benchmarks
         vars:
           WEB: false 

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,6 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
+NODE_LOWEST_LTS=18
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
@@ -96,7 +97,11 @@ fi
 
 if [[ $operating_system != "win" ]]; then
   # Update npm to latest when we can
-  npm install --global npm@latest
+  if [[ $NODE_LTS_VERSION -lt $NODE_LOWEST_LTS ]]; then
+    npm install --global npm@9
+  else
+    npm install --global npm@latest
+  fi
   hash -r
 fi
 

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,8 +2,9 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
-# npm 10 does not work with Node < 18 so npm 9 will be installed on those versions.
-NODE_LOWEST_LTS=18
+# npm version can be defined in the environment for cases where we need to install
+# a version lower than latest to support EOL Node versions.
+NPM_VERSION=${NPM_VERSION:-latest}
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
@@ -97,12 +98,7 @@ else
 fi
 
 if [[ $operating_system != "win" ]]; then
-  # Update npm to latest when we can
-  if [[ $NODE_LTS_VERSION -lt $NODE_LOWEST_LTS ]]; then
-    npm install --global npm@9
-  else
-    npm install --global npm@latest
-  fi
+  npm install --global npm@$NPM_VERSION
   hash -r
 fi
 

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,6 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
+# npm 10 does not work with Node < 18 so npm 9 will be installed on those versions.
 NODE_LOWEST_LTS=18
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"


### PR DESCRIPTION
### Description

Fixes Node 16 failures with npm 10.

#### What is changing?

- Installs npm@9 when on Node 16 or lower.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-5603

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
