### PR TITLE
test(NODE-5603): use npm 9 on eol node versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -101,6 +101,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_LTS_VERSION: 14
+          NPM_VERSION: 9
       - func: install dependencies
       - func: run tests
         vars:
@@ -112,6 +113,8 @@ tasks:
         vars:
           NODE_LTS_VERSION: 16
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: run tests
         vars:
           TEST_TARGET: node

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,6 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-14}
+NPM_VERSION=${NPM_VERSION:-latest}
 
 source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
@@ -94,8 +95,7 @@ else
 fi
 
 if [[ $operating_system != "win" ]]; then
-  # Update npm to latest when we can
-  npm install --global npm@latest
+  npm install --global npm@$NPM_VERSION
   hash -r
 fi
 


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
