### PR TITLE
chore: backport release scripting to 5.x branch

### DIFF
--- a/.github/scripts/highlights.mjs
+++ b/.github/scripts/highlights.mjs
@@ -70,7 +70,10 @@ async function pullRequestHighlights(prs) {
   if (!highlights.length) return '';
 
   highlights.unshift('## Release Notes\n\n');
-  return highlights.join('\n\n');
+
+  const highlight = highlights.join('\n\n');
+  console.log(`Total highlight is ${highlight.length} characters long`);
+  return highlight;
 }
 
 console.log('List of PRs to collect highlights from:', prs);

--- a/.github/scripts/pr_list.mjs
+++ b/.github/scripts/pr_list.mjs
@@ -13,10 +13,14 @@ const historyFilePath = path.join(__dirname, '..', '..', 'HISTORY.md');
  */
 function parsePRList(history) {
   const prRegexp = /js-bson\/issues\/(?<prNum>\d+)\)/iu;
-  return history
-    .split('\n')
-    .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
-    .filter(prNum => prNum !== '');
+  return Array.from(
+    new Set(
+      history
+        .split('\n')
+        .map(line => prRegexp.exec(line)?.groups?.prNum ?? '')
+        .filter(prNum => prNum !== '')
+    )
+  );
 }
 
 const historyContents = await fs.readFile(historyFilePath, { encoding: 'utf8' });

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: [5.x]
   workflow_dispatch: {}
 
 permissions:
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
   id-token: write
 
-name: release
+name: release-5x
 
 jobs:
   release-please:
@@ -24,7 +24,7 @@ jobs:
           pull-request-title-pattern: 'chore${scope}: release ${version} [skip-ci]'
           pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
           changelog-path: HISTORY.md
-          default-branch: main
+          default-branch: 5.x
 
       # If release-please created a release, publish to npm
       - if: ${{ steps.release.outputs.release_created }}
@@ -33,6 +33,6 @@ jobs:
         name: actions/setup
         uses: ./.github/actions/setup
       - if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance
+        run: npm publish --provenance --tag=5x
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,0 +1,34 @@
+on:
+  # Allows us to manually trigger an alpha
+  # workflow_dispatch can be given an alternative 'ref' to release from a feature branch
+  workflow_dispatch:
+    inputs:
+      alphaVersion:
+        description: 'Enter alpha version'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+
+name: release-alpha
+
+jobs:
+  release-alpha:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          ALPHA_SEMVER_REGEXP="-alpha(\.([0-9]|[1-9][0-9]+))?$"
+
+          if ! [[ "${{ inputs.alphaVersion }}" =~ $ALPHA_SEMVER_REGEXP ]]; then
+            echo "Invalid alphaVersion string"
+            exit 1
+          fi
+      - uses: actions/checkout@v3
+      - name: actions/setup
+        uses: ./.github/actions/setup
+      - run: npm version "${{ inputs.alphaVersion }}" --git-tag-version=false
+      - run: npm publish --provenance --tag=alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### What is changing?

- A clean sync of all the scripts and flows on main back to 5.x
  - `git restore -s chore-5x-release -SW -- .github`

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

When the highlights task runs, it will use the scripts on this branch

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
