### PR TITLE
fix: throw BSONVersionError according to its message

### DIFF
--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -358,7 +358,7 @@ function serializeDocument(doc: any, options: EJSONSerializeOptions) {
     doc != null &&
     typeof doc === 'object' &&
     typeof doc._bsontype === 'string' &&
-    doc[Symbol.for('@@mdb.bson.version')] !== BSON_MAJOR_VERSION
+    doc[Symbol.for('@@mdb.bson.version')] < BSON_MAJOR_VERSION
   ) {
     throw new BSONVersionError();
   } else if (isBSONType(doc)) {


### PR DESCRIPTION
### Description

#### What is changing?

- A comparison of BSON_MAJOR_VERSION

##### Is there new documentation needed for these changes?

- No

#### What is the motivation for this change?

- The [message thrown by `BSONVersionError`](https://github.com/mongodb/js-bson/blob/main/src/error.ts#L64) is that the BSON type should be the current major **or later**.
- The [symbol comparison at extended_json.js](https://github.com/mongodb/js-bson/blob/main/src/extended_json.ts#L361) should be an operator `<` instead a strict `!==`  to be in accordance with what the message stands.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
