### PR TITLE
fix(NODE-5640): BsonVersionError improve message clarity

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -60,9 +60,7 @@ export class BSONVersionError extends BSONError {
   }
 
   constructor() {
-    super(
-      `Unsupported BSON version, bson types must be from bson ${BSON_MAJOR_VERSION}.0 or later`
-    );
+    super(`Unsupported BSON version, bson types must be from bson ${BSON_MAJOR_VERSION}.x.x`);
   }
 }
 


### PR DESCRIPTION
### Description

#### What is changing?

- Change `BSONVersionError` to say MAJOR.x.x instead of MAJOR.0 or later

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Clarify BSONVersionError message

Previously our BSONVersionError when thrown stated that the "bson type must be from 6.0 or later" our intention is to prevent cross major bson types from reaching the serialization logic as breaking changes to the types could lead to silent incompatibilities in the serialization process. We've updated the message to make that intention clear: "bson types must be from bson 6.x.x"

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
