### PR TITLE
chore(NODE-5547): fix npm version setting var

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -101,8 +101,9 @@ tasks:
       - func: fetch source
         vars:
           NODE_LTS_VERSION: 14
-          NPM_VERSION: 9
       - func: install dependencies
+        vars:
+          NPM_VERSION: 9
       - func: run tests
         vars:
           TEST_TARGET: node


### PR DESCRIPTION
### Description

#### What is changing?

Move the `NPM_VERSION` var to the install dependencies task

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Make sure node 14 installs the right version of npm

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
