### PR TITLE
chore(NODE-5547): fix BSON 4.x CI

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -19,64 +19,71 @@ functions:
     - command: git.get_project
       params:
         directory: src
-    - command: shell.exec
-      params:
-        working_dir: src
-        script: |
-          # Get the current unique version of this checkout
-          if [ "${is_patch}" = "true" ]; then
-             CURRENT_VERSION=$(git describe)-patch-${version_id}
-          else
-             CURRENT_VERSION=latest
-          fi
-          export PROJECT_DIRECTORY="$(pwd)"
-
-          # get the latest version of node for given major version
-          NODE_VERSION=$(curl -sL nodejs.org/download/release/latest-v${NODE_MAJOR_VERSION}.x/SHASUMS256.txt -o - | head -n 1 | tr -s ' ' | cut -d' ' -f2 | cut -d- -f2 | cut -dv -f2)
-          echo "LATEST NODE ${NODE_MAJOR_VERSION}.x = $NODE_VERSION"
-
-          cat <<EOT > expansion.yml
-          CURRENT_VERSION: "$CURRENT_VERSION"
-          PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"
-          NODE_VERSION: "$NODE_VERSION"
-          PREPARE_SHELL: |
-             set -o errexit
-             set -o xtrace
-             export PROJECT_DIRECTORY="$PROJECT_DIRECTORY"
-             export NODE_VERSION="$NODE_VERSION"
-          EOT
-          # See what we've done
-          cat expansion.yml
     - command: expansions.update
       params:
-        file: src/expansion.yml
-  install dependencies:
-    - command: shell.exec
+        updates:
+          - key: NODE_LTS_VERSION
+            value: ${NODE_LTS_VERSION}
+          - key: NPM_VERSION
+            value: ${NPM_VERSION}
+          - key: PROJECT_DIRECTORY
+            value: ${workdir}/src
+
+  build typescript:
+    - command: subprocess.exec
       type: setup
       params:
         working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          echo "NODE_VERSION=${NODE_VERSION}"
-          NODE_VERSION=${NODE_VERSION} ${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh
+        binary: bash
+        env:
+          NODE_LTS_VERSION: "16"
+          NPM_VERSION: "9"
+          PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
+        args:
+          - .evergreen/install-dependencies.sh
+    - command: subprocess.exec
+      type: setup
+      params:
+        working_dir: src
+        binary: rm
+        args:
+          - -rf
+          - node-artifacts
+          - src/node-artifacts
+
+  install dependencies:
+    - command: subprocess.exec
+      type: setup
+      params:
+        working_dir: src
+        binary: bash
+        add_expansions_to_env: true
+        args:
+          - .evergreen/install-dependencies.sh
+
   run tests:
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
+        params:
         working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          echo "NODE_VERSION=${NODE_VERSION} TEST_TARGET=${TEST_TARGET}"
-          NODE_VERSION=${NODE_VERSION} ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh ${TEST_TARGET}
+        binary: bash
+        add_expansions_to_env: true
+        args:
+          - .evergreen/run-tests.sh
+          - ${TEST_TARGET}
+
   run checks:
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
+        params:
         working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          echo "NODE_VERSION=${NODE_VERSION} TEST_TARGET=${TEST_TARGET}"
-          bash ${PROJECT_DIRECTORY}/.evergreen/run-checks.sh
+        binary: bash
+        add_expansions_to_env: true
+        args:
+          - .evergreen/run-checks.sh
+
   run typescript:
     - command: subprocess.exec
       type: test
@@ -97,7 +104,9 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_MAJOR_VERSION: 6
+          NODE_LTS_VERSION: 6
+          NPM_VERSION: 6
+      - func: build typescript
       - func: install dependencies
       - func: run tests
         vars:
@@ -107,7 +116,9 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_MAJOR_VERSION: 8
+          NODE_LTS_VERSION: 8
+          NPM_VERSION: 6
+      - func: build typescript
       - func: install dependencies
       - func: run tests
         vars:
@@ -118,6 +129,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 10
+          NPM_VERSION: 7
       - func: install dependencies
       - func: run tests
         vars:
@@ -128,6 +140,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 12
+          NPM_VERSION: 8
       - func: install dependencies
       - func: run tests
         vars:
@@ -138,6 +151,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 14
+          NPM_VERSION: 9
       - func: install dependencies
       - func: run tests
         vars:
@@ -148,6 +162,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 16
+          NPM_VERSION: 9
       - func: install dependencies
       - func: run tests
         vars:
@@ -158,6 +173,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 16
+          NPM_VERSION: 9
       - func: install dependencies
       - func: run tests
         vars:
@@ -169,6 +185,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 16
+          NPM_VERSION: 9
       - func: install dependencies
       - func: run checks
   - name: check-typescript-oldest
@@ -176,6 +193,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 16
+          NPM_VERSION: 9
       - func: install dependencies
       - func: "run typescript"
         vars:
@@ -186,6 +204,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 16
+          NPM_VERSION: 9
       - func: install dependencies
       - func: "run typescript"
         vars:
@@ -196,6 +215,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_MAJOR_VERSION: 16
+          NPM_VERSION: 9
       - func: install dependencies
       - func: "run typescript"
         vars:

--- a/.evergreen/init-node-and-npm-env.sh
+++ b/.evergreen/init-node-and-npm-env.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+##
+## This script add the location of `npm` and `node` to the path.
+## This is necessary because evergreen uses separate bash scripts for
+## different functions in a given CI run but doesn't persist the environment
+## across them.  So we manually invoke this script everywhere we need
+## access to `npm`, `node`, or need to install something globally from
+## npm.
+
+NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
+if [[ "$OS" == "Windows_NT" ]]; then
+  NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH")
+fi
+
+export NODE_ARTIFACTS_PATH
+# npm uses this environment variable to determine where to install global packages
+export npm_global_prefix=$NODE_ARTIFACTS_PATH/npm_global
+export PATH="$npm_global_prefix/bin:$NODE_ARTIFACTS_PATH/nodejs/bin:$PATH"
+hash -r
+
+export NODE_OPTIONS="--trace-deprecation --trace-warnings"

--- a/.evergreen/init-nvm.sh
+++ b/.evergreen/init-nvm.sh
@@ -1,9 +1,0 @@
-#! /usr/bin/env bash
-
-export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
-export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
-
-[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
-
-export NODE_OPTIONS="--trace-deprecation --trace-warnings"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,59 +1,108 @@
-#!/bin/bash
-if [ -z "$NODE_VERSION" ]; then
-  echo "NODE_VERSION environment variable must be specified"
+#!/usr/bin/env bash
+set -o errexit  # Exit the script with error if any of the commands fail
+
+NODE_LTS_VERSION=${NODE_LTS_VERSION:-16}
+# npm version can be defined in the environment for cases where we need to install
+# a version lower than latest to support EOL Node versions.
+NPM_VERSION=${NPM_VERSION:-latest}
+
+source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
+
+if [[ -z "${npm_global_prefix}" ]]; then echo "npm_global_prefix is unset" && exit 1; fi
+if [[ -z "${NODE_ARTIFACTS_PATH}" ]]; then echo "NODE_ARTIFACTS_PATH is unset" && exit 1; fi
+
+CURL_FLAGS=(
+  --fail          # Exit code 1 if request fails
+  --compressed    # Request a compressed response should keep fetching fast
+  --location      # Follow a redirect
+  --retry 8       # Retry HTTP 408, 429, 500, 502, 503 or 504, 8 times
+  --silent        # Do not print a progress bar
+  --show-error    # Despite the silent flag still print out errors
+  --max-time 900  # 900 seconds is 15 minutes, evergreen times out at 20
+  # --continue-at - # If a download is interrupted it can figure out where to resume
+)
+
+mkdir -p "$NODE_ARTIFACTS_PATH/npm_global"
+
+# Comparisons are all case insensitive
+shopt -s nocasematch
+
+# index.tab is a sorted tab separated values file with the following headers
+# 0       1    2     3   4  5  6    7       8       9   10
+# version date files npm v8 uv zlib openssl modules lts security
+curl "${CURL_FLAGS[@]}" "https://nodejs.org/dist/index.tab" --output node_index.tab
+
+while IFS=$'\t' read -r -a row; do
+  node_index_version="${row[0]}"
+  node_index_major_version=$(echo $node_index_version | sed -E 's/^v([0-9]+).*$/\1/')
+  node_index_date="${row[1]}"
+  node_index_lts="${row[9]}"
+  [[ "$node_index_version" = "version" ]] && continue # skip tsv header
+  [[ "$NODE_LTS_VERSION" = "latest" ]] && break # first line is latest
+  [[ "$NODE_LTS_VERSION" = "$node_index_version" ]] && break # match full version if specified
+  [[ "$NODE_LTS_VERSION" = "$node_index_major_version" ]] && break # case insensitive compare
+done < node_index.tab
+
+if [[ "$OS" = "Windows_NT" ]]; then
+  operating_system="win"
+elif [[ $(uname) = "darwin" ]]; then
+  operating_system="darwin"
+elif [[ $(uname) = "linux" ]]; then
+  operating_system="linux"
+else
+  echo "Unable to determine operating system: $operating_system"
   exit 1
 fi
 
-set -o errexit  # Exit the script with error if any of the commands fail
+architecture=$(uname -m)
+if [[ $architecture = "x86_64" ]]; then
+  architecture="x64"
+elif [[ $architecture = "arm64" ]]; then
+  architecture="arm64"
+elif [[ $architecture = "aarch64" ]]; then
+  architecture="arm64"
+elif [[ $architecture == s390* ]]; then
+  architecture="s390x"
+elif [[ $architecture == ppc* ]]; then
+  architecture="ppc64le"
+else
+  echo "Unable to determine operating system: $architecture"
+  exit 1
+fi
 
-NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
-NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
-NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
-BIN_DIR="$(pwd)/bin"
-NVM_URL="https://raw.githubusercontent.com/creationix/nvm/v0.38.0/install.sh"
+file_extension="tar.gz"
+if [[ "$OS" = "Windows_NT" ]]; then file_extension="zip"; fi
 
-# this needs to be explicitly exported for the nvm install below
-export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
+node_directory="node-${node_index_version}-${operating_system}-${architecture}"
+node_archive="${node_directory}.${file_extension}"
+node_archive_path="$NODE_ARTIFACTS_PATH/${node_archive}"
+node_download_url="https://nodejs.org/dist/${node_index_version}/${node_archive}"
 
-# create node artifacts path if needed
-mkdir -p "${NODE_ARTIFACTS_PATH}"
-mkdir -p "${NPM_CACHE_DIR}"
-mkdir -p "${NPM_TMP_DIR}"
-mkdir -p "${BIN_DIR}"
-mkdir -p "${NVM_DIR}"
-
-# Add mongodb toolchain to path
-export PATH="${BIN_DIR}:${PATH}"
-
-# install Node.js
-echo "Installing Node ${NODE_LTS_NAME}"
-
-set +o xtrace
-
-echo "  Downloading nvm"
-curl -o- $NVM_URL | bash
-[ -s "${NVM_DIR}/nvm.sh" ] && \. "${NVM_DIR}/nvm.sh"
-
-echo "Running: nvm install --lts --latest-npm"
-nvm install --lts --latest-npm
-echo "Running: nvm install ${NODE_VERSION}"
-nvm install "${NODE_VERSION}"
-echo "Running: nvm use --lts"
-nvm use --lts
+echo "Node.js ${node_index_version} for ${operating_system}-${architecture} released on ${node_index_date}"
 
 set -o xtrace
 
+curl "${CURL_FLAGS[@]}" "${node_download_url}" --output "$node_archive_path"
 
+if [[ "$file_extension" = "zip" ]]; then
+  unzip -q "$node_archive_path" -d "${NODE_ARTIFACTS_PATH}"
+  mkdir -p "${NODE_ARTIFACTS_PATH}/nodejs"
+  # Windows "bins" are at the top level
+  mv "${NODE_ARTIFACTS_PATH}/${node_directory}" "${NODE_ARTIFACTS_PATH}/nodejs/bin"
+  # Need to add executable flag ourselves
+  chmod +x "${NODE_ARTIFACTS_PATH}/nodejs/bin/node.exe"
+  chmod +x "${NODE_ARTIFACTS_PATH}/nodejs/bin/npm"
+else
+  tar -xf "$node_archive_path" -C "${NODE_ARTIFACTS_PATH}"
+  mv "${NODE_ARTIFACTS_PATH}/${node_directory}" "${NODE_ARTIFACTS_PATH}/nodejs"
+fi
 
-# setup npm cache in a local directory
-cat <<EOT > .npmrc
-devdir=${NPM_CACHE_DIR}/.node-gyp
-init-module=${NPM_CACHE_DIR}/.npm-init.js
-cache=${NPM_CACHE_DIR}
-tmp=${NPM_TMP_DIR}
-registry=https://registry.npmjs.org
-EOT
+if [[ $operating_system != "win" && $NODE_LTS_VERSION != "6" ]]; then
+  npm install --global npm@$NPM_VERSION
+  hash -r
+fi
 
-# install node dependencies
-npm install # npm prepare runs after install and will compile the library
-nvm use "${NODE_VERSION}" # Switch to the node version we want to test against
+echo "npm location: $(which npm)"
+echo "npm version: $(npm -v)"
+
+npm install "${NPM_OPTIONS}";

--- a/.evergreen/run-checks.sh
+++ b/.evergreen/run-checks.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-export PROJECT_DIRECTORY="$(pwd)"
-NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
-export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
 npm run lint

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -1,15 +1,6 @@
-#!/bin/bash
-if [ -z "$NODE_VERSION" ]; then
-  echo "NODE_VERSION environment variable must be specified"
-  exit 1
-fi
+#!/usr/bin/env bash
 
-NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
-
-export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-
+source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
 case $1 in
   "node")

--- a/.evergreen/run-typescript.sh
+++ b/.evergreen/run-typescript.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
+
 set -o errexit # Exit the script with error if any of the commands fail
-
-# source "${PROJECT_DIRECTORY}/.evergreen/init-nvm.sh"
-
 set -o xtrace
+
+source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
 
 function get_current_ts_version {
     node -e "console.log(require('./package-lock.json').dependencies.typescript.version)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@rollup/plugin-node-resolve": "^9.0.0",
         "@rollup/plugin-replace": "^4.0.0",
         "@rollup/plugin-typescript": "^6.0.0",
-        "@types/node": "^18.0.0",
+        "@types/node": "^18.18.0",
         "@typescript-eslint/eslint-plugin": "^5.30.0",
         "@typescript-eslint/parser": "^5.30.0",
         "array-includes": "^3.1.3",
@@ -2184,9 +2184,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+      "version": "18.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
+      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -10976,9 +10976,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+      "version": "18.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
+      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-replace": "^4.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.18.0",
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "array-includes": "^3.1.3",


### PR DESCRIPTION
### Description

#### What is changing?

- Remove nvm and backport node download script from other repos
  - backports init-node-and-npm-env.sh in place of init-nvm
  - backports install-dependencies script.
    - Remove `--continue-at -` flag, older node versions unable to be downloaded with this set
    - exempt node 6 from upgrading its npm version, npm 3 is unable to install a newer npm version
- bump `@types/node` to fix a typescript@next compilation failure

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Fix BSON 4.x setup failures to make it usable for testing

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the correct format: `<type>(NODE-xxxx)<!>: <description>`
- [x] Changes are tests
- [x] New TODOs have a related JIRA ticket
