### PR TITLE
feat(Node 5040): add color to BSON inspect

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -1,4 +1,4 @@
-import { isAnyArrayBuffer, isUint8Array } from './parser/utils';
+import { getStylizeFunction, isAnyArrayBuffer, isUint8Array } from './parser/utils';
 import type { EJSONOptions } from './extended_json';
 import { BSONError } from './error';
 import { BSON_BINARY_SUBTYPE_UUID_NEW } from './constants';
@@ -264,13 +264,15 @@ export class Binary extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {  
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
     const base64 = ByteUtils.toBase64(this.buffer.subarray(0, this.position));
-    return `Binary.createFromBase64("${base64}", ${this.sub_type})`;
+    const base64Arg = stylize(`"${base64}"`, 'string');
+    return `Binary.createFromBase64(${base64Arg}, ${this.sub_type})`;
   }
 }
 
@@ -465,11 +467,12 @@ export class UUID extends Binary {
    * @returns return the 36 character hex string representation.
    * @internal
    */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
-    return `new UUID("${this.toHexString()}")`;
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
+    return `new UUID(${stylize(`"${this.toHexString()}"`, 'string')})`;
   }
 }

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -1,4 +1,9 @@
-import { getStylizeFunction, isAnyArrayBuffer, isUint8Array } from './parser/utils';
+import {
+  type InspectParameterFn,
+  getBasicInspectParameterFn,
+  isAnyArrayBuffer,
+  isUint8Array
+} from './parser/utils';
 import type { EJSONOptions } from './extended_json';
 import { BSONError } from './error';
 import { BSON_BINARY_SUBTYPE_UUID_NEW } from './constants';
@@ -264,15 +269,20 @@ export class Binary extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {  
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const stylize = getStylizeFunction(options);
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
     const base64 = ByteUtils.toBase64(this.buffer.subarray(0, this.position));
-    const base64Arg = stylize(`"${base64}"`, 'string');
-    return `Binary.createFromBase64(${base64Arg}, ${this.sub_type})`;
+    const base64Arg = inspect(base64, options);
+    const subTypeArg = inspect(this.sub_type, options);
+    return `Binary.createFromBase64(${base64Arg}, ${subTypeArg})`;
   }
 }
 
@@ -467,12 +477,16 @@ export class UUID extends Binary {
    * @returns return the 36 character hex string representation.
    * @internal
    */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const stylize = getStylizeFunction(options);
-    return `new UUID(${stylize(`"${this.toHexString()}"`, 'string')})`;
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
+    return `new UUID(${inspect(this.toHexString(), options)})`;
   }
 }

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,6 +1,6 @@
-import { getStylizeFunction } from './parser/utils';
 import type { Document } from './bson';
 import { BSONValue } from './bson_value';
+import { type InspectParameterFn, getBasicInspectParameterFn } from './parser/utils';
 
 /** @public */
 export interface CodeExtended {
@@ -60,22 +60,19 @@ export class Code extends BSONValue {
   [Symbol.for('nodejs.util.inspect.custom')](
     depth?: number,
     options?: unknown,
-    inspect?: (value: unknown, options: unknown) => string
+    inspect?: InspectParameterFn
   ): string {
     return this.inspect(depth, options, inspect);
   }
 
-  inspect(
-    depth?: number,
-    options?: unknown,
-    inspect?: (value: unknown, options: unknown) => string
-  ): string {
-    inspect ??= v => JSON.stringify(v);
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
     let parametersString = inspect(this.code, options);
     const multiLineFn = parametersString.includes('\n');
     if (this.scope != null) {
       parametersString += `,${multiLineFn ? '\n' : ' '}${inspect(this.scope, options)}`;
     }
-    return `new Code(${multiLineFn ? '\n' : ''}${parametersString}${multiLineFn ? '\n' : ''})`;
+    const endingNewline = multiLineFn && this.scope === null;
+    return `new Code(${multiLineFn ? '\n' : ''}${parametersString}${endingNewline ? '\n' : ''})`;
   }
 }

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,3 +1,4 @@
+import { getStylizeFunction } from './parser/utils';
 import type { Document } from './bson';
 import { BSONValue } from './bson_value';
 
@@ -56,14 +57,25 @@ export class Code extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: (value: unknown, options: unknown) => string
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(): string {
-    const codeJson = this.toJSON();
-    return `new Code(${JSON.stringify(String(codeJson.code))}${
-      codeJson.scope != null ? `, ${JSON.stringify(codeJson.scope)}` : ''
-    })`;
+  inspect(
+    depth?: number,
+    options?: unknown,
+    inspect?: (value: unknown, options: unknown) => string
+  ): string {
+    inspect ??= v => JSON.stringify(v);
+    let parametersString = inspect(this.code, options);
+    const multiLineFn = parametersString.includes('\n');
+    if (this.scope != null) {
+      parametersString += `,${multiLineFn ? '\n' : ' '}${inspect(this.scope, options)}`;
+    }
+    return `new Code(${multiLineFn ? '\n' : ''}${parametersString}${multiLineFn ? '\n' : ''})`;
   }
 }

--- a/src/db_ref.ts
+++ b/src/db_ref.ts
@@ -1,3 +1,4 @@
+import { getStylizeFunction, InspectParameterFn } from './parser/utils';
 import type { Document } from './bson';
 import { BSONValue } from './bson_value';
 import type { EJSONOptions } from './extended_json';
@@ -112,16 +113,28 @@ export class DBRef extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(): string {
-    // NOTE: if OID is an ObjectId class it will just print the oid string.
-    const oid =
-      this.oid === undefined || this.oid.toString === undefined ? this.oid : this.oid.toString();
-    return `new DBRef("${this.namespace}", new ObjectId("${String(oid)}")${
-      this.db ? `, "${this.db}"` : ''
-    })`;
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    const stylize = getStylizeFunction(options);
+    inspect ??= v => JSON.stringify(v);
+
+    const args = [stylize(`"${this.namespace}"`, 'string'), this.oid.inspect(depth, options)];
+
+    if (this.db) {
+      args.push(stylize(`"${this.db}"`, 'string'));
+    }
+
+    if (Object.keys(this.fields).length > 0) {
+      args.push(inspect(this.fields, options));
+    }
+
+    return `new DBRef(${args.join(', ')})`;
   }
 }

--- a/src/db_ref.ts
+++ b/src/db_ref.ts
@@ -1,8 +1,8 @@
-import { getStylizeFunction, InspectParameterFn } from './parser/utils';
 import type { Document } from './bson';
 import { BSONValue } from './bson_value';
 import type { EJSONOptions } from './extended_json';
 import type { ObjectId } from './objectid';
+import { type InspectParameterFn, getBasicInspectParameterFn } from './parser/utils';
 
 /** @public */
 export interface DBRefLike {
@@ -122,13 +122,12 @@ export class DBRef extends BSONValue {
   }
 
   inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
-    const stylize = getStylizeFunction(options);
-    inspect ??= v => JSON.stringify(v);
+    inspect ??= getBasicInspectParameterFn();
 
-    const args = [stylize(`"${this.namespace}"`, 'string'), this.oid.inspect(depth, options)];
+    const args = [inspect(this.namespace, options), inspect(this.oid, options)];
 
     if (this.db) {
-      args.push(stylize(`"${this.db}"`, 'string'));
+      args.push(inspect(this.db, options));
     }
 
     if (Object.keys(this.fields).length > 0) {

--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -1,7 +1,7 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import { Long } from './long';
-import { isUint8Array } from './parser/utils';
+import { getStylizeFunction, isUint8Array } from './parser/utils';
 import { ByteUtils } from './utils/byte_utils';
 
 const PARSE_STRING_REGEXP = /^(\+|-)?(\d+|(\d*\.\d*))?(E|e)?([-+])?(\d+)?$/;
@@ -848,11 +848,13 @@ export class Decimal128 extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
-    return `new Decimal128("${this.toString()}")`;
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
+    const d128string = stylize(`"${this.toString()}"`, 'string');
+    return `new Decimal128(${d128string})`;
   }
 }

--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -1,7 +1,7 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import { Long } from './long';
-import { getStylizeFunction, isUint8Array } from './parser/utils';
+import { type InspectParameterFn, getBasicInspectParameterFn, isUint8Array } from './parser/utils';
 import { ByteUtils } from './utils/byte_utils';
 
 const PARSE_STRING_REGEXP = /^(\+|-)?(\d+|(\d*\.\d*))?(E|e)?([-+])?(\d+)?$/;
@@ -848,13 +848,17 @@ export class Decimal128 extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const stylize = getStylizeFunction(options);
-    const d128string = stylize(`"${this.toString()}"`, 'string');
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
+    const d128string = inspect(this.toString(), options);
     return `new Decimal128(${d128string})`;
   }
 }

--- a/src/double.ts
+++ b/src/double.ts
@@ -1,5 +1,6 @@
 import { BSONValue } from './bson_value';
 import type { EJSONOptions } from './extended_json';
+import { getStylizeFunction } from './parser/utils';
 
 /** @public */
 export interface DoubleExtended {
@@ -72,12 +73,13 @@ export class Double extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
+  inspect(depth?: number, options?: unknown): string {
     const eJSON = this.toExtendedJSON() as DoubleExtended;
-    return `new Double(${eJSON.$numberDouble})`;
+    const stylize = getStylizeFunction(options);
+    return `new Double(${stylize(eJSON.$numberDouble, 'number')})`;
   }
 }

--- a/src/double.ts
+++ b/src/double.ts
@@ -1,6 +1,6 @@
 import { BSONValue } from './bson_value';
 import type { EJSONOptions } from './extended_json';
-import { getStylizeFunction } from './parser/utils';
+import { type InspectParameterFn, getBasicInspectParameterFn } from './parser/utils';
 
 /** @public */
 export interface DoubleExtended {
@@ -73,13 +73,16 @@ export class Double extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const eJSON = this.toExtendedJSON() as DoubleExtended;
-    const stylize = getStylizeFunction(options);
-    return `new Double(${stylize(eJSON.$numberDouble, 'number')})`;
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
+    return `new Double(${inspect(this.valueOf(), options)})`;
   }
 }

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -1,5 +1,6 @@
 import { BSONValue } from './bson_value';
 import type { EJSONOptions } from './extended_json';
+import { getStylizeFunction } from './parser/utils';
 
 /** @public */
 export interface Int32Extended {
@@ -60,11 +61,12 @@ export class Int32 extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
-    return `new Int32(${this.valueOf()})`;
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
+    return `new Int32(${stylize(this.value, 'number')})`;
   }
 }

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -1,6 +1,6 @@
 import { BSONValue } from './bson_value';
 import type { EJSONOptions } from './extended_json';
-import { getStylizeFunction } from './parser/utils';
+import { type InspectParameterFn, getBasicInspectParameterFn } from './parser/utils';
 
 /** @public */
 export interface Int32Extended {
@@ -61,12 +61,16 @@ export class Int32 extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const stylize = getStylizeFunction(options);
-    return `new Int32(${stylize(this.value, 'number')})`;
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
+    return `new Int32(${inspect(this.value, options)})`;
   }
 }

--- a/src/long.ts
+++ b/src/long.ts
@@ -1,6 +1,7 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import type { EJSONOptions } from './extended_json';
+import { getStylizeFunction } from './parser/utils';
 import type { Timestamp } from './timestamp';
 
 interface LongWASMHelpers {
@@ -1057,11 +1058,16 @@ export class Long extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
-    return `new Long("${this.toString()}"${this.unsigned ? ', true' : ''})`;
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
+    return `new Int32(${stylize(54, 'number')})`;
+    /*return `new Long(${stylize(this.toString() + 'n', 'number')}, ${stylize(
+      this.unsigned,
+      'boolean'
+    )})`; */
   }
 }

--- a/src/long.ts
+++ b/src/long.ts
@@ -1,7 +1,7 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import type { EJSONOptions } from './extended_json';
-import { getStylizeFunction } from './parser/utils';
+import { type InspectParameterFn, getBasicInspectParameterFn } from './parser/utils';
 import type { Timestamp } from './timestamp';
 
 interface LongWASMHelpers {
@@ -1058,15 +1058,18 @@ export class Long extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const stylize = getStylizeFunction(options);
-    return `new Long("${stylize(this.toString(), 'number')}" ${stylize(
-      this.unsigned,
-      'boolean'
-    )})`;
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
+    const longVal = inspect(this.toString(), options);
+    const unsignedVal = this.unsigned ? `', ' + ${inspect(this.unsigned, options)}` : '';
+    return `${longVal} + ${unsignedVal}`;
   }
 }

--- a/src/long.ts
+++ b/src/long.ts
@@ -1064,10 +1064,9 @@ export class Long extends BSONValue {
 
   inspect(depth?: number, options?: unknown): string {
     const stylize = getStylizeFunction(options);
-    return `new Int32(${stylize(54, 'number')})`;
-    /*return `new Long(${stylize(this.toString() + 'n', 'number')}, ${stylize(
+    return `new Long("${stylize(this.toString(), 'number')}" ${stylize(
       this.unsigned,
       'boolean'
-    )})`; */
+    )})`;
   }
 }

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -1,5 +1,6 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
+import { getStylizeFunction } from './parser/utils';
 import { BSONDataView, ByteUtils } from './utils/byte_utils';
 
 // Regular expression that checks for hex value
@@ -296,11 +297,12 @@ export class ObjectId extends BSONValue {
    * @returns return the 24 character hex string representation.
    * @internal
    */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
-    return `new ObjectId("${this.toHexString()}")`;
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
+    return `new ObjectId(${stylize(`"${this.toHexString()}"`, 'string')})`;
   }
 }

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -1,6 +1,6 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
-import { getStylizeFunction } from './parser/utils';
+import { type InspectParameterFn, getBasicInspectParameterFn } from './parser/utils';
 import { BSONDataView, ByteUtils } from './utils/byte_utils';
 
 // Regular expression that checks for hex value
@@ -297,12 +297,16 @@ export class ObjectId extends BSONValue {
    * @returns return the 24 character hex string representation.
    * @internal
    */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const stylize = getStylizeFunction(options);
-    return `new ObjectId(${stylize(`"${this.toHexString()}"`, 'string')})`;
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
+    return `new ObjectId(${inspect(this.toHexString(), options)})`;
   }
 }

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -27,3 +27,23 @@ export function isMap(d: unknown): d is Map<unknown, unknown> {
 export function isDate(d: unknown): d is Date {
   return Object.prototype.toString.call(d) === '[object Date]';
 }
+
+/** @internal */
+export type StylizeFunction = (x: unknown, style: string) => string;
+/** @internal */
+export type InspectParameterFn = (x: unknown, options: unknown) => string;
+export function getStylizeFunction(options?: unknown): StylizeFunction {
+  const stylizeExists = 
+    options != null && 
+    typeof options === 'object' && 
+    'stylize' in options && 
+    typeof options.stylize === 'function';
+  
+  if (stylizeExists) {
+    return options.stylize as 
+    (x: unknown, style: string) => string; 
+  } else {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    return v => `${v}`;
+  } 
+}

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -32,18 +32,20 @@ export function isDate(d: unknown): d is Date {
 export type StylizeFunction = (x: unknown, style: string) => string;
 /** @internal */
 export type InspectParameterFn = (x: unknown, options: unknown) => string;
+export function getBasicInspectParameterFn(): InspectParameterFn {
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  return v => `${v}`;
+}
 export function getStylizeFunction(options?: unknown): StylizeFunction {
-  const stylizeExists = 
-    options != null && 
-    typeof options === 'object' && 
-    'stylize' in options && 
+  const stylizeExists =
+    options != null &&
+    typeof options === 'object' &&
+    'stylize' in options &&
     typeof options.stylize === 'function';
-  
+
   if (stylizeExists) {
-    return options.stylize as 
-    (x: unknown, style: string) => string; 
+    return options.stylize as (x: unknown, style: string) => string;
   } else {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    return v => `${v}`;
-  } 
+    return getBasicInspectParameterFn();
+  }
 }

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -1,6 +1,7 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import type { EJSONOptions } from './extended_json';
+import { getStylizeFunction } from './parser/utils';
 
 function alphabetize(str: string): string {
   return str.split('').sort().join('');
@@ -104,11 +105,14 @@ export class BSONRegExp extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
-    return `new BSONRegExp(${JSON.stringify(this.pattern)}, ${JSON.stringify(this.options)})`;
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
+    const pattern = stylize(JSON.stringify(this.pattern), 'regexp');
+    const flags = stylize(JSON.stringify(this.options), 'regexp');
+    return `new BSONRegExp(${pattern}, ${flags})`;
   }
 }

--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -111,8 +111,8 @@ export class BSONRegExp extends BSONValue {
 
   inspect(depth?: number, options?: unknown): string {
     const stylize = getStylizeFunction(options);
-    const pattern = stylize(JSON.stringify(this.pattern), 'regexp');
-    const flags = stylize(JSON.stringify(this.options), 'regexp');
+    const pattern = stylize(`'${this.pattern}'`, 'regexp');
+    const flags = stylize(`${this.options}'`, 'regexp');
     return `new BSONRegExp(${pattern}, ${flags})`;
   }
 }

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,5 +1,5 @@
 import { BSONValue } from './bson_value';
-import { getStylizeFunction } from './parser/utils';
+import { type InspectParameterFn, getBasicInspectParameterFn } from './parser/utils';
 
 /** @public */
 export interface BSONSymbolExtended {
@@ -49,12 +49,16 @@ export class BSONSymbol extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const stylize = getStylizeFunction(options);
-    return `new BSONSymbol(${stylize(`"${this.value}"`, 'string')})`;
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
+    return `new BSONSymbol(${inspect(this.value, options)})`;
   }
 }

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,4 +1,5 @@
 import { BSONValue } from './bson_value';
+import { getStylizeFunction } from './parser/utils';
 
 /** @public */
 export interface BSONSymbolExtended {
@@ -33,10 +34,6 @@ export class BSONSymbol extends BSONValue {
     return this.value;
   }
 
-  inspect(): string {
-    return `new BSONSymbol(${JSON.stringify(this.value)})`;
-  }
-
   toJSON(): string {
     return this.value;
   }
@@ -52,7 +49,12 @@ export class BSONSymbol extends BSONValue {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
+  }
+
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
+    return `new BSONSymbol(${stylize(`"${this.value}"`, 'string')})`;
   }
 }

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -1,7 +1,7 @@
 import { BSONError } from './error';
 import type { Int32 } from './int_32';
 import { Long } from './long';
-import { getStylizeFunction } from './parser/utils';
+import { type InspectParameterFn, getBasicInspectParameterFn } from './parser/utils';
 
 /** @public */
 export type TimestampOverrides = '_bsontype' | 'toExtendedJSON' | 'fromExtendedJSON' | 'inspect';
@@ -143,14 +143,18 @@ export class Timestamp extends LongWithoutOverridesClass {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
-    return this.inspect(depth, options);
+  [Symbol.for('nodejs.util.inspect.custom')](
+    depth?: number,
+    options?: unknown,
+    inspect?: InspectParameterFn
+  ): string {
+    return this.inspect(depth, options, inspect);
   }
 
-  inspect(depth?: number, options?: unknown): string {
-    const stylize = getStylizeFunction(options);
-    const t = stylize(`${this.getHighBits()}`, 'number');
-    const i = stylize(`${this.getLowBits()}`, 'number');
+  inspect(depth?: number, options?: unknown, inspect?: InspectParameterFn): string {
+    inspect ??= getBasicInspectParameterFn();
+    const t = inspect(this.getHighBits(), options);
+    const i = inspect(this.getLowBits(), options);
     return `new Timestamp({ t: ${t}, i: ${i} })`;
   }
 }

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -1,6 +1,7 @@
 import { BSONError } from './error';
 import type { Int32 } from './int_32';
 import { Long } from './long';
+import { getStylizeFunction } from './parser/utils';
 
 /** @public */
 export type TimestampOverrides = '_bsontype' | 'toExtendedJSON' | 'fromExtendedJSON' | 'inspect';
@@ -142,11 +143,14 @@ export class Timestamp extends LongWithoutOverridesClass {
   }
 
   /** @internal */
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.inspect();
+  [Symbol.for('nodejs.util.inspect.custom')](depth?: number, options?: unknown): string {
+    return this.inspect(depth, options);
   }
 
-  inspect(): string {
-    return `new Timestamp({ t: ${this.getHighBits()}, i: ${this.getLowBits()} })`;
+  inspect(depth?: number, options?: unknown): string {
+    const stylize = getStylizeFunction(options);
+    const t = stylize(`${this.getHighBits()}`, 'number');
+    const i = stylize(`${this.getLowBits()}`, 'number');
+    return `new Timestamp({ t: ${t}, i: ${i} })`;
   }
 }

--- a/test/colors.mjs
+++ b/test/colors.mjs
@@ -1,0 +1,49 @@
+'use strict';
+
+import {
+  Binary,
+  UUID,
+  Code,
+  DBRef,
+  Decimal128,
+  Double,
+  Int32,
+  Long,
+  ObjectId,
+  BSONRegExp,
+  BSONSymbol,
+  Timestamp,
+  MaxKey,
+  MinKey
+} from '../lib/bson.mjs';
+
+console.log({
+  binary: new Binary(Buffer.from('abcdef', 'utf8'), 0x06),
+  uuid: new UUID(),
+  code: new Code(function iLoveJavaScript() {
+    do {
+      console.log('hello!');
+    } while (Math.random() > 0.5);
+  }),
+  code_w_scope: new Code(
+    function iLoveJavaScript() {
+      do {
+        console.log('hello!');
+      } while (Math.random() > 0.5);
+    },
+    { context: 'random looping!', reference: Long.fromString('2345') }
+  ),
+  dbref: new DBRef('collection', new ObjectId('00'.repeat(12))),
+  dbref_db: new DBRef('collection', new ObjectId('00'.repeat(12)), 'db'),
+  dbref_db_fields: new DBRef('collection', new ObjectId('00'.repeat(12)), 'db', { a: 1 }),
+  decimal128: new Decimal128('1.353e34'),
+  double: new Double(2.354),
+  int32: new Int32('4577'),
+  long: new Long(-12442),
+  objectid: new ObjectId('00'.repeat(12)),
+  bsonregexp: new BSONRegExp('abc', 'imx'),
+  bsonsymbol: new BSONSymbol('my symbol'),
+  timestamp: new Timestamp({ i: 2345, t: 23453 }),
+  maxkey: new MaxKey(),
+  minkey: new MinKey()
+});

--- a/test/colors.mjs
+++ b/test/colors.mjs
@@ -25,19 +25,25 @@ console.log({
       console.log('hello!');
     } while (Math.random() > 0.5);
   }),
-  code_w_scope: new Code(
+  c: new Code(
     function iLoveJavaScript() {
       do {
         console.log('hello!');
       } while (Math.random() > 0.5);
     },
-    { context: 'random looping!', reference: Long.fromString('2345') }
+    { context: 'random looping!', reference: Long.fromString('2345'), my_map: {a:1}}
+  ),
+  c2: new Code (
+    function iLoveJavaScript() { return `js`; },
+    { context: 'random looping!', reference: Long.fromString('2345'), my_map: {a:1}}
   ),
   dbref: new DBRef('collection', new ObjectId('00'.repeat(12))),
   dbref_db: new DBRef('collection', new ObjectId('00'.repeat(12)), 'db'),
   dbref_db_fields: new DBRef('collection', new ObjectId('00'.repeat(12)), 'db', { a: 1 }),
   decimal128: new Decimal128('1.353e34'),
   double: new Double(2.354),
+  double2: new Double(2),
+  double3: new Double(-0),
   int32: new Int32('4577'),
   long: new Long(-12442),
   objectid: new ObjectId('00'.repeat(12)),

--- a/test/node/bson_type_classes.test.ts
+++ b/test/node/bson_type_classes.test.ts
@@ -66,15 +66,22 @@ describe('BSON Type classes common interfaces', () => {
       it(`${name} inherits from BSONValue`, () => {
         expect(creator()).to.be.instanceOf(BSONValue);
       });
-      context.only(`${name}[Symbol.for('nodejs.util.inspect.custom')] ${(name === 'MinKey' || name === 'MaxKey') ? 'does not support' : 'supports'} color`, () => {
-        it(`returns string with ${(name === 'MinKey' || name === 'MaxKey') ? 'no ' : ''}ANSI colors`, () => {
-          if (name !== 'MinKey' && name !== 'MaxKey') {
-            const value = creator();
-            const string = inspect(value, { colors: true });
-            expect(string).include('\x1b');
-          }
-        });
-      });
+      context(
+        `${name}[Symbol.for('nodejs.util.inspect.custom')] ${
+          name === 'MinKey' || name === 'MaxKey' ? 'does not support' : 'supports'
+        } color`,
+        () => {
+          it(`returns string with ${
+            name === 'MinKey' || name === 'MaxKey' ? 'no ' : ''
+          }ANSI colors`, () => {
+            if (name !== 'MinKey' && name !== 'MaxKey') {
+              const value = creator();
+              const string = inspect(value, { colors: true });
+              expect(string).include('\x1b');
+            }
+          });
+        }
+      );
     }
   });
 

--- a/test/node/bson_type_classes.test.ts
+++ b/test/node/bson_type_classes.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { inspect } from 'node:util';
 import { __isWeb__ } from '../register-bson';
 import {
   Binary,
@@ -60,9 +61,19 @@ describe('BSON Type classes common interfaces', () => {
         return this.currentTest?.skip();
       }
     });
+
     for (const [name, creator] of BSONTypeClassCtors) {
       it(`${name} inherits from BSONValue`, () => {
         expect(creator()).to.be.instanceOf(BSONValue);
+      });
+      context.only(`${name}[Symbol.for('nodejs.util.inspect.custom')] ${(name === 'MinKey' || name === 'MaxKey') ? 'does not support' : 'supports'} color`, () => {
+        it(`returns string with ${(name === 'MinKey' || name === 'MaxKey') ? 'no ' : ''}ANSI colors`, () => {
+          if (name !== 'MinKey' && name !== 'MaxKey') {
+            const value = creator();
+            const string = inspect(value, { colors: true });
+            expect(string).include('\x1b');
+          }
+        });
       });
     }
   });


### PR DESCRIPTION
### Description
Utilizing Node.js's custom inspect functionality `[Symbol.for('nodejs.util.inspect.custom')]`, we are able to write custom functions to print out user input to BSON types. This allows users to visualize their BSON objects in color, as well as set options to their inspect function. 

#### What is changing?
Node.js colors the various types of javascript values, through the inspect function, and we can now harness that for BSON types. In addition, we support all user-defined inspect option inputs, for all types except RegExp.

This functionality is not available in the browser, in which case the Node Driver defaults to the default JS inspect. 

##### Is there new documentation needed for these changes?
Yes. Users need to be provided with information about what is printed with the new inspect functionality and how to modify the options.

#### What is the motivation for this change?
To help users have better control over their visualization of BSON objects, especially in the case of color visualization of values of different types.


### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Node.js BSON now supports inspect options, specifically visualizing in color
| First Header  | Second Header | Second Header |
| ------------- | ------------- | ------------- | ------------- |
| Content Cell  | Content Cell  | Content Cell  | Content Cell  |
| Content Cell  | Content Cell  | Content Cell  | Content Cell  |
| Content Cell  | Content Cell  | Content Cell  | Content Cell  |
| Content Cell  | Content Cell  | Content Cell  | Content Cell  |
| Content Cell  | Content Cell  | Content Cell  | Content Cell  |
| Content Cell  | Content Cell  | Content Cell  | Content Cell  |
| Content Cell  | Content Cell  | Content Cell  | Content Cell  |
| Content Cell  | Content Cell  | Content Cell  | Content Cell  |


<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
