### PR TITLE
fix(NODE-3034): ObjectId.isValid() returns false if a number is passed

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -269,8 +269,10 @@ export class ObjectId extends BSONValue {
    * Checks if a value can be used to create a valid bson ObjectId
    * @param id - any JS value
    */
-  static isValid(id: string | number | ObjectId | ObjectIdLike | Uint8Array): boolean {
+  static isValid(id: string | ObjectId | ObjectIdLike | Uint8Array): boolean {
     if (id == null) return false;
+    // ObjectId constructor accepts a number (seconds) but a number is not a valid ObjectId
+    if (typeof id === 'number') return false;
 
     try {
       new ObjectId(id);

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1696,7 +1696,6 @@ describe('BSON', function () {
     expect(false).to.equal(ObjectId.isValid({ length: 12 }));
     expect(false).to.equal(ObjectId.isValid([]));
     expect(false).to.equal(ObjectId.isValid(true));
-    expect(true).to.equal(ObjectId.isValid(0));
     expect(false).to.equal(ObjectId.isValid('invalid'));
     expect(false).to.equal(ObjectId.isValid('zzzzzzzzzzzzzzzzzzzzzzzz'));
     expect(true).to.equal(ObjectId.isValid('000000000000000000000000'));

--- a/test/node/object_id.test.ts
+++ b/test/node/object_id.test.ts
@@ -344,12 +344,12 @@ describe('ObjectId', function () {
     });
 
     context('when called with a number', () => {
-      it('returns true for any number (0)', () => expect(ObjectId.isValid(0)).to.be.true);
+      it('returns false for any number (0)', () => expect(ObjectId.isValid(0)).to.be.false);
 
-      it('returns true for any number (MIN_SAFE_INTEGER)', () =>
-        expect(ObjectId.isValid(Number.MIN_SAFE_INTEGER)).to.be.true);
+      it('returns false for any number (MIN_SAFE_INTEGER)', () =>
+        expect(ObjectId.isValid(Number.MIN_SAFE_INTEGER)).to.be.false);
 
-      it('returns true for any number (NaN)', () => expect(ObjectId.isValid(NaN)).to.be.true);
+      it('returns false for any number (NaN)', () => expect(ObjectId.isValid(NaN)).to.be.false);
     });
 
     context('when called with a ObjectId or ObjectIdLike', () => {


### PR DESCRIPTION
### Description

#### What is changing?

- Change `ObjectId.isValid()` to fail when a number is passed as an argument

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

`ObjectId.isValid(1)` returns `true` but this is wrong, since _numbers_ aren't valid ObjectIds.
The improper behaviour has been added with [this commit](https://github.com/mongodb/js-bson/commit/cd132d9b8498d1a10f93a011223758f340f3a466) on May 20, 2015.
Since then the `ObjectId.isValid()` function has been refactored a couple of times but the behaviour is still the same.
The last major refactor occurred on [Dec 2, 2021](https://github.com/mongodb/js-bson/commit/187d1c40f7222fd63dbc55d1535669ff0bfcbce2#diff-18c447fb56b40e1238fd00fc5473e2994d33a1f4618c2bdb71a3af1759c599abL293) where all the checks have been replaced with a try-catched call to the ObjectId constructor, but the programmer was misled by the existing (wrong) support for `number`.

`ObjectId.isValid()` tests with numbers were added with [this commit](https://github.com/mongodb/js-bson/commit/409c592524a6eec6a89eb96dee4b51e4f8adf5ae#diff-dd8a26a1854c387c9ca9fa21c8edbb62d38d81e51f96e4a76335fd023b1024baR346) on Aug 1, 2023 during a fix to the ObjectId constructor (perhaps to improve coverage).

This bug is tracked by [NODE-3034](https://jira.mongodb.org/browse/NODE-3034).

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
