### PR TITLE
test(NODE-5922): replace hardcoded reference to bson#main

### DIFF
--- a/test/bench/etc/run_granular_benchmarks.js
+++ b/test/bench/etc/run_granular_benchmarks.js
@@ -9,7 +9,7 @@ const fs = require('fs/promises');
 const path = require('path');
 const { once } = require('events');
 const { Task } = require('dbx-js-tools/packages/bson-bench');
-const { LIBRARY_SPEC } = require('../granular/common');
+const { LIBRARY_SPEC } = require('../lib/granular/common');
 
 const BENCHMARK_REGEX = /(.*)\.bench\.js$/;
 const BENCHMARK_PATH = path.resolve(`${__dirname}/../lib/granular`);

--- a/test/bench/etc/run_granular_benchmarks.js
+++ b/test/bench/etc/run_granular_benchmarks.js
@@ -9,6 +9,7 @@ const fs = require('fs/promises');
 const path = require('path');
 const { once } = require('events');
 const { Task } = require('dbx-js-tools/packages/bson-bench');
+const { LIBRARY_SPEC } = require('../granular/common');
 
 const BENCHMARK_REGEX = /(.*)\.bench\.js$/;
 const BENCHMARK_PATH = path.resolve(`${__dirname}/../lib/granular`);
@@ -18,7 +19,7 @@ const DOCUMENT_ROOT = path.resolve(`${__dirname}/../documents`);
   // FIXME(NODE-5759): replace this with a call to Package.install()
   await new Task({
     documentPath: path.resolve(`${DOCUMENT_ROOT}/binary_small.json`),
-    library: `bson#main`,
+    library: LIBRARY_SPEC,
     iterations: 1,
     warmup: 1,
     operation: 'deserialize',


### PR DESCRIPTION
### Description

#### What is changing?
Replaced hardcoded reference to `bson#main` when running pre-benchmark setup for `run_granular_benchmarks.js`

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

NODE-5922

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->


<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
