### PR TITLE
perf(NODE-5934): replace DataView uses with bit math

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -75,7 +75,8 @@
     "no-bigint-usage/no-bigint-literals": "error",
     "no-restricted-globals": [
       "error",
-      "BigInt"
+      "BigInt",
+      "DataView"
     ]
   },
   "overrides": [

--- a/src/bson.ts
+++ b/src/bson.ts
@@ -16,6 +16,7 @@ import { BSONRegExp } from './regexp';
 import { BSONSymbol } from './symbol';
 import { Timestamp } from './timestamp';
 import { ByteUtils } from './utils/byte_utils';
+import { NumberUtils } from './utils/number_utils';
 export type { UUIDExtended, BinaryExtended, BinaryExtendedLegacy, BinarySequence } from './binary';
 export type { CodeExtended } from './code';
 export type { DBRefLike } from './db_ref';
@@ -232,11 +233,7 @@ export function deserializeStream(
   // Loop over all documents
   for (let i = 0; i < numberOfDocuments; i++) {
     // Find size of the document
-    const size =
-      bufferData[index] |
-      (bufferData[index + 1] << 8) |
-      (bufferData[index + 2] << 16) |
-      (bufferData[index + 3] << 24);
+    const size = NumberUtils.getInt32LE(bufferData, index);
     // Update options with index
     internalOptions.index = index;
     // Parse the document at this point

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -1,7 +1,7 @@
 import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import { type InspectFn, defaultInspect } from './parser/utils';
-import { BSONDataView, ByteUtils } from './utils/byte_utils';
+import { ByteUtils } from './utils/byte_utils';
 
 // Regular expression that checks for hex value
 const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
@@ -179,7 +179,13 @@ export class ObjectId extends BSONValue {
     const buffer = ByteUtils.allocate(12);
 
     // 4-byte timestamp
-    BSONDataView.fromUint8Array(buffer).setUint32(0, time, false);
+    buffer[3] = time;
+    time = time >>> 8;
+    buffer[2] = time;
+    time = time >>> 8;
+    buffer[1] = time;
+    time = time >>> 8;
+    buffer[0] = time;
 
     // set PROCESS_UNIQUE if yet not initialized
     if (PROCESS_UNIQUE === null) {
@@ -259,7 +265,11 @@ export class ObjectId extends BSONValue {
   /** Returns the generation date (accurate up to the second) that this ID was generated. */
   getTimestamp(): Date {
     const timestamp = new Date();
-    const time = BSONDataView.fromUint8Array(this.id).getUint32(0, false);
+    const time =
+      this.buffer[3] +
+      this.buffer[2] * (1 << 8) +
+      this.buffer[1] * (1 << 16) +
+      this.buffer[0] * (1 << 24);
     timestamp.setTime(Math.floor(time) * 1000);
     return timestamp;
   }
@@ -292,9 +302,16 @@ export class ObjectId extends BSONValue {
    * @param time - an integer number representing a number of seconds.
    */
   static createFromTime(time: number): ObjectId {
-    const buffer = ByteUtils.fromNumberArray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    const buffer = ByteUtils.allocate(12);
+    for (let i = 11; i >= 4; i--) buffer[i] = 0;
     // Encode time into first 4 bytes
-    BSONDataView.fromUint8Array(buffer).setUint32(0, time, false);
+    buffer[3] = time;
+    time = time >>> 8;
+    buffer[2] = time;
+    time = time >>> 8;
+    buffer[1] = time;
+    time = time >>> 8;
+    buffer[0] = time;
     // Return the new objectId
     return new ObjectId(buffer);
   }

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -2,6 +2,7 @@ import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import { type InspectFn, defaultInspect } from './parser/utils';
 import { ByteUtils } from './utils/byte_utils';
+import { NumberUtils } from './utils/number_utils';
 
 // Regular expression that checks for hex value
 const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
@@ -179,13 +180,7 @@ export class ObjectId extends BSONValue {
     const buffer = ByteUtils.allocate(12);
 
     // 4-byte timestamp
-    buffer[3] = time;
-    time >>>= 8;
-    buffer[2] = time;
-    time >>>= 8;
-    buffer[1] = time;
-    time >>>= 8;
-    buffer[0] = time;
+    NumberUtils.setInt32BE(buffer, 0, time);
 
     // set PROCESS_UNIQUE if yet not initialized
     if (PROCESS_UNIQUE === null) {
@@ -265,11 +260,7 @@ export class ObjectId extends BSONValue {
   /** Returns the generation date (accurate up to the second) that this ID was generated. */
   getTimestamp(): Date {
     const timestamp = new Date();
-    const time =
-      this.buffer[3] +
-      this.buffer[2] * (1 << 8) +
-      this.buffer[1] * (1 << 16) +
-      this.buffer[0] * (1 << 24);
+    const time = NumberUtils.getUint32BE(this.buffer, 0);
     timestamp.setTime(Math.floor(time) * 1000);
     return timestamp;
   }
@@ -305,13 +296,7 @@ export class ObjectId extends BSONValue {
     const buffer = ByteUtils.allocate(12);
     for (let i = 11; i >= 4; i--) buffer[i] = 0;
     // Encode time into first 4 bytes
-    buffer[3] = time;
-    time >>>= 8;
-    buffer[2] = time;
-    time >>>= 8;
-    buffer[1] = time;
-    time >>>= 8;
-    buffer[0] = time;
+    NumberUtils.setInt32BE(buffer, 0, time);
     // Return the new objectId
     return new ObjectId(buffer);
   }

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -180,11 +180,11 @@ export class ObjectId extends BSONValue {
 
     // 4-byte timestamp
     buffer[3] = time;
-    time = time >>> 8;
+    time >>>= 8;
     buffer[2] = time;
-    time = time >>> 8;
+    time >>>= 8;
     buffer[1] = time;
-    time = time >>> 8;
+    time >>>= 8;
     buffer[0] = time;
 
     // set PROCESS_UNIQUE if yet not initialized
@@ -306,11 +306,11 @@ export class ObjectId extends BSONValue {
     for (let i = 11; i >= 4; i--) buffer[i] = 0;
     // Encode time into first 4 bytes
     buffer[3] = time;
-    time = time >>> 8;
+    time >>>= 8;
     buffer[2] = time;
-    time = time >>> 8;
+    time >>>= 8;
     buffer[1] = time;
-    time = time >>> 8;
+    time >>>= 8;
     buffer[0] = time;
     // Return the new objectId
     return new ObjectId(buffer);

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -95,11 +95,11 @@ function serializeNumber(buffer: Uint8Array, key: string, value: number, index: 
   if (type === constants.BSON_DATA_INT) {
     let int32 = value;
     buffer[index++] = int32;
-    int32 = int32 >>> 8;
+    int32 >>>= 8;
     buffer[index++] = int32;
-    int32 = int32 >>> 8;
+    int32 >>>= 8;
     buffer[index++] = int32;
-    int32 = int32 >>> 8;
+    int32 >>>= 8;
     buffer[index++] = int32;
   } else {
     FLOAT_WRITE[0] = value;
@@ -129,21 +129,21 @@ function serializeBigInt(buffer: Uint8Array, key: string, value: bigint, index: 
 
   let lo = Number(value & mask32bits);
   buffer[index++] = lo;
-  lo = lo >> 8;
+  lo >>= 8;
   buffer[index++] = lo;
-  lo = lo >> 8;
+  lo >>= 8;
   buffer[index++] = lo;
-  lo = lo >> 8;
+  lo >>= 8;
   buffer[index++] = lo;
 
   /* eslint-disable-next-line no-restricted-globals -- This is allowed here as useBigInt64=true */
   let hi = Number((value >> BigInt(32)) & mask32bits);
   buffer[index++] = hi;
-  hi = hi >> 8;
+  hi >>= 8;
   buffer[index++] = hi;
-  hi = hi >> 8;
+  hi >>= 8;
   buffer[index++] = hi;
-  hi = hi >> 8;
+  hi >>= 8;
   buffer[index++] = hi;
 
   return index;

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -12,6 +12,7 @@ import type { MinKey } from '../min_key';
 import type { ObjectId } from '../objectid';
 import type { BSONRegExp } from '../regexp';
 import { ByteUtils } from '../utils/byte_utils';
+import { NumberUtils } from '../utils/number_utils';
 import { isAnyArrayBuffer, isDate, isMap, isRegExp, isUint8Array } from './utils';
 
 /** @public */
@@ -61,19 +62,13 @@ function serializeString(buffer: Uint8Array, key: string, value: string, index: 
   // Write the string
   const size = ByteUtils.encodeUTF8Into(buffer, value, index + 4);
   // Write the size of the string to buffer
-  buffer[index + 3] = ((size + 1) >> 24) & 0xff;
-  buffer[index + 2] = ((size + 1) >> 16) & 0xff;
-  buffer[index + 1] = ((size + 1) >> 8) & 0xff;
-  buffer[index] = (size + 1) & 0xff;
+  NumberUtils.setInt32LE(buffer, index, size + 1);
   // Update index
   index = index + 4 + size;
   // Write zero
   buffer[index++] = 0;
   return index;
 }
-
-const FLOAT_WRITE = new Float64Array(1);
-const FLOAT_READ_BYTES = new Uint8Array(FLOAT_WRITE.buffer, 0, 8);
 
 function serializeNumber(buffer: Uint8Array, key: string, value: number, index: number) {
   const isNegativeZero = Object.is(value, -0);
@@ -93,24 +88,9 @@ function serializeNumber(buffer: Uint8Array, key: string, value: number, index: 
   buffer[index++] = 0x00;
 
   if (type === constants.BSON_DATA_INT) {
-    let int32 = value;
-    buffer[index++] = int32;
-    int32 >>>= 8;
-    buffer[index++] = int32;
-    int32 >>>= 8;
-    buffer[index++] = int32;
-    int32 >>>= 8;
-    buffer[index++] = int32;
+    index += NumberUtils.setInt32LE(buffer, index, value);
   } else {
-    FLOAT_WRITE[0] = value;
-    buffer[index++] = FLOAT_READ_BYTES[0];
-    buffer[index++] = FLOAT_READ_BYTES[1];
-    buffer[index++] = FLOAT_READ_BYTES[2];
-    buffer[index++] = FLOAT_READ_BYTES[3];
-    buffer[index++] = FLOAT_READ_BYTES[4];
-    buffer[index++] = FLOAT_READ_BYTES[5];
-    buffer[index++] = FLOAT_READ_BYTES[6];
-    buffer[index++] = FLOAT_READ_BYTES[7];
+    index += NumberUtils.setFloat64LE(buffer, index, value);
   }
 
   return index;
@@ -124,27 +104,7 @@ function serializeBigInt(buffer: Uint8Array, key: string, value: bigint, index: 
   index += numberOfWrittenBytes;
   buffer[index++] = 0;
 
-  /* eslint-disable-next-line no-restricted-globals -- This is allowed here as useBigInt64=true */
-  const mask32bits = BigInt(0xffff_ffff);
-
-  let lo = Number(value & mask32bits);
-  buffer[index++] = lo;
-  lo >>= 8;
-  buffer[index++] = lo;
-  lo >>= 8;
-  buffer[index++] = lo;
-  lo >>= 8;
-  buffer[index++] = lo;
-
-  /* eslint-disable-next-line no-restricted-globals -- This is allowed here as useBigInt64=true */
-  let hi = Number((value >> BigInt(32)) & mask32bits);
-  buffer[index++] = hi;
-  hi >>= 8;
-  buffer[index++] = hi;
-  hi >>= 8;
-  buffer[index++] = hi;
-  hi >>= 8;
-  buffer[index++] = hi;
+  index += NumberUtils.setBigInt64LE(buffer, index, value);
 
   return index;
 }
@@ -189,15 +149,9 @@ function serializeDate(buffer: Uint8Array, key: string, value: Date, index: numb
   const lowBits = dateInMilis.getLowBits();
   const highBits = dateInMilis.getHighBits();
   // Encode low bits
-  buffer[index++] = lowBits & 0xff;
-  buffer[index++] = (lowBits >> 8) & 0xff;
-  buffer[index++] = (lowBits >> 16) & 0xff;
-  buffer[index++] = (lowBits >> 24) & 0xff;
+  index += NumberUtils.setInt32LE(buffer, index, lowBits);
   // Encode high bits
-  buffer[index++] = highBits & 0xff;
-  buffer[index++] = (highBits >> 8) & 0xff;
-  buffer[index++] = (highBits >> 16) & 0xff;
-  buffer[index++] = (highBits >> 24) & 0xff;
+  index += NumberUtils.setInt32LE(buffer, index, highBits);
   return index;
 }
 
@@ -300,10 +254,7 @@ function serializeBuffer(buffer: Uint8Array, key: string, value: Uint8Array, ind
   // Get size of the buffer (current write point)
   const size = value.length;
   // Write the size of the string to buffer
-  buffer[index++] = size & 0xff;
-  buffer[index++] = (size >> 8) & 0xff;
-  buffer[index++] = (size >> 16) & 0xff;
-  buffer[index++] = (size >> 24) & 0xff;
+  index += NumberUtils.setInt32LE(buffer, index, size);
   // Write the default subtype
   buffer[index++] = constants.BSON_BINARY_SUBTYPE_DEFAULT;
   // Copy the content form the binary field to the buffer
@@ -382,15 +333,9 @@ function serializeLong(buffer: Uint8Array, key: string, value: Long, index: numb
   const lowBits = value.getLowBits();
   const highBits = value.getHighBits();
   // Encode low bits
-  buffer[index++] = lowBits & 0xff;
-  buffer[index++] = (lowBits >> 8) & 0xff;
-  buffer[index++] = (lowBits >> 16) & 0xff;
-  buffer[index++] = (lowBits >> 24) & 0xff;
+  index += NumberUtils.setInt32LE(buffer, index, lowBits);
   // Encode high bits
-  buffer[index++] = highBits & 0xff;
-  buffer[index++] = (highBits >> 8) & 0xff;
-  buffer[index++] = (highBits >> 16) & 0xff;
-  buffer[index++] = (highBits >> 24) & 0xff;
+  index += NumberUtils.setInt32LE(buffer, index, highBits);
   return index;
 }
 
@@ -404,10 +349,7 @@ function serializeInt32(buffer: Uint8Array, key: string, value: Int32 | number, 
   index = index + numberOfWrittenBytes;
   buffer[index++] = 0;
   // Write the int value
-  buffer[index++] = value & 0xff;
-  buffer[index++] = (value >> 8) & 0xff;
-  buffer[index++] = (value >> 16) & 0xff;
-  buffer[index++] = (value >> 24) & 0xff;
+  index += NumberUtils.setInt32LE(buffer, index, value);
   return index;
 }
 
@@ -423,15 +365,7 @@ function serializeDouble(buffer: Uint8Array, key: string, value: Double, index: 
   buffer[index++] = 0;
 
   // Write float
-  FLOAT_WRITE[0] = value.value;
-  buffer[index++] = FLOAT_READ_BYTES[0];
-  buffer[index++] = FLOAT_READ_BYTES[1];
-  buffer[index++] = FLOAT_READ_BYTES[2];
-  buffer[index++] = FLOAT_READ_BYTES[3];
-  buffer[index++] = FLOAT_READ_BYTES[4];
-  buffer[index++] = FLOAT_READ_BYTES[5];
-  buffer[index++] = FLOAT_READ_BYTES[6];
-  buffer[index++] = FLOAT_READ_BYTES[7];
+  index += NumberUtils.setFloat64LE(buffer, index, value.value);
 
   return index;
 }
@@ -449,10 +383,7 @@ function serializeFunction(buffer: Uint8Array, key: string, value: Function, ind
   // Write the string
   const size = ByteUtils.encodeUTF8Into(buffer, functionString, index + 4) + 1;
   // Write the size of the string to buffer
-  buffer[index] = size & 0xff;
-  buffer[index + 1] = (size >> 8) & 0xff;
-  buffer[index + 2] = (size >> 16) & 0xff;
-  buffer[index + 3] = (size >> 24) & 0xff;
+  NumberUtils.setInt32LE(buffer, index, size);
   // Update index
   index = index + 4 + size - 1;
   // Write zero
@@ -491,10 +422,7 @@ function serializeCode(
     // Write string into buffer
     const codeSize = ByteUtils.encodeUTF8Into(buffer, functionString, index + 4) + 1;
     // Write the size of the string to buffer
-    buffer[index] = codeSize & 0xff;
-    buffer[index + 1] = (codeSize >> 8) & 0xff;
-    buffer[index + 2] = (codeSize >> 16) & 0xff;
-    buffer[index + 3] = (codeSize >> 24) & 0xff;
+    NumberUtils.setInt32LE(buffer, index, codeSize);
     // Write end 0
     buffer[index + 4 + codeSize - 1] = 0;
     // Write the
@@ -517,10 +445,7 @@ function serializeCode(
     const totalSize = endIndex - startIndex;
 
     // Write the total size of the object
-    buffer[startIndex++] = totalSize & 0xff;
-    buffer[startIndex++] = (totalSize >> 8) & 0xff;
-    buffer[startIndex++] = (totalSize >> 16) & 0xff;
-    buffer[startIndex++] = (totalSize >> 24) & 0xff;
+    startIndex += NumberUtils.setInt32LE(buffer, startIndex, totalSize);
     // Write trailing zero
     buffer[index++] = 0;
   } else {
@@ -535,10 +460,7 @@ function serializeCode(
     // Write the string
     const size = ByteUtils.encodeUTF8Into(buffer, functionString, index + 4) + 1;
     // Write the size of the string to buffer
-    buffer[index] = size & 0xff;
-    buffer[index + 1] = (size >> 8) & 0xff;
-    buffer[index + 2] = (size >> 16) & 0xff;
-    buffer[index + 3] = (size >> 24) & 0xff;
+    NumberUtils.setInt32LE(buffer, index, size);
     // Update index
     index = index + 4 + size - 1;
     // Write zero
@@ -563,20 +485,14 @@ function serializeBinary(buffer: Uint8Array, key: string, value: Binary, index: 
   // Add the deprecated 02 type 4 bytes of size to total
   if (value.sub_type === Binary.SUBTYPE_BYTE_ARRAY) size = size + 4;
   // Write the size of the string to buffer
-  buffer[index++] = size & 0xff;
-  buffer[index++] = (size >> 8) & 0xff;
-  buffer[index++] = (size >> 16) & 0xff;
-  buffer[index++] = (size >> 24) & 0xff;
+  index += NumberUtils.setInt32LE(buffer, index, size);
   // Write the subtype to the buffer
   buffer[index++] = value.sub_type;
 
   // If we have binary type 2 the 4 first bytes are the size
   if (value.sub_type === Binary.SUBTYPE_BYTE_ARRAY) {
     size = size - 4;
-    buffer[index++] = size & 0xff;
-    buffer[index++] = (size >> 8) & 0xff;
-    buffer[index++] = (size >> 16) & 0xff;
-    buffer[index++] = (size >> 24) & 0xff;
+    index += NumberUtils.setInt32LE(buffer, index, size);
   }
 
   if (size <= 16) {
@@ -600,14 +516,11 @@ function serializeSymbol(buffer: Uint8Array, key: string, value: BSONSymbol, ind
   // Write the string
   const size = ByteUtils.encodeUTF8Into(buffer, value.value, index + 4) + 1;
   // Write the size of the string to buffer
-  buffer[index] = size & 0xff;
-  buffer[index + 1] = (size >> 8) & 0xff;
-  buffer[index + 2] = (size >> 16) & 0xff;
-  buffer[index + 3] = (size >> 24) & 0xff;
+  NumberUtils.setInt32LE(buffer, index, size);
   // Update index
   index = index + 4 + size - 1;
   // Write zero
-  buffer[index++] = 0x00;
+  buffer[index++] = 0;
   return index;
 }
 
@@ -654,10 +567,7 @@ function serializeDBRef(
   // Calculate object size
   const size = endIndex - startIndex;
   // Write the size
-  buffer[startIndex++] = size & 0xff;
-  buffer[startIndex++] = (size >> 8) & 0xff;
-  buffer[startIndex++] = (size >> 16) & 0xff;
-  buffer[startIndex++] = (size >> 24) & 0xff;
+  startIndex += NumberUtils.setInt32LE(buffer, index, size);
   // Set index
   return endIndex;
 }
@@ -829,7 +739,7 @@ export function serializeInto(
         if (checkKeys) {
           if ('$' === key[0]) {
             throw new BSONError('key ' + key + " must not start with '$'");
-          } else if (~key.indexOf('.')) {
+          } else if (key.includes('.')) {
             throw new BSONError('key ' + key + " must not contain '.'");
           }
         }
@@ -937,7 +847,7 @@ export function serializeInto(
         if (checkKeys) {
           if ('$' === key[0]) {
             throw new BSONError('key ' + key + " must not start with '$'");
-          } else if (~key.indexOf('.')) {
+          } else if (key.includes('.')) {
             throw new BSONError('key ' + key + " must not contain '.'");
           }
         }
@@ -1027,9 +937,6 @@ export function serializeInto(
   // Final size
   const size = index - startingIndex;
   // Write the size of the object
-  buffer[startingIndex++] = size & 0xff;
-  buffer[startingIndex++] = (size >> 8) & 0xff;
-  buffer[startingIndex++] = (size >> 16) & 0xff;
-  buffer[startingIndex++] = (size >> 24) & 0xff;
+  startingIndex += NumberUtils.setInt32LE(buffer, startingIndex, size);
   return index;
 }

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -72,9 +72,8 @@ function serializeString(buffer: Uint8Array, key: string, value: string, index: 
   return index;
 }
 
-const NUMBER_SPACE = new DataView(new ArrayBuffer(8), 0, 8);
-const FOUR_BYTE_VIEW_ON_NUMBER = new Uint8Array(NUMBER_SPACE.buffer, 0, 4);
-const EIGHT_BYTE_VIEW_ON_NUMBER = new Uint8Array(NUMBER_SPACE.buffer, 0, 8);
+const FLOAT_WRITE = new Float64Array(1);
+const FLOAT_READ_BYTES = new Uint8Array(FLOAT_WRITE.buffer, 0, 8);
 
 function serializeNumber(buffer: Uint8Array, key: string, value: number, index: number) {
   const isNegativeZero = Object.is(value, -0);
@@ -87,23 +86,32 @@ function serializeNumber(buffer: Uint8Array, key: string, value: number, index: 
       ? constants.BSON_DATA_INT
       : constants.BSON_DATA_NUMBER;
 
-  if (type === constants.BSON_DATA_INT) {
-    NUMBER_SPACE.setInt32(0, value, true);
-  } else {
-    NUMBER_SPACE.setFloat64(0, value, true);
-  }
-
-  const bytes =
-    type === constants.BSON_DATA_INT ? FOUR_BYTE_VIEW_ON_NUMBER : EIGHT_BYTE_VIEW_ON_NUMBER;
-
   buffer[index++] = type;
 
   const numberOfWrittenBytes = ByteUtils.encodeUTF8Into(buffer, key, index);
   index = index + numberOfWrittenBytes;
   buffer[index++] = 0x00;
 
-  buffer.set(bytes, index);
-  index += bytes.byteLength;
+  if (type === constants.BSON_DATA_INT) {
+    let int32 = value;
+    buffer[index++] = int32;
+    int32 = int32 >>> 8;
+    buffer[index++] = int32;
+    int32 = int32 >>> 8;
+    buffer[index++] = int32;
+    int32 = int32 >>> 8;
+    buffer[index++] = int32;
+  } else {
+    FLOAT_WRITE[0] = value;
+    buffer[index++] = FLOAT_READ_BYTES[0];
+    buffer[index++] = FLOAT_READ_BYTES[1];
+    buffer[index++] = FLOAT_READ_BYTES[2];
+    buffer[index++] = FLOAT_READ_BYTES[3];
+    buffer[index++] = FLOAT_READ_BYTES[4];
+    buffer[index++] = FLOAT_READ_BYTES[5];
+    buffer[index++] = FLOAT_READ_BYTES[6];
+    buffer[index++] = FLOAT_READ_BYTES[7];
+  }
 
   return index;
 }
@@ -115,10 +123,29 @@ function serializeBigInt(buffer: Uint8Array, key: string, value: bigint, index: 
   // Encode the name
   index += numberOfWrittenBytes;
   buffer[index++] = 0;
-  NUMBER_SPACE.setBigInt64(0, value, true);
-  // Write BigInt value
-  buffer.set(EIGHT_BYTE_VIEW_ON_NUMBER, index);
-  index += EIGHT_BYTE_VIEW_ON_NUMBER.byteLength;
+
+  /* eslint-disable-next-line no-restricted-globals -- This is allowed here as useBigInt64=true */
+  const mask32bits = BigInt(0xffff_ffff);
+
+  let lo = Number(value & mask32bits);
+  buffer[index++] = lo;
+  lo = lo >> 8;
+  buffer[index++] = lo;
+  lo = lo >> 8;
+  buffer[index++] = lo;
+  lo = lo >> 8;
+  buffer[index++] = lo;
+
+  /* eslint-disable-next-line no-restricted-globals -- This is allowed here as useBigInt64=true */
+  let hi = Number((value >> BigInt(32)) & mask32bits);
+  buffer[index++] = hi;
+  hi = hi >> 8;
+  buffer[index++] = hi;
+  hi = hi >> 8;
+  buffer[index++] = hi;
+  hi = hi >> 8;
+  buffer[index++] = hi;
+
   return index;
 }
 
@@ -396,11 +423,16 @@ function serializeDouble(buffer: Uint8Array, key: string, value: Double, index: 
   buffer[index++] = 0;
 
   // Write float
-  NUMBER_SPACE.setFloat64(0, value.value, true);
-  buffer.set(EIGHT_BYTE_VIEW_ON_NUMBER, index);
+  FLOAT_WRITE[0] = value.value;
+  buffer[index++] = FLOAT_READ_BYTES[0];
+  buffer[index++] = FLOAT_READ_BYTES[1];
+  buffer[index++] = FLOAT_READ_BYTES[2];
+  buffer[index++] = FLOAT_READ_BYTES[3];
+  buffer[index++] = FLOAT_READ_BYTES[4];
+  buffer[index++] = FLOAT_READ_BYTES[5];
+  buffer[index++] = FLOAT_READ_BYTES[6];
+  buffer[index++] = FLOAT_READ_BYTES[7];
 
-  // Adjust index
-  index = index + 8;
   return index;
 }
 

--- a/src/utils/byte_utils.ts
+++ b/src/utils/byte_utils.ts
@@ -51,9 +51,3 @@ const hasGlobalBuffer = typeof Buffer === 'function' && Buffer.prototype?._isBuf
  * @internal
  */
 export const ByteUtils: ByteUtils = hasGlobalBuffer ? nodeJsByteUtils : webByteUtils;
-
-export class BSONDataView extends DataView {
-  static fromUint8Array(input: Uint8Array) {
-    return new DataView(input.buffer, input.byteOffset, input.byteLength);
-  }
-}

--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -1,0 +1,135 @@
+const FLOAT = new Float64Array(1);
+const FLOAT_BYTES = new Uint8Array(FLOAT.buffer, 0, 8);
+
+/**
+ * Number parsing and serializing utilities.
+ *
+ * @internal
+ */
+export const NumberUtils = {
+  /** Reads a little-endian 32-bit integer from source */
+  getInt32LE(source: Uint8Array, offset: number): number {
+    return (
+      source[offset] |
+      (source[offset + 1] << 8) |
+      (source[offset + 2] << 16) |
+      (source[offset + 3] << 24)
+    );
+  },
+
+  /** Reads a little-endian 32-bit unsigned integer from source */
+  getUint32LE(source: Uint8Array, offset: number): number {
+    return (
+      source[offset] +
+      source[offset + 1] * 256 +
+      source[offset + 2] * 65536 +
+      source[offset + 3] * 16777216
+    );
+  },
+
+  /** Reads a big-endian 32-bit integer from source */
+  getUint32BE(source: Uint8Array, offset: number): number {
+    return (
+      source[offset + 3] +
+      source[offset + 2] * 256 +
+      source[offset + 1] * 65536 +
+      source[offset] * 16777216
+    );
+  },
+
+  /** Reads a little-endian 64-bit integer from source */
+  getBigInt64LE(source: Uint8Array, offset: number): bigint {
+    const lo = NumberUtils.getUint32LE(source, offset);
+    const hi = NumberUtils.getUint32LE(source, offset + 4);
+
+    /*
+      eslint-disable-next-line no-restricted-globals
+      -- This is allowed since this helper should not be called unless bigint features are enabled
+     */
+    return (BigInt(hi) << BigInt(32)) + BigInt(lo);
+  },
+
+  /** Reads a little-endian 64-bit float from source */
+  getFloat64LE(source: Uint8Array, offset: number): number {
+    FLOAT_BYTES[0] = source[offset];
+    FLOAT_BYTES[1] = source[offset + 1];
+    FLOAT_BYTES[2] = source[offset + 2];
+    FLOAT_BYTES[3] = source[offset + 3];
+    FLOAT_BYTES[4] = source[offset + 4];
+    FLOAT_BYTES[5] = source[offset + 5];
+    FLOAT_BYTES[6] = source[offset + 6];
+    FLOAT_BYTES[7] = source[offset + 7];
+    return FLOAT[0];
+  },
+
+  /** Writes a big-endian 32-bit integer to destination, can be signed or unsigned */
+  setInt32BE(destination: Uint8Array, offset: number, value: number): 4 {
+    destination[offset + 3] = value;
+    value >>>= 8;
+    destination[offset + 2] = value;
+    value >>>= 8;
+    destination[offset + 1] = value;
+    value >>>= 8;
+    destination[offset] = value;
+    return 4;
+  },
+
+  /** Writes a little-endian 32-bit integer to destination, can be signed or unsigned */
+  setInt32LE(destination: Uint8Array, offset: number, value: number): 4 {
+    destination[offset] = value;
+    value >>>= 8;
+    destination[offset + 1] = value;
+    value >>>= 8;
+    destination[offset + 2] = value;
+    value >>>= 8;
+    destination[offset + 3] = value;
+    return 4;
+  },
+
+  /** Write a little-endian 64-bit integer to source */
+  setBigInt64LE(destination: Uint8Array, offset: number, value: bigint): 8 {
+    /* eslint-disable-next-line no-restricted-globals -- This is allowed here as useBigInt64=true */
+    const mask32bits = BigInt(0xffff_ffff);
+
+    /** lower 32 bits */
+    let lo = Number(value & mask32bits);
+    destination[offset] = lo;
+    lo >>= 8;
+    destination[offset + 1] = lo;
+    lo >>= 8;
+    destination[offset + 2] = lo;
+    lo >>= 8;
+    destination[offset + 3] = lo;
+
+    /*
+       eslint-disable-next-line no-restricted-globals
+       -- This is allowed here as useBigInt64=true
+
+       upper 32 bits
+     */
+    let hi = Number((value >> BigInt(32)) & mask32bits);
+    destination[offset + 4] = hi;
+    hi >>= 8;
+    destination[offset + 5] = hi;
+    hi >>= 8;
+    destination[offset + 6] = hi;
+    hi >>= 8;
+    destination[offset + 7] = hi;
+
+    return 8;
+  },
+
+  /** Writes a little-endian 64-bit float to destination */
+  setFloat64LE(destination: Uint8Array, offset: number, value: number): 8 {
+    FLOAT[0] = value;
+    destination[offset] = FLOAT_BYTES[0];
+    destination[offset + 1] = FLOAT_BYTES[1];
+    destination[offset + 2] = FLOAT_BYTES[2];
+    destination[offset + 3] = FLOAT_BYTES[3];
+    destination[offset + 4] = FLOAT_BYTES[4];
+    destination[offset + 5] = FLOAT_BYTES[5];
+    destination[offset + 6] = FLOAT_BYTES[6];
+    destination[offset + 7] = FLOAT_BYTES[7];
+    return 8;
+  }
+};

--- a/src/utils/web_byte_utils.ts
+++ b/src/utils/web_byte_utils.ts
@@ -189,9 +189,9 @@ export const webByteUtils = {
     return new TextEncoder().encode(input).byteLength;
   },
 
-  encodeUTF8Into(buffer: Uint8Array, source: string, byteOffset: number): number {
+  encodeUTF8Into(uint8array: Uint8Array, source: string, byteOffset: number): number {
     const bytes = new TextEncoder().encode(source);
-    buffer.set(bytes, byteOffset);
+    uint8array.set(bytes, byteOffset);
     return bytes.byteLength;
   },
 

--- a/test/node/bigint.test.ts
+++ b/test/node/bigint.test.ts
@@ -2,7 +2,6 @@ import { BSON, BSONError, EJSON, __noBigInt__ } from '../register-bson';
 import { bufferFromHexArray } from './tools/utils';
 import { expect } from 'chai';
 import { BSON_DATA_LONG } from '../../src/constants';
-import { BSONDataView } from '../../src/utils/byte_utils';
 
 describe('BSON BigInt support', function () {
   beforeEach(function () {
@@ -126,7 +125,11 @@ describe('BSON BigInt support', function () {
       const DATA_TYPE_OFFSET = 4;
       const KEY_OFFSET = 5;
 
-      const dataView = BSONDataView.fromUint8Array(serializedDoc);
+      const dataView = new DataView(
+        serializedDoc.buffer,
+        serializedDoc.byteOffset,
+        serializedDoc.byteLength
+      );
       const keySlice = serializedDoc.slice(KEY_OFFSET);
 
       let keyLength = 0;
@@ -407,7 +410,11 @@ describe('BSON BigInt support', function () {
         const serialized = BSON.serialize(number);
 
         const VALUE_OFFSET = 7;
-        const dataView = BSONDataView.fromUint8Array(serialized);
+        const dataView = new DataView(
+          serialized.buffer,
+          serialized.byteOffset,
+          serialized.byteLength
+        );
         const serializedValue = dataView.getBigInt64(VALUE_OFFSET, true);
         const parsed = JSON.parse(stringified);
 
@@ -431,7 +438,11 @@ describe('BSON BigInt support', function () {
         const serializedDoc = BSON.serialize(number);
 
         const VALUE_OFFSET = 7;
-        const dataView = BSONDataView.fromUint8Array(serializedDoc);
+        const dataView = new DataView(
+          serializedDoc.buffer,
+          serializedDoc.byteOffset,
+          serializedDoc.byteLength
+        );
         const parsed = JSON.parse(stringified);
 
         expect(parsed).to.have.property('a');

--- a/test/node/release.test.ts
+++ b/test/node/release.test.ts
@@ -45,6 +45,7 @@ const REQUIRED_FILES = [
   'src/timestamp.ts',
   'src/utils/byte_utils.ts',
   'src/utils/node_byte_utils.ts',
+  'src/utils/number_utils.ts',
   'src/utils/web_byte_utils.ts',
   'src/utils/latin.ts',
   'src/validate_utf8.ts',

--- a/test/node/utils/number_utils.test.ts
+++ b/test/node/utils/number_utils.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { NumberUtils } from '../../../src/utils/number_utils';
 
-describe.only('NumberUtils', () => {
+describe('NumberUtils', () => {
   /** Make a Uint8Array in a less verbose way */
   const b = (...values) => new Uint8Array(values);
 

--- a/test/node/utils/number_utils.test.ts
+++ b/test/node/utils/number_utils.test.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+import { NumberUtils } from '../../../src/utils/number_utils';
+
+describe.only('NumberUtils', () => {
+  /** Make a Uint8Array in a less verbose way */
+  const b = (...values) => new Uint8Array(values);
+
+  context('getInt32LE()', () => {
+    it('parses an int32 little endian', () => {
+      expect(NumberUtils.getInt32LE(b(0, 0, 0, 1), 0)).to.equal(1 << 24);
+    });
+
+    it('parses an signed int32 little endian', () => {
+      expect(NumberUtils.getInt32LE(b(255, 255, 255, 255), 0)).to.equal(-1);
+    });
+
+    it('parses an int32 little endian at offset', () => {
+      expect(NumberUtils.getInt32LE(b(0, 0, 0, 0, 0, 1), 2)).to.equal(1 << 24);
+    });
+
+    it('does not check bounds of offset', () => {
+      expect(NumberUtils.getInt32LE(b(0, 0, 0, 1), 4)).to.equal(0);
+    });
+  });
+
+  context('getUint32LE()', () => {
+    it('parses an unsigned int32 little endian', () => {
+      expect(NumberUtils.getUint32LE(b(255, 255, 255, 255), 0)).to.equal(0xffff_ffff);
+    });
+
+    it('parses an int32 little endian at offset', () => {
+      expect(NumberUtils.getUint32LE(b(0, 0, 255, 255, 255, 255), 2)).to.equal(0xffff_ffff);
+    });
+
+    it('does not check bounds of offset', () => {
+      expect(NumberUtils.getUint32LE(b(0, 0, 0, 1), 4)).to.be.NaN;
+    });
+  });
+
+  context('getUint32BE()', () => {
+    it('parses an int32 big endian', () => {
+      expect(NumberUtils.getUint32BE(b(0, 0, 0, 1), 0)).to.equal(1);
+    });
+
+    it('parses an unsigned int32 big endian', () => {
+      expect(NumberUtils.getUint32LE(b(255, 255, 255, 255), 0)).to.equal(0xffff_ffff);
+    });
+
+    it('parses an int32 big endian at offset', () => {
+      expect(NumberUtils.getUint32BE(b(0, 0, 0, 0, 0, 1), 2)).to.equal(1);
+    });
+
+    it('does not check bounds of offset', () => {
+      expect(NumberUtils.getUint32BE(b(0, 0, 0, 1), 4)).to.be.NaN;
+    });
+  });
+
+  context('getBigInt64LE()', () => {
+    it('parses an int64 little endian', () => {
+      expect(NumberUtils.getBigInt64LE(b(0, 0, 0, 0, 0, 0, 0, 1), 0)).to.equal(1n << 56n);
+    });
+
+    it('parses an int64 little endian at offset', () => {
+      expect(NumberUtils.getBigInt64LE(b(0, 0, 0, 0, 0, 0, 0, 0, 0, 1), 2)).to.equal(1n << 56n);
+    });
+
+    it('throws if offset is out of bounds', () => {
+      expect(() => NumberUtils.getBigInt64LE(b(0, 0, 0, 0, 0, 0, 0, 1), 4)).to.throw(RangeError);
+    });
+  });
+
+  context('getFloat64LE()', () => {
+    /** 2.3 in bytes */
+    const num = [0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x02, 0x40];
+
+    it('parses an float64 little endian', () => {
+      expect(NumberUtils.getFloat64LE(b(...num), 0)).to.equal(2.3);
+    });
+
+    it('parses an float64 little endian at offset', () => {
+      expect(NumberUtils.getFloat64LE(b(0, 0, ...num), 2)).to.equal(2.3);
+    });
+
+    it('does not check bounds of offset', () => {
+      expect(NumberUtils.getFloat64LE(b(...num), 4)).to.not.equal(2.3);
+    });
+  });
+
+  context('setInt32BE()', () => {
+    it('writes an int32 big endian', () => {
+      const space = new Uint8Array(4);
+      expect(NumberUtils.setInt32BE(space, 0, 1)).to.equal(4);
+      expect(space).to.deep.equal(b(0, 0, 0, 1));
+    });
+
+    it('writes an int32 big endian at offset', () => {
+      const space = new Uint8Array(6);
+      expect(NumberUtils.setInt32BE(space, 2, 1)).to.equal(4);
+      expect(space).to.deep.equal(b(0, 0, 0, 0, 0, 1));
+    });
+
+    it('does not bound or type check', () => {
+      const space = {};
+      // @ts-expect-error: testing incorrect type
+      expect(NumberUtils.setInt32BE(space, 'a', 1)).to.equal(4);
+      expect(space).to.deep.equal({ a: 0, a1: 0, a2: 0, a3: 1 });
+    });
+  });
+
+  context('setInt32LE()', () => {
+    it('writes an int32 big endian', () => {
+      const space = new Uint8Array(4);
+      expect(NumberUtils.setInt32LE(space, 0, 1)).to.equal(4);
+      expect(space).to.deep.equal(b(1, 0, 0, 0));
+    });
+
+    it('writes an int32 big endian at offset', () => {
+      const space = new Uint8Array(6);
+      expect(NumberUtils.setInt32LE(space, 2, 1)).to.equal(4);
+      expect(space).to.deep.equal(b(0, 0, 1, 0, 0, 0));
+    });
+
+    it('does not bound or type check', () => {
+      const space = {};
+      // @ts-expect-error: testing incorrect type
+      expect(NumberUtils.setInt32LE(space, 'a', 1)).to.equal(4);
+      expect(space).to.deep.equal({ a: 1, a1: 0, a2: 0, a3: 0 });
+    });
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?

- Removes all usage of dataview in favor of Float64Arrays and bit math

We keep a Float64Array and a Uint8Array referencing the same ArrayBuffer. With 8 lines worth of assignment we can take the bytes from input BSON and put them into the Uint8Array and use the Float64Array to interpret them as a LE double.

For bigints we can shift the value into two 32 bit components and use javascript's truncation logic to pull out the bytes as we shift down to each segment of the number.  

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Creating data views has an impact on peformance, and we can easily avoid using it altogether. Generally, we see better performance the more logic we code in JavaScript.

Benchmarks See below

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Improved the performance of serializing and deserializing doubles and bigints

We now use bit shifting and multiplication operators in place of DataView getX/setX calls to parse and serialize bigints and a Float64Array to convert a double to bytes. This change has been shown to increase deserializing performance ~1.3x and serializing performance ~1.75x. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] Changes have been benchmarked
- [x] New TODOs have a related JIRA ticket
