### PR TITLE
perf(NODE-5910): optimize small byte copies

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -269,6 +269,23 @@ export class ObjectId extends BSONValue {
     return new ObjectId();
   }
 
+  /** @internal */
+  serializeInto(uint8array: Uint8Array, index: number): 12 {
+    uint8array[index] = this.buffer[0];
+    uint8array[index + 1] = this.buffer[1];
+    uint8array[index + 2] = this.buffer[2];
+    uint8array[index + 3] = this.buffer[3];
+    uint8array[index + 4] = this.buffer[4];
+    uint8array[index + 5] = this.buffer[5];
+    uint8array[index + 6] = this.buffer[6];
+    uint8array[index + 7] = this.buffer[7];
+    uint8array[index + 8] = this.buffer[8];
+    uint8array[index + 9] = this.buffer[9];
+    uint8array[index + 10] = this.buffer[10];
+    uint8array[index + 11] = this.buffer[11];
+    return 12;
+  }
+
   /**
    * Creates an ObjectId from a second based number, with the rest of the ObjectId zeroed out. Used for comparisons or sorting the ObjectId.
    *

--- a/test/node/object_id.test.ts
+++ b/test/node/object_id.test.ts
@@ -485,4 +485,43 @@ describe('ObjectId', function () {
       });
     });
   });
+
+  context('serializeInto()', () => {
+    it('writes oid bytes to input buffer', () => {
+      const oid = new ObjectId('61'.repeat(12));
+      const buffer = new Uint8Array(20);
+      // @ts-expect-error: internal method
+      oid.serializeInto(buffer, 0);
+      expect(buffer.subarray(0, 12)).to.deep.equal(Buffer.from('61'.repeat(12), 'hex'));
+    });
+
+    it('writes oid bytes to input buffer at offset', () => {
+      const oid = new ObjectId('61'.repeat(12));
+      const buffer = new Uint8Array(20);
+      // @ts-expect-error: internal method
+      oid.serializeInto(buffer, 5);
+      expect(buffer.subarray(5, 5 + 12)).to.deep.equal(Buffer.from('61'.repeat(12), 'hex'));
+    });
+
+    it('does not validate input types', () => {
+      const oid = new ObjectId('61'.repeat(12));
+      const object = {};
+      // @ts-expect-error: internal method
+      oid.serializeInto(object, 'b');
+      expect(object).to.deep.equal({
+        b: 0x61,
+        b1: 0x61,
+        b2: 0x61,
+        b3: 0x61,
+        b4: 0x61,
+        b5: 0x61,
+        b6: 0x61,
+        b7: 0x61,
+        b8: 0x61,
+        b9: 0x61,
+        b10: 0x61,
+        b11: 0x61
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description

#### What is changing?

- For small byte sequences copy the values "manually" rather than using TypedArray.set

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

- `TypedArray.set` can be slower than just running a for loop or manually assigning bytes into the array for copies of 16 bytes or less. 
- ObjectIds are 12 bytes, UUIDs are 16, and decimal128 values are 16 bytes.

[benchmarks](https://docs.google.com/spreadsheets/d/1gRaiQGJYDnxh4TRn6HNm0KxBQkyEZBAmKEeGEPXJpuI/edit#gid=1025312026)

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Improve the performance of small byte copies

When serializing ObjectIds, Decimal128, and UUID values we can get better performance by writing the byte-copying logic in Javascript for loops rather than using the TypedArray.set API. ObjectId serialization performance is 1.5x-2x faster.

<!-- RELEASE_HIGHLIGHT_END -->

### Double-check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
