### PR TITLE
perf: refactor bit operations into helper functions

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -16,6 +16,7 @@ import { BSONRegExp } from './regexp';
 import { BSONSymbol } from './symbol';
 import { Timestamp } from './timestamp';
 import { ByteUtils } from './utils/byte_utils';
+import { NumberUtils } from './utils/number_utils';
 export type { UUIDExtended, BinaryExtended, BinaryExtendedLegacy, BinarySequence } from './binary';
 export type { CodeExtended } from './code';
 export type { DBRefLike } from './db_ref';
@@ -232,11 +233,7 @@ export function deserializeStream(
   // Loop over all documents
   for (let i = 0; i < numberOfDocuments; i++) {
     // Find size of the document
-    const size =
-      bufferData[index] |
-      (bufferData[index + 1] << 8) |
-      (bufferData[index + 2] << 16) |
-      (bufferData[index + 3] << 24);
+    const size = NumberUtils.getInt32LE(bufferData, index);
     // Update options with index
     internalOptions.index = index;
     // Parse the document at this point

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -2,6 +2,7 @@ import { BSONValue } from './bson_value';
 import { BSONError } from './error';
 import { type InspectFn, defaultInspect } from './parser/utils';
 import { ByteUtils } from './utils/byte_utils';
+import { NumberUtils } from './utils/number_utils';
 
 // Regular expression that checks for hex value
 const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
@@ -179,13 +180,7 @@ export class ObjectId extends BSONValue {
     const buffer = ByteUtils.allocate(12);
 
     // 4-byte timestamp
-    buffer[3] = time;
-    time >>>= 8;
-    buffer[2] = time;
-    time >>>= 8;
-    buffer[1] = time;
-    time >>>= 8;
-    buffer[0] = time;
+    NumberUtils.setInt32BE(buffer, 0, time);
 
     // set PROCESS_UNIQUE if yet not initialized
     if (PROCESS_UNIQUE === null) {
@@ -265,11 +260,7 @@ export class ObjectId extends BSONValue {
   /** Returns the generation date (accurate up to the second) that this ID was generated. */
   getTimestamp(): Date {
     const timestamp = new Date();
-    const time =
-      this.buffer[3] +
-      this.buffer[2] * (1 << 8) +
-      this.buffer[1] * (1 << 16) +
-      this.buffer[0] * (1 << 24);
+    const time = NumberUtils.getUint32BE(this.buffer, 0);
     timestamp.setTime(Math.floor(time) * 1000);
     return timestamp;
   }
@@ -288,13 +279,7 @@ export class ObjectId extends BSONValue {
     const buffer = ByteUtils.allocate(12);
     for (let i = 11; i >= 4; i--) buffer[i] = 0;
     // Encode time into first 4 bytes
-    buffer[3] = time;
-    time >>>= 8;
-    buffer[2] = time;
-    time >>>= 8;
-    buffer[1] = time;
-    time >>>= 8;
-    buffer[0] = time;
+    NumberUtils.setInt32BE(buffer, 0, time);
     // Return the new objectId
     return new ObjectId(buffer);
   }

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -280,9 +280,8 @@ function deserializeObject(
       if (promoteValues === false) value = new Double(value);
     } else if (elementType === constants.BSON_DATA_DATE) {
       const lowBits = NumberUtils.getInt32LE(buffer, index);
-      index += 4;
-      const highBits = NumberUtils.getInt32LE(buffer, index);
-      index += 4;
+      const highBits = NumberUtils.getInt32LE(buffer, index + 4);
+      index += 8;
 
       value = new Date(new Long(lowBits, highBits).toNumber());
     } else if (elementType === constants.BSON_DATA_BOOLEAN) {
@@ -340,9 +339,8 @@ function deserializeObject(
       } else {
         // Unpack the low and high bits
         const lowBits = NumberUtils.getInt32LE(buffer, index);
-        index += 4;
-        const highBits = NumberUtils.getInt32LE(buffer, index);
-        index += 4;
+        const highBits = NumberUtils.getInt32LE(buffer, index + 4);
+        index += 8;
 
         const long = new Long(lowBits, highBits);
         // Promote the long if possible
@@ -516,15 +514,11 @@ function deserializeObject(
       value = promoteValues ? symbol : new BSONSymbol(symbol);
       index = index + stringSize;
     } else if (elementType === constants.BSON_DATA_TIMESTAMP) {
-      // We intentionally **do not** use bit shifting here
-      // Bit shifting in javascript coerces numbers to **signed** int32s
-      // We need to keep i, and t unsigned
-      const i = NumberUtils.getUInt32LE(buffer, index);
-      index += 4;
-      const t = NumberUtils.getUInt32LE(buffer, index);
-      index += 4;
-
-      value = new Timestamp({ i, t });
+      value = new Timestamp({
+        i: NumberUtils.getUint32LE(buffer, index),
+        t: NumberUtils.getUint32LE(buffer, index + 4)
+      });
+      index += 8;
     } else if (elementType === constants.BSON_DATA_MIN_KEY) {
       value = new MinKey();
     } else if (elementType === constants.BSON_DATA_MAX_KEY) {

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -15,6 +15,7 @@ import { BSONRegExp } from '../regexp';
 import { BSONSymbol } from '../symbol';
 import { Timestamp } from '../timestamp';
 import { ByteUtils } from '../utils/byte_utils';
+import { NumberUtils } from '../utils/number_utils';
 import { validateUtf8 } from '../validate_utf8';
 
 /** @public */
@@ -91,11 +92,7 @@ export function internalDeserialize(
   options = options == null ? {} : options;
   const index = options && options.index ? options.index : 0;
   // Read the document size
-  const size =
-    buffer[index] |
-    (buffer[index + 1] << 8) |
-    (buffer[index + 2] << 16) |
-    (buffer[index + 3] << 24);
+  const size = NumberUtils.getInt32LE(buffer, index);
 
   if (size < 5) {
     throw new BSONError(`bson size must be >= 5, is ${size}`);
@@ -127,9 +124,6 @@ export function internalDeserialize(
 }
 
 const allowedDBRefKeys = /^\$ref$|^\$id$|^\$db$/;
-
-const FLOAT_READ = new Float64Array(1);
-const FLOAT_WRITE_BYTES = new Uint8Array(FLOAT_READ.buffer, 0, 8);
 
 function deserializeObject(
   buffer: Uint8Array,
@@ -207,8 +201,8 @@ function deserializeObject(
   if (buffer.length < 5) throw new BSONError('corrupt bson message < 5 bytes long');
 
   // Read the document size
-  const size =
-    buffer[index++] | (buffer[index++] << 8) | (buffer[index++] << 16) | (buffer[index++] << 24);
+  const size = NumberUtils.getInt32LE(buffer, index);
+  index += 4;
 
   // Ensure buffer is valid size
   if (size < 5 || size > buffer.length) throw new BSONError('corrupt bson message');
@@ -258,11 +252,8 @@ function deserializeObject(
     index = i + 1;
 
     if (elementType === constants.BSON_DATA_STRING) {
-      const stringSize =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      const stringSize = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
       if (
         stringSize <= 0 ||
         stringSize > buffer.length - index ||
@@ -278,37 +269,20 @@ function deserializeObject(
       value = new ObjectId(oid);
       index = index + 12;
     } else if (elementType === constants.BSON_DATA_INT && promoteValues === false) {
-      value = new Int32(
-        buffer[index++] | (buffer[index++] << 8) | (buffer[index++] << 16) | (buffer[index++] << 24)
-      );
+      value = new Int32(NumberUtils.getInt32LE(buffer, index));
+      index += 4;
     } else if (elementType === constants.BSON_DATA_INT) {
-      value =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      value = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
     } else if (elementType === constants.BSON_DATA_NUMBER) {
-      FLOAT_WRITE_BYTES[0] = buffer[index++];
-      FLOAT_WRITE_BYTES[1] = buffer[index++];
-      FLOAT_WRITE_BYTES[2] = buffer[index++];
-      FLOAT_WRITE_BYTES[3] = buffer[index++];
-      FLOAT_WRITE_BYTES[4] = buffer[index++];
-      FLOAT_WRITE_BYTES[5] = buffer[index++];
-      FLOAT_WRITE_BYTES[6] = buffer[index++];
-      FLOAT_WRITE_BYTES[7] = buffer[index++];
-      value = FLOAT_READ[0];
+      value = NumberUtils.getFloat64LE(buffer, index);
+      index += 8;
       if (promoteValues === false) value = new Double(value);
     } else if (elementType === constants.BSON_DATA_DATE) {
-      const lowBits =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
-      const highBits =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      const lowBits = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
+      const highBits = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
 
       value = new Date(new Long(lowBits, highBits).toNumber());
     } else if (elementType === constants.BSON_DATA_BOOLEAN) {
@@ -317,11 +291,8 @@ function deserializeObject(
       value = buffer[index++] === 1;
     } else if (elementType === constants.BSON_DATA_OBJECT) {
       const _index = index;
-      const objectSize =
-        buffer[index] |
-        (buffer[index + 1] << 8) |
-        (buffer[index + 2] << 16) |
-        (buffer[index + 3] << 24);
+      const objectSize = NumberUtils.getInt32LE(buffer, index);
+
       if (objectSize <= 0 || objectSize > buffer.length - index)
         throw new BSONError('bad embedded document length in bson');
 
@@ -339,11 +310,7 @@ function deserializeObject(
       index = index + objectSize;
     } else if (elementType === constants.BSON_DATA_ARRAY) {
       const _index = index;
-      const objectSize =
-        buffer[index] |
-        (buffer[index + 1] << 8) |
-        (buffer[index + 2] << 16) |
-        (buffer[index + 3] << 24);
+      const objectSize = NumberUtils.getInt32LE(buffer, index);
       let arrayOptions: DeserializeOptions = options;
 
       // Stop index
@@ -368,32 +335,15 @@ function deserializeObject(
       value = null;
     } else if (elementType === constants.BSON_DATA_LONG) {
       if (useBigInt64) {
-        const lo =
-          buffer[index] +
-          buffer[index + 1] * 2 ** 8 +
-          buffer[index + 2] * 2 ** 16 +
-          buffer[index + 3] * 2 ** 24;
-        const hi =
-          buffer[index + 4] +
-          buffer[index + 5] * 2 ** 8 +
-          buffer[index + 6] * 2 ** 16 +
-          (buffer[index + 7] << 24); // Overflow
-
-        /* eslint-disable-next-line no-restricted-globals -- This is allowed here as useBigInt64=true */
-        value = (BigInt(hi) << BigInt(32)) + BigInt(lo);
+        value = NumberUtils.getBigInt64LE(buffer, index);
         index += 8;
       } else {
         // Unpack the low and high bits
-        const lowBits =
-          buffer[index++] |
-          (buffer[index++] << 8) |
-          (buffer[index++] << 16) |
-          (buffer[index++] << 24);
-        const highBits =
-          buffer[index++] |
-          (buffer[index++] << 8) |
-          (buffer[index++] << 16) |
-          (buffer[index++] << 24);
+        const lowBits = NumberUtils.getInt32LE(buffer, index);
+        index += 4;
+        const highBits = NumberUtils.getInt32LE(buffer, index);
+        index += 4;
+
         const long = new Long(lowBits, highBits);
         // Promote the long if possible
         if (promoteLongs && promoteValues === true) {
@@ -415,11 +365,8 @@ function deserializeObject(
       // Assign the new Decimal128 value
       value = new Decimal128(bytes);
     } else if (elementType === constants.BSON_DATA_BINARY) {
-      let binarySize =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      let binarySize = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
       const totalBinarySize = binarySize;
       const subType = buffer[index++];
 
@@ -434,11 +381,8 @@ function deserializeObject(
       if (buffer['slice'] != null) {
         // If we have subtype 2 skip the 4 bytes for the size
         if (subType === Binary.SUBTYPE_BYTE_ARRAY) {
-          binarySize =
-            buffer[index++] |
-            (buffer[index++] << 8) |
-            (buffer[index++] << 16) |
-            (buffer[index++] << 24);
+          binarySize = NumberUtils.getInt32LE(buffer, index);
+          index += 4;
           if (binarySize < 0)
             throw new BSONError('Negative binary type element size found for subtype 0x02');
           if (binarySize > totalBinarySize - 4)
@@ -459,11 +403,8 @@ function deserializeObject(
         const _buffer = ByteUtils.allocate(binarySize);
         // If we have subtype 2 skip the 4 bytes for the size
         if (subType === Binary.SUBTYPE_BYTE_ARRAY) {
-          binarySize =
-            buffer[index++] |
-            (buffer[index++] << 8) |
-            (buffer[index++] << 16) |
-            (buffer[index++] << 24);
+          binarySize = NumberUtils.getInt32LE(buffer, index);
+          index += 4;
           if (binarySize < 0)
             throw new BSONError('Negative binary type element size found for subtype 0x02');
           if (binarySize > totalBinarySize - 4)
@@ -562,11 +503,8 @@ function deserializeObject(
       // Set the object
       value = new BSONRegExp(source, regExpOptions);
     } else if (elementType === constants.BSON_DATA_SYMBOL) {
-      const stringSize =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      const stringSize = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
       if (
         stringSize <= 0 ||
         stringSize > buffer.length - index ||
@@ -581,16 +519,10 @@ function deserializeObject(
       // We intentionally **do not** use bit shifting here
       // Bit shifting in javascript coerces numbers to **signed** int32s
       // We need to keep i, and t unsigned
-      const i =
-        buffer[index++] +
-        buffer[index++] * (1 << 8) +
-        buffer[index++] * (1 << 16) +
-        buffer[index++] * (1 << 24);
-      const t =
-        buffer[index++] +
-        buffer[index++] * (1 << 8) +
-        buffer[index++] * (1 << 16) +
-        buffer[index++] * (1 << 24);
+      const i = NumberUtils.getUInt32LE(buffer, index);
+      index += 4;
+      const t = NumberUtils.getUInt32LE(buffer, index);
+      index += 4;
 
       value = new Timestamp({ i, t });
     } else if (elementType === constants.BSON_DATA_MIN_KEY) {
@@ -598,11 +530,8 @@ function deserializeObject(
     } else if (elementType === constants.BSON_DATA_MAX_KEY) {
       value = new MaxKey();
     } else if (elementType === constants.BSON_DATA_CODE) {
-      const stringSize =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      const stringSize = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
       if (
         stringSize <= 0 ||
         stringSize > buffer.length - index ||
@@ -622,11 +551,8 @@ function deserializeObject(
       // Update parse index position
       index = index + stringSize;
     } else if (elementType === constants.BSON_DATA_CODE_W_SCOPE) {
-      const totalSize =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      const totalSize = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
 
       // Element cannot be shorter than totalSize + stringSize + documentSize + terminator
       if (totalSize < 4 + 4 + 4 + 1) {
@@ -634,11 +560,8 @@ function deserializeObject(
       }
 
       // Get the code string size
-      const stringSize =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      const stringSize = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
       // Check if we have a valid string
       if (
         stringSize <= 0 ||
@@ -660,11 +583,7 @@ function deserializeObject(
       // Parse the element
       const _index = index;
       // Decode the size of the object document
-      const objectSize =
-        buffer[index] |
-        (buffer[index + 1] << 8) |
-        (buffer[index + 2] << 16) |
-        (buffer[index + 3] << 24);
+      const objectSize = NumberUtils.getInt32LE(buffer, index);
       // Decode the scope object
       const scopeObject = deserializeObject(buffer, _index, options, false);
       // Adjust the index
@@ -683,11 +602,8 @@ function deserializeObject(
       value = new Code(functionString, scopeObject);
     } else if (elementType === constants.BSON_DATA_DBPOINTER) {
       // Get the code string size
-      const stringSize =
-        buffer[index++] |
-        (buffer[index++] << 8) |
-        (buffer[index++] << 16) |
-        (buffer[index++] << 24);
+      const stringSize = NumberUtils.getInt32LE(buffer, index);
+      index += 4;
       // Check if we have a valid string
       if (
         stringSize <= 0 ||

--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -1,0 +1,135 @@
+const FLOAT = new Float64Array(1);
+const FLOAT_BYTES = new Uint8Array(FLOAT.buffer, 0, 8);
+
+/**
+ * Number parsing and serializing utilities.
+ *
+ * @internal
+ */
+export const NumberUtils = {
+  /** Reads a little-endian 32-bit integer from source */
+  getInt32LE(source: Uint8Array, offset: number): number {
+    return (
+      source[offset] |
+      (source[offset + 1] << 8) |
+      (source[offset + 2] << 16) |
+      (source[offset + 3] << 24)
+    );
+  },
+
+  /** Reads a little-endian 32-bit unsigned integer from source */
+  getUInt32LE(source: Uint8Array, offset: number): number {
+    return (
+      source[offset] +
+      source[offset + 1] * 256 +
+      source[offset + 2] * 65536 +
+      source[offset + 3] * 16777216
+    );
+  },
+
+  /** Reads a big-endian 32-bit integer from source */
+  getUint32BE(source: Uint8Array, offset: number): number {
+    return (
+      source[offset + 3] +
+      source[offset + 2] * 256 +
+      source[offset + 1] * 65536 +
+      source[offset] * 16777216
+    );
+  },
+
+  /** Reads a little-endian 64-bit integer from source */
+  getBigInt64LE(source: Uint8Array, offset: number): bigint {
+    const lo = NumberUtils.getUInt32LE(source, offset);
+    const hi = NumberUtils.getUInt32LE(source, offset + 4);
+
+    /*
+      eslint-disable-next-line no-restricted-globals
+      -- This is allowed since this helper should not be called unless bigint features are enabled
+     */
+    return (BigInt(hi) << BigInt(32)) + BigInt(lo);
+  },
+
+  /** Reads a little-endian 64-bit float from source */
+  getFloat64LE(source: Uint8Array, offset: number): number {
+    FLOAT_BYTES[0] = source[offset];
+    FLOAT_BYTES[1] = source[offset + 1];
+    FLOAT_BYTES[2] = source[offset + 2];
+    FLOAT_BYTES[3] = source[offset + 3];
+    FLOAT_BYTES[4] = source[offset + 4];
+    FLOAT_BYTES[5] = source[offset + 5];
+    FLOAT_BYTES[6] = source[offset + 6];
+    FLOAT_BYTES[7] = source[offset + 7];
+    return FLOAT[0];
+  },
+
+  /** Writes a big-endian 32-bit integer to destination, can be signed or unsigned */
+  setInt32BE(destination: Uint8Array, offset: number, value: number): 4 {
+    destination[offset + 3] = value;
+    value >>>= 8;
+    destination[offset + 2] = value;
+    value >>>= 8;
+    destination[offset + 1] = value;
+    value >>>= 8;
+    destination[offset] = value;
+    return 4;
+  },
+
+  /** Writes a little-endian 32-bit integer to destination, can be signed or unsigned */
+  setInt32LE(destination: Uint8Array, offset: number, value: number): 4 {
+    destination[offset] = value;
+    value >>>= 8;
+    destination[offset + 1] = value;
+    value >>>= 8;
+    destination[offset + 2] = value;
+    value >>>= 8;
+    destination[offset + 3] = value;
+    return 4;
+  },
+
+  /** Write a little-endian 64-bit integer to source */
+  setBigInt64LE(destination: Uint8Array, offset: number, value: bigint): 8 {
+    /* eslint-disable-next-line no-restricted-globals -- This is allowed here as useBigInt64=true */
+    const mask32bits = BigInt(0xffff_ffff);
+
+    /** lower 32 bits */
+    let lo = Number(value & mask32bits);
+    destination[offset] = lo;
+    lo >>= 8;
+    destination[offset + 1] = lo;
+    lo >>= 8;
+    destination[offset + 2] = lo;
+    lo >>= 8;
+    destination[offset + 3] = lo;
+
+    /*
+       eslint-disable-next-line no-restricted-globals
+       -- This is allowed here as useBigInt64=true
+
+       upper 32 bits
+     */
+    let hi = Number((value >> BigInt(32)) & mask32bits);
+    destination[offset + 4] = hi;
+    hi >>= 8;
+    destination[offset + 5] = hi;
+    hi >>= 8;
+    destination[offset + 6] = hi;
+    hi >>= 8;
+    destination[offset + 7] = hi;
+
+    return 8;
+  },
+
+  /** Writes a little-endian 64-bit float to destination */
+  setFloat64LE(destination: Uint8Array, offset: number, value: number): 8 {
+    FLOAT[0] = value;
+    destination[offset] = FLOAT_BYTES[0];
+    destination[offset + 1] = FLOAT_BYTES[1];
+    destination[offset + 2] = FLOAT_BYTES[2];
+    destination[offset + 3] = FLOAT_BYTES[3];
+    destination[offset + 4] = FLOAT_BYTES[4];
+    destination[offset + 5] = FLOAT_BYTES[5];
+    destination[offset + 6] = FLOAT_BYTES[6];
+    destination[offset + 7] = FLOAT_BYTES[7];
+    return 8;
+  }
+};

--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -18,7 +18,7 @@ export const NumberUtils = {
   },
 
   /** Reads a little-endian 32-bit unsigned integer from source */
-  getUInt32LE(source: Uint8Array, offset: number): number {
+  getUint32LE(source: Uint8Array, offset: number): number {
     return (
       source[offset] +
       source[offset + 1] * 256 +
@@ -39,8 +39,8 @@ export const NumberUtils = {
 
   /** Reads a little-endian 64-bit integer from source */
   getBigInt64LE(source: Uint8Array, offset: number): bigint {
-    const lo = NumberUtils.getUInt32LE(source, offset);
-    const hi = NumberUtils.getUInt32LE(source, offset + 4);
+    const lo = NumberUtils.getUint32LE(source, offset);
+    const hi = NumberUtils.getUint32LE(source, offset + 4);
 
     /*
       eslint-disable-next-line no-restricted-globals

--- a/test/node/release.test.ts
+++ b/test/node/release.test.ts
@@ -45,6 +45,7 @@ const REQUIRED_FILES = [
   'src/timestamp.ts',
   'src/utils/byte_utils.ts',
   'src/utils/node_byte_utils.ts',
+  'src/utils/number_utils.ts',
   'src/utils/web_byte_utils.ts',
   'src/utils/latin.ts',
   'src/validate_utf8.ts',


### PR DESCRIPTION
### Description

#### What is changing?

Add number bytewise get and set utils

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- Instead of repeating bit shifting work throughout the serializer and deserializer we can consolidate the operations to helper utils that work across web and node
- These utils employ bit shifting operations which are more performant than using a DataView

### Release Highlight

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
