### PR TITLE
perf(NODE-5955): use pooled memory when possible

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -116,7 +116,7 @@ export function serialize(object: Document, options: SerializeOptions = {}): Uin
   );
 
   // Create the final buffer
-  const finishedBuffer = ByteUtils.allocate(serializationIndex);
+  const finishedBuffer = ByteUtils.allocateUnsafe(serializationIndex);
 
   // Copy into the finished buffer
   finishedBuffer.set(buffer.subarray(0, serializationIndex), 0);

--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -591,7 +591,7 @@ export class Decimal128 extends BSONValue {
     }
 
     // Encode into a buffer
-    const buffer = ByteUtils.allocate(16);
+    const buffer = ByteUtils.allocateUnsafe(16);
     index = 0;
 
     // Encode the low 64 bits of the decimal

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -177,7 +177,7 @@ export class ObjectId extends BSONValue {
     }
 
     const inc = ObjectId.getInc();
-    const buffer = ByteUtils.allocate(12);
+    const buffer = ByteUtils.allocateUnsafe(12);
 
     // 4-byte timestamp
     NumberUtils.setInt32BE(buffer, 0, time);

--- a/src/utils/byte_utils.ts
+++ b/src/utils/byte_utils.ts
@@ -7,6 +7,8 @@ export type ByteUtils = {
   toLocalBufferType(buffer: Uint8Array | ArrayBufferView | ArrayBuffer): Uint8Array;
   /** Create empty space of size */
   allocate: (size: number) => Uint8Array;
+  /** Create empty space of size, use pooled memory when available */
+  allocateUnsafe: (size: number) => Uint8Array;
   /** Check if two Uint8Arrays are deep equal */
   equals: (a: Uint8Array, b: Uint8Array) => boolean;
   /** Check if two Uint8Arrays are deep equal */

--- a/src/utils/node_byte_utils.ts
+++ b/src/utils/node_byte_utils.ts
@@ -12,6 +12,7 @@ type NodeJsBuffer = ArrayBufferView &
   };
 type NodeJsBufferConstructor = Omit<Uint8ArrayConstructor, 'from'> & {
   alloc: (size: number) => NodeJsBuffer;
+  allocUnsafe: (size: number) => NodeJsBuffer;
   from(array: number[]): NodeJsBuffer;
   from(array: Uint8Array): NodeJsBuffer;
   from(array: ArrayBuffer): NodeJsBuffer;
@@ -87,6 +88,10 @@ export const nodeJsByteUtils = {
 
   allocate(size: number): NodeJsBuffer {
     return Buffer.alloc(size);
+  },
+
+  allocateUnsafe(size: number): NodeJsBuffer {
+    return Buffer.allocUnsafe(size);
   },
 
   equals(a: Uint8Array, b: Uint8Array): boolean {

--- a/src/utils/web_byte_utils.ts
+++ b/src/utils/web_byte_utils.ts
@@ -109,6 +109,10 @@ export const webByteUtils = {
     return new Uint8Array(size);
   },
 
+  allocateUnsafe(size: number): Uint8Array {
+    return webByteUtils.allocate(size);
+  },
+
   equals(a: Uint8Array, b: Uint8Array): boolean {
     if (a.byteLength !== b.byteLength) {
       return false;


### PR DESCRIPTION
### Description

#### What is changing?

Use allocUnsafe which uses Node.js' pool of pre-allocated memory and does not santize it before returning it to the caller. We can use it in cases where we overwrite the entire returned Buffer to improve the performance of creating small memory allocations for ObjectIds and Decimal128 instances.

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

Using the memory pool is faster than creating a new allocation.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Use allocUnsafe for ObjectIds and Decimal128

For small allocations Node.js performance can be improved by using pre-allocated pooled memory. ObjectIds and Decimal128 instance will now use allocUnsafe on Node.js.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
