### PR TITLE
feat(NODE-5506): add Binary subtype sensitive

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -56,6 +56,8 @@ export class Binary extends BSONValue {
   static readonly SUBTYPE_ENCRYPTED = 6;
   /** Column BSON type */
   static readonly SUBTYPE_COLUMN = 7;
+  /** Sensitive BSON type */
+  static readonly SENSITIVE_COLUMN = 8;
   /** User BSON type */
   static readonly SUBTYPE_USER_DEFINED = 128;
 

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -57,7 +57,7 @@ export class Binary extends BSONValue {
   /** Column BSON type */
   static readonly SUBTYPE_COLUMN = 7;
   /** Sensitive BSON type */
-  static readonly SENSITIVE_COLUMN = 8;
+  static readonly SUBTYPE_SENSITIVE = 8;
   /** User BSON type */
   static readonly SUBTYPE_USER_DEFINED = 128;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,6 +109,8 @@ export const BSON_BINARY_SUBTYPE_ENCRYPTED = 6;
 /** Column BSON type @internal */
 export const BSON_BINARY_SUBTYPE_COLUMN = 7;
 
+export const BSON_BINARY_SUBTYPE_SENSITIVE = 8;
+
 /** Binary User Defined Type @internal */
 export const BSON_BINARY_SUBTYPE_USER_DEFINED = 128;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,6 +109,7 @@ export const BSON_BINARY_SUBTYPE_ENCRYPTED = 6;
 /** Column BSON type @internal */
 export const BSON_BINARY_SUBTYPE_COLUMN = 7;
 
+/** Sensitive BSON type @internal */
 export const BSON_BINARY_SUBTYPE_SENSITIVE = 8;
 
 /** Binary User Defined Type @internal */

--- a/test/node/constants.test.ts
+++ b/test/node/constants.test.ts
@@ -19,6 +19,8 @@ describe('BSON Constants', () => {
      |  "\x04"  UUID
      |  "\x05"  MD5
      |  "\x06"  Encrypted BSON value
+     |  "\x07"  Column BSON value
+     |  "\x08"  Sensitive BSON value
      |  "\x80"  User defined
     */
     it('Default should be 0', () => {
@@ -54,6 +56,11 @@ describe('BSON Constants', () => {
     it('Column should be 7', () => {
       expect(constants.BSON_BINARY_SUBTYPE_COLUMN).to.equal(7);
       expect(Binary.SUBTYPE_COLUMN).to.equal(7);
+    });
+
+    it('Sensitive should be 7', () => {
+      expect(constants.BSON_BINARY_SUBTYPE_SENSITIVE).to.equal(8);
+      expect(Binary.SUBTYPE_SENSITIVE).to.equal(8);
     });
   });
   context('BSON Type indicators', () => {

--- a/test/node/constants.test.ts
+++ b/test/node/constants.test.ts
@@ -58,7 +58,7 @@ describe('BSON Constants', () => {
       expect(Binary.SUBTYPE_COLUMN).to.equal(7);
     });
 
-    it('Sensitive should be 7', () => {
+    it('Sensitive should be 8', () => {
       expect(constants.BSON_BINARY_SUBTYPE_SENSITIVE).to.equal(8);
       expect(Binary.SUBTYPE_SENSITIVE).to.equal(8);
     });

--- a/test/node/specs/bson-corpus/binary.json
+++ b/test/node/specs/bson-corpus/binary.json
@@ -56,6 +56,11 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"07\"}}}"
         },
         {
+            "description": "subtype 0x08",
+            "canonical_bson": "1D000000057800100000000873FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"08\"}}}"
+        },
+        {
             "description": "subtype 0x80",
             "canonical_bson": "0F0000000578000200000080FFFF00",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"80\"}}}"


### PR DESCRIPTION
### Description
 New `BSON.Binary` subtype 0x08 `sensitive` is introduced.

#### What is changing?
See release highlights.

##### Is there new documentation needed for these changes?
No,  internal changes only.

#### What is the motivation for this change?
- Required by downstream teams (shell).
- Sensitive = excluded from logging, creating more security for sensitive values like HMAC keys. 

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Add SUBTYPE_SENSITIVE on BSON.Binary class
When a BSON.Binary object is of 'sensitive' subtype, the object's subtype will equal `0x08`.

<!-- RELEASE_HIGHLIGHT_END -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->


### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
