### PR TITLE
test(NODE-6017): add an s390x big endian test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -50,6 +50,16 @@ functions:
         args:
           - .evergreen/run-tests.sh
 
+  run big endian tests:
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src
+        add_expansions_to_env: true
+        binary: bash
+        args:
+          - .evergreen/run-big-endian-test.sh
+
   run checks:
     - command: subprocess.exec
       type: test
@@ -236,7 +246,6 @@ tasks:
       - command: perf.send
         params:
           file: src/test/bench/etc/resultsCollectedMeans.json
-
   - name: run-spec-benchmarks-node-18
     commands:
       - func: fetch source
@@ -257,12 +266,25 @@ tasks:
           NODE_LTS_VERSION: 20
       - func: install dependencies
       - func: run eslint plugin tests
+  - name: node-tests-big-endian
+    commands:
+      - func: fetch source
+        vars:
+          NODE_LTS_VERSION: 20
+      - func: install dependencies
+        vars:
+          NPM_OPTIONS: "--ignore-scripts"
+      - func: run big endian tests
 
 buildvariants:
   - name: linux
     display_name: RHEL 8.0
     run_on: rhel80-small
     tasks: [".node", ".web", "check-eslint-plugin"]
+  - name: linux-zseries
+    display_name: RHEL 8.3 zSeries
+    run_on: rhel83-zseries-small
+    tasks: ["node-tests-big-endian"]
   - name: lint
     display_name: lint
     run_on: rhel80-small

--- a/.evergreen/run-big-endian-test.sh
+++ b/.evergreen/run-big-endian-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
+
+npx mocha test/s390x/big_endian.test.ts

--- a/test/s390x/big_endian.test.ts
+++ b/test/s390x/big_endian.test.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import { BSON } from '../../src/index';
+
+const FLOAT = new Float64Array(1);
+const FLOAT_BYTES = new Uint8Array(FLOAT.buffer, 0, 8);
+
+FLOAT[0] = -1;
+// Little endian [0, 0, 0, 0, 0, 0,  240, 191]
+// Big endian    [191, 240, 0, 0, 0, 0, 0, 0]
+const isBigEndian = FLOAT_BYTES[7] === 0;
+
+context(`handles big endianness correctly`, () => {
+  before(function () {
+    if (!isBigEndian) {
+      throw new Error('expected to only run on big endian system');
+    }
+  });
+
+  const bsonWithFloat = Buffer.from(
+    [
+      '10000000', // 16 bytes in size
+      '01', // double
+      '6100', // 'a'
+      '00'.repeat(6) + 'f0bf', // 8 byte LE float equal to -1
+      '00' // doc terminator
+    ].join(''),
+    'hex'
+  );
+
+  it('deserialize should return -1', () => {
+    const res = BSON.deserialize(bsonWithFloat);
+    expect(res).to.have.property('a', -1);
+  });
+
+  it('serialize should set bytes to -1 in little endian format', () => {
+    const res = BSON.serialize({ a: new BSON.Double(-1) });
+    expect(res).to.deep.equal(bsonWithFloat);
+  });
+});


### PR DESCRIPTION
### Description

#### What is changing?

- Add a zSeries task that specifically runs the big endian test
- Temporary solution to make sure our change actually fixes the bug and no further regressions

##### Is there new documentation needed for these changes?

No.

#### What is the motivation for this change?

- Inspect what we expect

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
