### PR TITLE
feat(NODE-5959): make byte parsing utils available on onDemand library

### DIFF
--- a/src/parser/on_demand/index.ts
+++ b/src/parser/on_demand/index.ts
@@ -1,5 +1,7 @@
 import { type BSONError, BSONOffsetError } from '../../error';
-import { type BSONElement, parseToElements } from './parse_to_elements';
+import { ByteUtils } from '../../utils/byte_utils';
+import { NumberUtils } from '../../utils/number_utils';
+import { type BSONElement, parseToElements, getSize } from './parse_to_elements';
 import { type BSONReviver, type Container, parseToStructure } from './parse_to_structure';
 /**
  * @experimental
@@ -28,6 +30,11 @@ export type OnDemand = {
   BSONElement: BSONElement;
   Container: Container;
   BSONReviver: BSONReviver;
+
+  // Utils
+  ByteUtils: ByteUtils;
+  NumberUtils: NumberUtils;
+  getSize: (source: Uint8Array, offset: number) => number;
 };
 
 /**
@@ -39,6 +46,9 @@ const onDemand: OnDemand = Object.create(null);
 onDemand.parseToElements = parseToElements;
 onDemand.parseToStructure = parseToStructure;
 onDemand.BSONOffsetError = BSONOffsetError;
+onDemand.ByteUtils = ByteUtils;
+onDemand.NumberUtils = NumberUtils;
+onDemand.getSize = getSize;
 
 Object.freeze(onDemand);
 

--- a/src/parser/on_demand/parse_to_elements.ts
+++ b/src/parser/on_demand/parse_to_elements.ts
@@ -45,7 +45,9 @@ export type BSONElement = [
 ];
 
 /**
- * @internal
+ * @experimental
+ * @public
+ *
  * Parses a int32 little-endian at offset, throws if it is negative
  */
 export function getSize(source: Uint8Array, offset: number): number {

--- a/src/utils/byte_utils.ts
+++ b/src/utils/byte_utils.ts
@@ -1,7 +1,10 @@
 import { nodeJsByteUtils } from './node_byte_utils';
 import { webByteUtils } from './web_byte_utils';
 
-/** @internal */
+/**
+ * @public
+ * @experimental
+ */
 export type ByteUtils = {
   /** Transforms the input to an instance of Buffer if running on node, otherwise Uint8Array */
   toLocalBufferType(buffer: Uint8Array | ArrayBufferView | ArrayBuffer): Uint8Array;

--- a/src/utils/byte_utils.ts
+++ b/src/utils/byte_utils.ts
@@ -4,6 +4,9 @@ import { webByteUtils } from './web_byte_utils';
 /**
  * @public
  * @experimental
+ *
+ * A collection of functions that help work with data in a Uint8Array.
+ * ByteUtils is configured at load time to use Node.js or Web based APIs for the internal implementations.
  */
 export type ByteUtils = {
   /** Transforms the input to an instance of Buffer if running on node, otherwise Uint8Array */

--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -7,11 +7,28 @@ FLOAT[0] = -1;
 const isBigEndian = FLOAT_BYTES[7] === 0;
 
 /**
+ * @experimental
+ * @public
+ */
+export type NumberUtils = {
+  getInt32LE(source: Uint8Array, offset: number): number;
+  getUint32LE(source: Uint8Array, offset: number): number;
+  getUint32BE(source: Uint8Array, offset: number): number;
+  getBigInt64LE(source: Uint8Array, offset: number): bigint;
+  getFloat64LE(source: Uint8Array, offset: number): number;
+  setInt32BE(destination: Uint8Array, offset: number, value: number): 4;
+  setInt32LE(destination: Uint8Array, offset: number, value: number): 4;
+  setBigInt64LE(destination: Uint8Array, offset: number, value: bigint): 8;
+  setFloat64LE(destination: Uint8Array, offset: number, value: number): 8;
+};
+
+/**
  * Number parsing and serializing utilities.
  *
- * @internal
+ * @experimental
+ * @public
  */
-export const NumberUtils = {
+export const NumberUtils: NumberUtils = {
   /** Reads a little-endian 32-bit integer from source */
   getInt32LE(source: Uint8Array, offset: number): number {
     return (

--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -9,6 +9,8 @@ const isBigEndian = FLOAT_BYTES[7] === 0;
 /**
  * @experimental
  * @public
+ *
+ * A collection of functions that get or set various numeric types and bit widths from a Uint8Array.
  */
 export type NumberUtils = {
   getInt32LE(source: Uint8Array, offset: number): number;


### PR DESCRIPTION
### Description

#### What is changing?

- Adds utf and number parsing utils to onDemand

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

A reviver will be receiving offsets into a BSON byte sequence and will need to interpret them at JS values. These utilities provide what we need without rewriting the logic they already implement. We do not necessarily need these to be part of the final API, the driver works on Node.js so we do not need the logic for switching between web and node. We also probably only need a subset of these functions as mentioned above, for example, toHex is for display purposes and likely does not have a use for what we aim to do with this API.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
