### PR TITLE
fix(NODE-6042): Binary.toString output with respect to position

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -193,8 +193,8 @@ export class Binary extends BSONValue {
     if (encoding === 'hex') return ByteUtils.toHex(this.buffer);
     if (encoding === 'base64') return ByteUtils.toBase64(this.buffer);
     if (encoding === 'utf8' || encoding === 'utf-8')
-      return ByteUtils.toUTF8(this.buffer, 0, this.buffer.byteLength, false);
-    return ByteUtils.toUTF8(this.buffer, 0, this.buffer.byteLength, false);
+      return ByteUtils.toUTF8(this.buffer, 0, this.position, false);
+    return ByteUtils.toUTF8(this.buffer, 0, this.position, false);
   }
 
   /** @internal */

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -186,12 +186,12 @@ export class Binary extends BSONValue {
   }
 
   toJSON(): string {
-    return ByteUtils.toBase64(this.buffer);
+    return ByteUtils.toBase64(this.buffer.subarray(0, this.position));
   }
 
   toString(encoding?: 'hex' | 'base64' | 'utf8' | 'utf-8'): string {
-    if (encoding === 'hex') return ByteUtils.toHex(this.buffer);
-    if (encoding === 'base64') return ByteUtils.toBase64(this.buffer);
+    if (encoding === 'hex') return ByteUtils.toHex(this.buffer.subarray(0, this.position));
+    if (encoding === 'base64') return ByteUtils.toBase64(this.buffer.subarray(0, this.position));
     if (encoding === 'utf8' || encoding === 'utf-8')
       return ByteUtils.toUTF8(this.buffer, 0, this.position, false);
     return ByteUtils.toUTF8(this.buffer, 0, this.position, false);

--- a/test/node/binary.test.ts
+++ b/test/node/binary.test.ts
@@ -144,4 +144,20 @@ describe('class Binary', () => {
       });
     });
   });
+
+  context('toString()', () => {
+    it('should respect position when converting toUTF8 (default)', () => {
+      const bin = new Binary();
+      expect(bin.toString()).to.equal('');
+      bin.put(1);
+      expect(bin.toString()).to.equal('\u0001');
+    });
+    it('should remain same after round trip', () => {
+      const bin = new BSON.Binary();
+      bin.toString()
+      const serializedBin = BSON.serialize({ bin });
+      const roundTrippedBin = BSON.deserialize(serializedBin);
+      expect(roundTrippedBin.bin.toString()).to.equal(bin.toString());
+    });
+  });
 });

--- a/test/node/binary.test.ts
+++ b/test/node/binary.test.ts
@@ -154,7 +154,7 @@ describe('class Binary', () => {
     });
     it('should remain same after round trip', () => {
       const bin = new BSON.Binary();
-      bin.toString()
+      bin.toString();
       const serializedBin = BSON.serialize({ bin });
       const roundTrippedBin = BSON.deserialize(serializedBin);
       expect(roundTrippedBin.bin.toString()).to.equal(bin.toString());

--- a/test/node/binary.test.ts
+++ b/test/node/binary.test.ts
@@ -145,19 +145,67 @@ describe('class Binary', () => {
     });
   });
 
-  context('toString()', () => {
-    it('should respect position when converting toUTF8 (default)', () => {
-      const bin = new Binary();
-      expect(bin.toString()).to.equal('');
-      bin.put(1);
-      expect(bin.toString()).to.equal('\u0001');
+  context.only('toString()', () => {
+    context('when case is UTF8 (default)', () => {
+      it('should respect position when converting to string', () => {
+        const bin = new Binary();
+        expect(bin.toString()).to.equal('');
+        bin.put(1);
+        expect(bin.toString()).to.equal('\u0001');
+      });
+      it('should remain same after round trip', () => {
+        const bin = new BSON.Binary();
+        const serializedBin = BSON.serialize({ bin });
+        const roundTrippedBin = BSON.deserialize(serializedBin);
+        expect(roundTrippedBin.bin.toString()).to.equal(bin.toString());
+      });
     });
+
+    context('when case is hex', () => {
+      it('should respect position when converting to string', () => {
+        const bin = new Binary();
+        expect(bin.toString('hex')).to.equal('');
+        bin.put(1);
+        expect(bin.toString('hex')).to.equal('01');
+      });
+      it('should remain same after round trip', () => {
+        const bin = new BSON.Binary();
+        const serializedBin = BSON.serialize({ bin });
+        const roundTrippedBin = BSON.deserialize(serializedBin);
+        expect(roundTrippedBin.bin.toString('hex')).to.equal(bin.toString('hex'));
+      });
+    });
+
+    context('when case is base64', () => {
+      it('should respect position when converting to string', () => {
+        const bin = new Binary();
+        expect(bin.toString('base64')).to.equal('');
+        bin.put(1);
+        expect(bin.toString('base64')).to.equal('AQ==');
+      });
+      it('should remain same after round trip', () => {
+        const bin = new BSON.Binary();
+        const serializedBin = BSON.serialize({ bin });
+        const roundTrippedBin = BSON.deserialize(serializedBin);
+        expect(roundTrippedBin.bin.toString('base64')).to.equal(bin.toString());
+      });
+    });
+  });
+
+  context.only('toJSON()', () => {
+    it('should respect position when converting to JSON', () => {
+      const bin = new Binary();
+      expect(bin.toJSON()).to.equal('');
+      bin.put(1);
+      // toJSON uses base64
+      expect(bin.toJSON()).to.equal('AQ==');
+    });
+
     it('should remain same after round trip', () => {
       const bin = new BSON.Binary();
-      bin.toString();
       const serializedBin = BSON.serialize({ bin });
       const roundTrippedBin = BSON.deserialize(serializedBin);
-      expect(roundTrippedBin.bin.toString()).to.equal(bin.toString());
+      expect(roundTrippedBin.bin.toJSON()).to.equal(bin.toJSON());
     });
   });
 });

--- a/test/node/binary.test.ts
+++ b/test/node/binary.test.ts
@@ -145,7 +145,7 @@ describe('class Binary', () => {
     });
   });
 
-  context.only('toString()', () => {
+  context('toString()', () => {
     context('when case is UTF8 (default)', () => {
       it('should respect position when converting to string', () => {
         const bin = new Binary();
@@ -192,7 +192,7 @@ describe('class Binary', () => {
     });
   });
 
-  context.only('toJSON()', () => {
+  context('toJSON()', () => {
     it('should respect position when converting to JSON', () => {
       const bin = new Binary();
       expect(bin.toJSON()).to.equal('');


### PR DESCRIPTION
### Description
`Binary.toString` and `Binary.toJSON` now respect position when printing out binary object.

#### What is changing?
See release highlights.

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
Bug Fix.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `Binary.toString`  and `Binary.toJSON` now respect position when printing out binary object.
When the `toString()` or `toJSON` method is called on a `Binary` instance, it will print out until the instance's position property of the object, instead of the entire buffer.

Example:
```typescript
new BSON.Binary().toString();
// old output: '\x00\x00\x00\x00...' (256 zeros)
// new output:  ' ' 
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
