### PR TITLE
feat(NODE-6087): add Int32.fromString method

### DIFF
--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -39,17 +39,21 @@ export class Int32 extends BSONValue {
    * This method will throw a BSONError on any string input that is not representable as an Int32.
    * Notably, this method will also throw on the following string formats:
    * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
-   * - Strings with leading zeros
-   * - Strings with decimal points (ex: '2.0')
+   * - Strings with non-numeric characters (ex: '2.0', '24,000')
    *
-   * Strings with whitespace, however, are allowed.
+   * Strings with whitespace and/or leading zeros, however, are allowed.
    *
    * @param value - the string we want to represent as an int32.
    */
   static fromString(value: string): number {
     const trimmedValue = value.trim();
-    const coercedValue = Number(trimmedValue);
-    if (coercedValue.toString() !== trimmedValue) {
+    const cleanedValue = !/[^0]+/.test(trimmedValue)
+      ? trimmedValue.replace(/^0+/, '0') // all zeros case
+      : trimmedValue.includes('-')
+        ? trimmedValue.replace(/^-0+/, '-') // negative number with leading zeros
+        : trimmedValue.replace(/^0+/, ''); // positive number with leading zeros
+    const coercedValue = Number(cleanedValue);
+    if (coercedValue.toString() !== cleanedValue) {
       throw new BSONError(`Input: '${value}' is not a valid Int32 string`);
     }
     return coercedValue;

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -40,7 +40,7 @@ export class Int32 extends BSONValue {
    * This method will throw a BSONError on any string input that is not representable as an Int32.
    * Notably, this method will also throw on the following string formats:
    * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
-   * - Strings with characters other than sign or numeric characters (ex: '2.0', '24,000')
+   * - Strings non-numeric and non-leading sign characters (ex: '2.0', '24,000')
    * - Strings with leading and/or trailing whitespace
    *
    * Strings with leading zeros, however, are also allowed

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -43,7 +43,7 @@ export class Int32 extends BSONValue {
    * - Strings non-numeric and non-leading sign characters (ex: '2.0', '24,000')
    * - Strings with leading and/or trailing whitespace
    *
-   * Strings with leading zeros, however, are also allowed
+   * Strings with leading zeros, however, are allowed.
    *
    * @param value - the string we want to represent as an int32.
    */

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -40,7 +40,7 @@ export class Int32 extends BSONValue {
    * This method will throw a BSONError on any string input that is not representable as an Int32.
    * Notably, this method will also throw on the following string formats:
    * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
-   * - Strings with non-numeric characters (ex: '2.0', '24,000')
+   * - Strings with non-numeric or sign characters (ex: '2.0', '24,000')
    * - Strings with leading and/or trailing whitespace
    *
    * Strings with leading zeros, however, are also allowed
@@ -52,7 +52,7 @@ export class Int32 extends BSONValue {
       ? value.replace(/^0+/, '0') // all zeros case
       : value[0] === '-'
         ? value.replace(/^-0+/, '-') // negative number with leading zeros
-        : value.replace(/^0+/, ''); // positive number with leading zeros
+        : value.replace(/^\+?0+/, ''); // positive number with leading zeros
 
     const coercedValue = Number(value);
     if (

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -40,7 +40,7 @@ export class Int32 extends BSONValue {
    * This method will throw a BSONError on any string input that is not representable as an Int32.
    * Notably, this method will also throw on the following string formats:
    * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
-   * - Strings with non-numeric or sign characters (ex: '2.0', '24,000')
+   * - Strings with characters other than sign or numeric characters (ex: '2.0', '24,000')
    * - Strings with leading and/or trailing whitespace
    *
    * Strings with leading zeros, however, are also allowed

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -55,12 +55,15 @@ export class Int32 extends BSONValue {
         : value.replace(/^\+?0+/, ''); // positive number with leading zeros
 
     const coercedValue = Number(value);
-    if (
-      coercedValue.toString() !== cleanedValue ||
-      !Number.isSafeInteger(coercedValue) ||
-      BSON_INT32_MAX < coercedValue ||
-      BSON_INT32_MIN > coercedValue
-    ) {
+
+    if (BSON_INT32_MAX < coercedValue) {
+      throw new BSONError(`Input: '${value}' is larger than the maximum value for Int32`);
+    } else if (BSON_INT32_MIN > coercedValue) {
+      throw new BSONError(`Input: '${value}' is smaller than the minimum value for Int32`);
+    } else if (!Number.isSafeInteger(coercedValue)) {
+      throw new BSONError(`Input: '${value}' is not a safe integer`);
+    } else if (coercedValue.toString() !== cleanedValue) {
+      // catch all case
       throw new BSONError(`Input: '${value}' is not a valid Int32 string`);
     }
     return new Int32(coercedValue);

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -47,10 +47,10 @@ export class Int32 extends BSONValue {
    *
    * @param value - the string we want to represent as an int32.
    */
-  static fromString(value: string): number {
+  static fromString(value: string): Int32 {
     const cleanedValue = !/[^0]+/.test(value)
       ? value.replace(/^0+/, '0') // all zeros case
-      : value.includes('-')
+      : value[0] === '-'
         ? value.replace(/^-0+/, '-') // negative number with leading zeros
         : value.replace(/^0+/, ''); // positive number with leading zeros
 
@@ -63,7 +63,7 @@ export class Int32 extends BSONValue {
     ) {
       throw new BSONError(`Input: '${value}' is not a valid Int32 string`);
     }
-    return coercedValue;
+    return new Int32(coercedValue);
   }
 
   /**

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -33,6 +33,19 @@ export class Int32 extends BSONValue {
     this.value = +value | 0;
   }
 
+  /**
+   * Attempt to create an Int32 type from string.
+   *
+   * This method will throw a BSONError on any string input that is not representable as an Int32.
+   * Notably, this method will also throw on the following string formats:
+   * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
+   * - Strings with leading zeros
+   * - Strings with decimal points (ex: '2.0')
+   *
+   * Strings with whitespace, however, are allowed.
+   *
+   * @param value - the string we want to represent as an int32.
+   */
   static fromString(value: string): number {
     const trimmedValue = value.trim();
     const coercedValue = Number(trimmedValue);

--- a/src/int_32.ts
+++ b/src/int_32.ts
@@ -1,4 +1,5 @@
 import { BSONValue } from './bson_value';
+import { BSONError } from './error';
 import type { EJSONOptions } from './extended_json';
 import { type InspectFn, defaultInspect } from './parser/utils';
 
@@ -30,6 +31,15 @@ export class Int32 extends BSONValue {
     }
 
     this.value = +value | 0;
+  }
+
+  static fromString(value: string): number {
+    const trimmedValue = value.trim();
+    const coercedValue = Number(trimmedValue);
+    if (coercedValue.toString() !== trimmedValue) {
+      throw new BSONError(`Input: '${value}' is not a valid Int32 string`);
+    }
+    return coercedValue;
   }
 
   /**

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -104,42 +104,42 @@ describe('Int32', function () {
       ['Int32.max', '2147483647', 2147483647],
       ['Int32.min', '-2147483648', -2147483648],
       ['zero', '0', 0],
-      ['non-leading zeros', '45000000', 45000000],
-      ['zero with leading zeros', '000000', 0],
-      ['positive leading zeros', '000000867', 867],
-      ['explicity positive leading zeros', '+000000867', 867],
-      ['negative leading zeros', '-00007', -7]
+      ['a string with non-leading consecutive zeros', '45000000', 45000000],
+      ['a string with zero with leading zeros', '000000', 0],
+      ['a string with positive leading zeros', '000000867', 867],
+      ['a string with explicity positive leading zeros', '+000000867', 867],
+      ['a string with negative leading zeros', '-00007', -7]
     ];
     const errorInputs = [
-      ['Int32.max + 1', '2147483648'],
-      ['Int32.min - 1', '-2147483649'],
-      ['positive integer with decimal', '2.0'],
-      ['zero with decimal', '0.0'],
-      ['negative zero', '-0'],
-      ['Infinity', 'Infinity'],
-      ['-Infinity', '-Infinity'],
-      ['NaN', 'NaN'],
-      ['fraction', '2/3'],
-      ['commas', '34,450'],
-      ['exponentiation notation', '1e1'],
-      ['octal', '0o1'],
-      ['binary', '0b1'],
-      ['hex', '0x1'],
-      ['empty string', ''],
-      ['leading and trailing whitespace', '    89   ', 89]
+      ['Int32.max + 1', '2147483648', 'larger than the maximum value for Int32'],
+      ['Int32.min - 1', '-2147483649', 'smaller than the minimum value for Int32'],
+      ['positive integer with decimal', '2.0', 'not a valid Int32 string'],
+      ['zero with decimals', '0.0', 'not a valid Int32 string'],
+      ['negative zero', '-0', 'not a valid Int32 string'],
+      ['Infinity', 'Infinity', 'larger than the maximum value for Int32'],
+      ['-Infinity', '-Infinity', 'smaller than the minimum value for Int32'],
+      ['NaN', 'NaN', 'not a safe integer'],
+      ['a fraction', '2/3', 'not a safe integer'],
+      ['a string containing commas', '34,450', 'not a safe integer'],
+      ['a string in exponentiation notation', '1e1', 'not a valid Int32 string'],
+      ['a octal string', '0o1', 'not a valid Int32 string'],
+      ['a binary string', '0b1', 'not a valid Int32 string'],
+      ['a hexadecimal string', '0x1', 'not a valid Int32 string'],
+      ['a empty string', '', 'not a valid Int32 string'],
+      ['a leading and trailing whitespace', '    89   ', 'not a valid Int32 string']
     ];
 
     for (const [testName, value, expectedInt32] of acceptedInputs) {
-      context(`when case is ${testName}`, () => {
-        it(`should return Int32 that matches expected value`, () => {
+      context(`when the input is ${testName}`, () => {
+        it(`should successfully return an Int32 representation`, () => {
           expect(Int32.fromString(value).value).to.equal(expectedInt32);
         });
       });
     }
-    for (const [testName, value] of errorInputs) {
-      context(`when case is ${testName}`, () => {
-        it(`should throw correct error`, () => {
-          expect(() => Int32.fromString(value)).to.throw(BSONError, /not a valid Int32 string/);
+    for (const [testName, value, expectedErrMsg] of errorInputs) {
+      context(`when the input is ${testName}`, () => {
+        it(`should throw an error containing '${expectedErrMsg}'`, () => {
+          expect(() => Int32.fromString(value)).to.throw(BSONError, expectedErrMsg);
         });
       });
     }

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -2,6 +2,7 @@
 
 const BSON = require('../register-bson');
 const Int32 = BSON.Int32;
+const BSONError = BSON.BSONError;
 
 describe('Int32', function () {
   context('Constructor', function () {
@@ -103,9 +104,8 @@ describe('Int32', function () {
       ['Int32.max', '2147483647', 2147483647],
       ['Int32.min', '-2147483648', -2147483648],
       ['zero', '0', 0],
-      ['zero with leading zeros', '000000', 0],
       ['non-leading zeros', '45000000', 45000000],
-      ['leading and trailing whitespace', '    89   ', 89],
+      ['zero with leading zeros', '000000', 0],
       ['positive leading zeros', '000000867', 867],
       ['negative leading zeros', '-00007', -7]
     ];
@@ -124,7 +124,8 @@ describe('Int32', function () {
       ['octal', '0o1'],
       ['binary', '0b1'],
       ['hex', '0x1'],
-      ['empty string', '']
+      ['empty string', ''],
+      ['leading and trailing whitespace', '    89   ', 89]
     ];
 
     for (const [testName, value, expectedInt32] of acceptedInputs) {
@@ -136,12 +137,8 @@ describe('Int32', function () {
     }
     for (const [testName, value] of errorInputs) {
       context(`when case is ${testName}`, () => {
-        it(`should throw error`, () => {
-          try {
-            Int32.fromString(value);
-          } catch (error) {
-            expect(error.message).to.equal(`Input: '${value}' is not a valid Int32 string`);
-          }
+        it(`should throw correct error`, () => {
+          expect(() => Int32.fromString(value)).to.throw(BSONError, /not a valid Int32 string/);
         });
       });
     }

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -101,14 +101,14 @@ describe('Int32', function () {
 
   describe('fromString', () => {
     const acceptedInputs = [
-      ['Int32.max', '2147483647', new Int32(2147483647)],
-      ['Int32.min', '-2147483648', new Int32(-2147483648)],
-      ['zero', '0', new Int32(0)],
-      ['non-leading zeros', '45000000', new Int32(45000000)],
-      ['zero with leading zeros', '000000', new Int32(0)],
-      ['positive leading zeros', '000000867', new Int32(867)],
-      ['explicity positive leading zeros', '+000000867', new Int32(867)],
-      ['negative leading zeros', '-00007', new Int32(-7)]
+      ['Int32.max', '2147483647', 2147483647],
+      ['Int32.min', '-2147483648', -2147483648],
+      ['zero', '0', 0],
+      ['non-leading zeros', '45000000', 45000000],
+      ['zero with leading zeros', '000000', 0],
+      ['positive leading zeros', '000000867', 867],
+      ['explicity positive leading zeros', '+000000867', 867],
+      ['negative leading zeros', '-00007', -7]
     ];
     const errorInputs = [
       ['Int32.max + 1', '2147483648'],
@@ -132,7 +132,7 @@ describe('Int32', function () {
     for (const [testName, value, expectedInt32] of acceptedInputs) {
       context(`when case is ${testName}`, () => {
         it(`should return Int32 that matches expected value`, () => {
-          expect(Int32.fromString(value).value).to.equal(expectedInt32.value);
+          expect(Int32.fromString(value).value).to.equal(expectedInt32);
         });
       });
     }

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -101,13 +101,13 @@ describe('Int32', function () {
 
   describe('fromString', () => {
     const acceptedInputs = [
-      ['Int32.max', '2147483647', 2147483647],
-      ['Int32.min', '-2147483648', -2147483648],
-      ['zero', '0', 0],
-      ['non-leading zeros', '45000000', 45000000],
-      ['zero with leading zeros', '000000', 0],
-      ['positive leading zeros', '000000867', 867],
-      ['negative leading zeros', '-00007', -7]
+      ['Int32.max', '2147483647', new Int32(2147483647)],
+      ['Int32.min', '-2147483648', new Int32(-2147483648)],
+      ['zero', '0', new Int32(0)],
+      ['non-leading zeros', '45000000', new Int32(45000000)],
+      ['zero with leading zeros', '000000', new Int32(0)],
+      ['positive leading zeros', '000000867', new Int32(867)],
+      ['negative leading zeros', '-00007', new Int32(-7)]
     ];
     const errorInputs = [
       ['Int32.max + 1', '2147483648'],
@@ -131,7 +131,7 @@ describe('Int32', function () {
     for (const [testName, value, expectedInt32] of acceptedInputs) {
       context(`when case is ${testName}`, () => {
         it(`should return Int32 that matches expected value`, () => {
-          expect(Int32.fromString(value)).to.equal(expectedInt32);
+          expect(Int32.fromString(value).value).to.equal(expectedInt32.value);
         });
       });
     }

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -116,7 +116,11 @@ describe('Int32', function () {
       ['NaN', 'NaN'],
       ['fraction', '2/3'],
       ['leading zeros', '-00007'],
-      ['commas', '34,450']
+      ['commas', '34,450'],
+      ['exponentiation notation', '1e1'],
+      ['octal', '0o1'],
+      ['binary', '0b1'],
+      ['hex', '0x1']
     ];
 
     for (const [testName, value, expectedInt32] of acceptedInputs) {

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -107,6 +107,7 @@ describe('Int32', function () {
       ['non-leading zeros', '45000000', new Int32(45000000)],
       ['zero with leading zeros', '000000', new Int32(0)],
       ['positive leading zeros', '000000867', new Int32(867)],
+      ['explicity positive leading zeros', '+000000867', new Int32(867)],
       ['negative leading zeros', '-00007', new Int32(-7)]
     ];
     const errorInputs = [

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -103,7 +103,11 @@ describe('Int32', function () {
       ['Int32.max', '2147483647', 2147483647],
       ['Int32.min', '-2147483648', -2147483648],
       ['zero', '0', 0],
-      ['leading and trailing whitespace', '    89   ', 89]
+      ['zero with leading zeros', '000000', 0],
+      ['non-leading zeros', '45000000', 45000000],
+      ['leading and trailing whitespace', '    89   ', 89],
+      ['positive leading zeros', '000000867', 867],
+      ['negative leading zeros', '-00007', -7]
     ];
     const errorInputs = [
       ['Int32.max + 1', '2147483648'],
@@ -115,12 +119,12 @@ describe('Int32', function () {
       ['-Infinity', '-Infinity'],
       ['NaN', 'NaN'],
       ['fraction', '2/3'],
-      ['leading zeros', '-00007'],
       ['commas', '34,450'],
       ['exponentiation notation', '1e1'],
       ['octal', '0o1'],
       ['binary', '0b1'],
-      ['hex', '0x1']
+      ['hex', '0x1'],
+      ['empty string', '']
     ];
 
     for (const [testName, value, expectedInt32] of acceptedInputs) {

--- a/test/node/int_32_tests.js
+++ b/test/node/int_32_tests.js
@@ -97,4 +97,45 @@ describe('Int32', function () {
       });
     }
   });
+
+  describe('fromString', () => {
+    const acceptedInputs = [
+      ['Int32.max', '2147483647', 2147483647],
+      ['Int32.min', '-2147483648', -2147483648],
+      ['zero', '0', 0],
+      ['leading and trailing whitespace', '    89   ', 89]
+    ];
+    const errorInputs = [
+      ['Int32.max + 1', '2147483648'],
+      ['Int32.min - 1', '-2147483649'],
+      ['positive integer with decimal', '2.0'],
+      ['zero with decimal', '0.0'],
+      ['negative zero', '-0'],
+      ['Infinity', 'Infinity'],
+      ['-Infinity', '-Infinity'],
+      ['NaN', 'NaN'],
+      ['fraction', '2/3'],
+      ['leading zeros', '-00007'],
+      ['commas', '34,450']
+    ];
+
+    for (const [testName, value, expectedInt32] of acceptedInputs) {
+      context(`when case is ${testName}`, () => {
+        it(`should return Int32 that matches expected value`, () => {
+          expect(Int32.fromString(value)).to.equal(expectedInt32);
+        });
+      });
+    }
+    for (const [testName, value] of errorInputs) {
+      context(`when case is ${testName}`, () => {
+        it(`should throw error`, () => {
+          try {
+            Int32.fromString(value);
+          } catch (error) {
+            expect(error.message).to.equal(`Input: '${value}' is not a valid Int32 string`);
+          }
+        });
+      });
+    }
+  });
 });


### PR DESCRIPTION
### Description
Add static `Int32.fromString()` method.

#### What is changing?

##### Is there new documentation needed for these changes?
Yes, there are new API docs.

#### What is the motivation for this change?
NODE-3660 user ticket, our validation in the Int32 is lacking. In V7, we will add `Int32.fromString(value)` validation call into the `Int32` constructor's `string` case.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Add static `Int32.fromString` method
This method attempts to create an `Int32` type from string, and will throw a `BSONError` on any string input that is not representable as an `Int32`.
Notably, this method will also throw on the following string formats:
- Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
- Strings with non-numeric and non-leading sign characters (ex: '2.0', '24,000')
- Strings with leading and/or trailing whitespace

Strings with leading zeros, however, are allowed

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
