### PR TITLE
feat(NODE-6086): add Double.fromString() method

### DIFF
--- a/src/double.ts
+++ b/src/double.ts
@@ -49,14 +49,18 @@ export class Double extends BSONValue {
   static fromString(value: string): Double {
     const coercedValue = Number(value);
     const nonFiniteValidInputs = ['Infinity', '-Infinity', 'NaN'];
-    if (
+
+    if (value.trim() !== value) {
+      throw new BSONError(`Input: '${value}' contains whitespace`);
+    } else if (value === '') {
+      throw new BSONError(`Input is an empty string`);
+    } else if (/[^-0-9.]/.test(value) && !nonFiniteValidInputs.includes(value)) {
+      throw new BSONError(`Input: '${value}' contains invalid characters`);
+    } else if (
       (!Number.isFinite(coercedValue) && !nonFiniteValidInputs.includes(value)) ||
-      (Number.isNaN(coercedValue) && value !== 'NaN') ||
-      value === '' ||
-      (/[^-0-9.]/.test(value) && !nonFiniteValidInputs.includes(value)) ||
-      value.trim() !== value
+      (Number.isNaN(coercedValue) && value !== 'NaN')
     ) {
-      throw new BSONError(`Input: '${value}' is not a valid Double string`);
+      throw new BSONError(`Input: ${value} is not representable as a Double`); // generic case
     }
     return new Double(coercedValue);
   }

--- a/src/double.ts
+++ b/src/double.ts
@@ -39,7 +39,7 @@ export class Double extends BSONValue {
    * This method will throw a BSONError on any string input that is not representable as a IEEE-754 64-bit double.
    * Notably, this method will also throw on the following string formats:
    * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
-   * - Strings with non-numeric, floating point, or slash characters; however, 'Infinity', '-Infinity', and 'NaN' input strings are allowed
+   * - Strings with characters other than sign, numeric, floating point, or slash characters (Note: 'Infinity', '-Infinity', and 'NaN' input strings are still allowed)
    * - Strings with leading and/or trailing whitespace
    *
    * Strings with leading zeros, however, are also allowed

--- a/src/double.ts
+++ b/src/double.ts
@@ -1,4 +1,5 @@
 import { BSONValue } from './bson_value';
+import { BSONError } from './error';
 import type { EJSONOptions } from './extended_json';
 import { type InspectFn, defaultInspect } from './parser/utils';
 
@@ -30,6 +31,34 @@ export class Double extends BSONValue {
     }
 
     this.value = +value;
+  }
+
+  /**
+   * Attempt to create an double type from string.
+   *
+   * This method will throw a BSONError on any string input that is not representable as a IEEE-754 64-bit double.
+   * Notably, this method will also throw on the following string formats:
+   * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
+   * - Strings with non-numeric, floating point, or slash characters; however, 'Infinity', '-Infinity', and 'NaN' input strings are allowed
+   * - Strings with leading and/or trailing whitespace
+   *
+   * Strings with leading zeros, however, are also allowed
+   *
+   * @param value - the string we want to represent as an double.
+   */
+  static fromString(value: string): number {
+    const coercedValue = Number(value);
+    const nonFiniteValidInputs = ['Infinity', '-Infinity', 'NaN'];
+    if (
+      (!Number.isFinite(coercedValue) && !nonFiniteValidInputs.includes(value)) ||
+      (Number.isNaN(coercedValue) && value !== 'NaN') ||
+      value === '' ||
+      (/[^-0-9.]/.test(value) && !nonFiniteValidInputs.includes(value)) ||
+      value.trim() !== value
+    ) {
+      throw new BSONError(`Input: '${value}' is not a valid Double string`);
+    }
+    return coercedValue;
   }
 
   /**

--- a/src/double.ts
+++ b/src/double.ts
@@ -46,7 +46,7 @@ export class Double extends BSONValue {
    *
    * @param value - the string we want to represent as an double.
    */
-  static fromString(value: string): number {
+  static fromString(value: string): Double {
     const coercedValue = Number(value);
     const nonFiniteValidInputs = ['Infinity', '-Infinity', 'NaN'];
     if (
@@ -58,7 +58,7 @@ export class Double extends BSONValue {
     ) {
       throw new BSONError(`Input: '${value}' is not a valid Double string`);
     }
-    return coercedValue;
+    return new Double(coercedValue);
   }
 
   /**

--- a/src/double.ts
+++ b/src/double.ts
@@ -39,7 +39,7 @@ export class Double extends BSONValue {
    * This method will throw a BSONError on any string input that is not representable as a IEEE-754 64-bit double.
    * Notably, this method will also throw on the following string formats:
    * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
-   * - Strings with characters other than sign, numeric, floating point, or slash characters (Note: 'Infinity', '-Infinity', and 'NaN' input strings are still allowed)
+   * - Strings with characters other than numeric, floating point, or leading sign characters (Note: 'Infinity', '-Infinity', and 'NaN' input strings are still allowed)
    * - Strings with leading and/or trailing whitespace
    *
    * Strings with leading zeros, however, are also allowed

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -243,22 +243,22 @@ describe('BSON Double Precision', function () {
       ];
 
       const errorInputs = [
-        ['commas', '34,450'],
-        ['exponentiation notation', '1.34e16'],
-        ['octal', '0o1'],
-        ['binary', '0b1'],
-        ['hex', '0x1'],
-        ['empty string', ''],
-        ['leading and trailing whitespace', '    89   ', 89],
-        ['fake positive infinity', '2e308'],
-        ['fake negative infinity', '-2e308'],
-        ['fraction', '3/4'],
-        ['foo', 'foo']
+        ['commas', '34,450', 'contains invalid characters'],
+        ['exponentiation notation', '1.34e16', 'contains invalid characters'],
+        ['octal', '0o1', 'contains invalid characters'],
+        ['binary', '0b1', 'contains invalid characters'],
+        ['hex', '0x1', 'contains invalid characters'],
+        ['empty string', '', 'is an empty string'],
+        ['leading and trailing whitespace', '    89   ', 'contains whitespace'],
+        ['fake positive infinity', '2e308', 'contains invalid characters'],
+        ['fake negative infinity', '-2e308', 'contains invalid characters'],
+        ['fraction', '3/4', 'contains invalid characters'],
+        ['foo', 'foo', 'contains invalid characters']
       ];
 
       for (const [testName, value, expectedDouble] of acceptedInputs) {
-        context(`when case is ${testName}`, () => {
-          it(`should return Double that matches expected value`, () => {
+        context(`when the input is ${testName}`, () => {
+          it(`should successfully return a Double representation`, () => {
             if (value === 'NaN') {
               expect(isNaN(Double.fromString(value))).to.be.true;
             } else {
@@ -267,13 +267,10 @@ describe('BSON Double Precision', function () {
           });
         });
       }
-      for (const [testName, value] of errorInputs) {
-        context(`when case is ${testName}`, () => {
-          it(`should throw correct error`, () => {
-            expect(() => Double.fromString(value)).to.throw(
-              BSON.BSONError,
-              /not a valid Double string/
-            );
+      for (const [testName, value, expectedErrMsg] of errorInputs) {
+        context(`when the input is ${testName}`, () => {
+          it(`should throw an error containing '${expectedErrMsg}'`, () => {
+            expect(() => Double.fromString(value)).to.throw(BSON.BSONError, expectedErrMsg);
           });
         });
       }

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -226,7 +226,7 @@ describe('BSON Double Precision', function () {
       });
     });
 
-    describe('fromString', () => {
+    describe.only('fromString', () => {
       const acceptedInputs = [
         ['zero', '0', 0],
         ['non-leading zeros', '45000000', 45000000],
@@ -238,7 +238,8 @@ describe('BSON Double Precision', function () {
         ['Infinity', 'Infinity', Infinity],
         ['-Infinity', '-Infinity', -Infinity],
         ['NaN', 'NaN', NaN],
-        ['basic floating point', '-4.556000', -4.556]
+        ['basic floating point', '-4.556000', -4.556],
+        ['negative zero', '-0', -0]
       ];
 
       const errorInputs = [

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -226,7 +226,7 @@ describe('BSON Double Precision', function () {
       });
     });
 
-    describe.only('fromString', () => {
+    describe('fromString', () => {
       const acceptedInputs = [
         ['zero', '0', 0],
         ['non-leading zeros', '45000000', 45000000],
@@ -262,7 +262,7 @@ describe('BSON Double Precision', function () {
             if (value === 'NaN') {
               expect(isNaN(Double.fromString(value))).to.be.true;
             } else {
-              expect(Double.fromString(value)).to.equal(expectedDouble);
+              expect(Double.fromString(value).value).to.equal(expectedDouble);
             }
           });
         });

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -225,6 +225,58 @@ describe('BSON Double Precision', function () {
         });
       });
     });
+
+    describe('fromString', () => {
+      const acceptedInputs = [
+        ['zero', '0', 0],
+        ['non-leading zeros', '45000000', 45000000],
+        ['zero with leading zeros', '000000.0000', 0],
+        ['positive leading zeros', '000000867.1', 867.1],
+        ['negative leading zeros', '-00007.980', -7.98],
+        ['positive integer with decimal', '2.0', 2],
+        ['zero with decimal', '0.0', 0.0],
+        ['Infinity', 'Infinity', Infinity],
+        ['-Infinity', '-Infinity', -Infinity],
+        ['NaN', 'NaN', NaN],
+        ['basic floating point', '-4.556000', -4.556]
+      ];
+
+      const errorInputs = [
+        ['commas', '34,450'],
+        ['exponentiation notation', '1.34e16'],
+        ['octal', '0o1'],
+        ['binary', '0b1'],
+        ['hex', '0x1'],
+        ['empty string', ''],
+        ['leading and trailing whitespace', '    89   ', 89],
+        ['fake positive infinity', '2e308'],
+        ['fake negative infinity', '-2e308'],
+        ['fraction', '3/4'],
+        ['foo', 'foo']
+      ];
+
+      for (const [testName, value, expectedDouble] of acceptedInputs) {
+        context(`when case is ${testName}`, () => {
+          it(`should return Double that matches expected value`, () => {
+            if (value === 'NaN') {
+              expect(isNaN(Double.fromString(value))).to.be.true;
+            } else {
+              expect(Double.fromString(value)).to.equal(expectedDouble);
+            }
+          });
+        });
+      }
+      for (const [testName, value] of errorInputs) {
+        context(`when case is ${testName}`, () => {
+          it(`should throw correct error`, () => {
+            expect(() => Double.fromString(value)).to.throw(
+              BSON.BSONError,
+              /not a valid Double string/
+            );
+          });
+        });
+      }
+    });
   });
 
   function serializeThenDeserialize(value) {


### PR DESCRIPTION
### Description
Add static `Double.fromString()` method.

#### What is changing?

##### Is there new documentation needed for these changes?
Yes, there are new API docs.

#### What is the motivation for this change?
NODE-3660 user ticket, our validation in the Double is lacking. In V7, we will add `Double.fromString(value)` validation call into the `Double` constructor's `string` case.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Add static `Double.fromString` method
This method attempts to create an `Double` type from a string, and will throw a `BSONError` on any string input that is not representable as a `IEEE-754 64-bit double`.
 Notably, this method will also throw on the following string formats:
   - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
   - Strings with characters other than sign, numeric, floating point, or slash characters (Note: `'Infinity'`, `'-Infinity'`, and `'NaN'` input strings are still allowed)
   - Strings with leading and/or trailing whitespace
Strings with leading zeros, however, are also allowed.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket