### PR TITLE
fix(NODE-6102): Double.fromString prohibiting '+' character and prohibiting exponential notation

### DIFF
--- a/src/double.ts
+++ b/src/double.ts
@@ -59,13 +59,13 @@ export class Double extends BSONValue {
 
     if (value.trim() !== value) {
       throw new BSONError(`Input: '${value}' contains whitespace`);
+    } else if (!Number.isFinite(coercedValue) && !Number.isNaN(coercedValue)) {
+      throw new BSONError(`Input: ${value} is not representable as a Double`); // generic case
     } else if (value === '') {
       throw new BSONError(`Input is an empty string`);
-    } else if (/[^+-0-9.]/.test(value)) {
+    } else if (/[^-0-9.+]/.test(value)) {
       throw new BSONError(`Input: '${value}' contains invalid characters`);
     } else if (Number.isNaN(coercedValue)) {
-      throw new BSONError(`Input: ${value} is not representable as a Double`); // generic case
-    } else if (!Number.isFinite(coercedValue)) {
       throw new BSONError(`Input: ${value} is not representable as a Double`); // generic case
     }
     return new Double(coercedValue);

--- a/src/double.ts
+++ b/src/double.ts
@@ -38,35 +38,32 @@ export class Double extends BSONValue {
    *
    * This method will throw a BSONError on any string input that is not representable as a IEEE-754 64-bit double.
    * Notably, this method will also throw on the following string formats:
-   * - Strings in non-decimal formats (exponent notation, binary, hex, or octal digits)
+   * - Strings in non-decimal and non-exponential formats (binary, hex, or octal digits)
    * - Strings with characters other than numeric, floating point, or leading sign characters (Note: 'Infinity', '-Infinity', and 'NaN' input strings are still allowed)
    * - Strings with leading and/or trailing whitespace
    *
    * Strings with leading zeros, however, are also allowed
    *
-   * @param value - the string we want to represent as an double.
+   * @param value - the string we want to represent as a double.
    */
   static fromString(value: string): Double {
     const coercedValue = Number(value);
 
-    if (value === 'NaN') {
-      return new Double(NaN);
-    } else if (value === 'Infinity') {
-      return new Double(Infinity);
-    } else if (value === '-Infinity') {
-      return new Double(-Infinity);
-    }
+    if (value === 'NaN') return new Double(NaN);
+    if (value === 'Infinity') return new Double(Infinity);
+    if (value === '-Infinity') return new Double(-Infinity);
 
+    if (!Number.isFinite(coercedValue)) {
+      throw new BSONError(`Input: ${value} is not representable as a Double`);
+    }
     if (value.trim() !== value) {
       throw new BSONError(`Input: '${value}' contains whitespace`);
-    } else if (!Number.isFinite(coercedValue) && !Number.isNaN(coercedValue)) {
-      throw new BSONError(`Input: ${value} is not representable as a Double`); // generic case
-    } else if (value === '') {
+    }
+    if (value === '') {
       throw new BSONError(`Input is an empty string`);
-    } else if (/[^-0-9.+]/.test(value)) {
-      throw new BSONError(`Input: '${value}' contains invalid characters`);
-    } else if (Number.isNaN(coercedValue)) {
-      throw new BSONError(`Input: ${value} is not representable as a Double`); // generic case
+    }
+    if (/[^-0-9.+e]/.test(value)) {
+      throw new BSONError(`Input: '${value}' is not in decimal or exponential notation`);
     }
     return new Double(coercedValue);
   }

--- a/src/double.ts
+++ b/src/double.ts
@@ -62,7 +62,7 @@ export class Double extends BSONValue {
     if (value === '') {
       throw new BSONError(`Input is an empty string`);
     }
-    if (/[^-0-9.+e]/.test(value)) {
+    if (/[^-0-9.+eE]/.test(value)) {
       throw new BSONError(`Input: '${value}' is not in decimal or exponential notation`);
     }
     return new Double(coercedValue);

--- a/src/double.ts
+++ b/src/double.ts
@@ -48,18 +48,24 @@ export class Double extends BSONValue {
    */
   static fromString(value: string): Double {
     const coercedValue = Number(value);
-    const nonFiniteValidInputs = ['Infinity', '-Infinity', 'NaN'];
+
+    if (value === 'NaN') {
+      return new Double(NaN);
+    } else if (value === 'Infinity') {
+      return new Double(Infinity);
+    } else if (value === '-Infinity') {
+      return new Double(-Infinity);
+    }
 
     if (value.trim() !== value) {
       throw new BSONError(`Input: '${value}' contains whitespace`);
     } else if (value === '') {
       throw new BSONError(`Input is an empty string`);
-    } else if (/[^-0-9.]/.test(value) && !nonFiniteValidInputs.includes(value)) {
+    } else if (/[^+-0-9.]/.test(value)) {
       throw new BSONError(`Input: '${value}' contains invalid characters`);
-    } else if (
-      (!Number.isFinite(coercedValue) && !nonFiniteValidInputs.includes(value)) ||
-      (Number.isNaN(coercedValue) && value !== 'NaN')
-    ) {
+    } else if (Number.isNaN(coercedValue)) {
+      throw new BSONError(`Input: ${value} is not representable as a Double`); // generic case
+    } else if (!Number.isFinite(coercedValue)) {
       throw new BSONError(`Input: ${value} is not representable as a Double`); // generic case
     }
     return new Double(coercedValue);

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -226,7 +226,7 @@ describe('BSON Double Precision', function () {
       });
     });
 
-    describe.only('fromString', () => {
+    describe('fromString', () => {
       const acceptedInputs = [
         ['zero', '0', 0],
         ['non-leading zeros', '45000000', 45000000],
@@ -257,7 +257,11 @@ describe('BSON Double Precision', function () {
         ['fake negative infinity', '-2e308', 'is not representable as a Double'],
         ['fraction', '3/4', 'contains invalid characters'],
         ['foo', 'foo', 'contains invalid characters'],
-        ['malformed number without invalid characters', '9.0.+76', 'is not representable as a Double']
+        [
+          'malformed number without invalid characters',
+          '9.0.+76',
+          'is not representable as a Double'
+        ]
       ];
 
       for (const [testName, value, expectedDouble] of acceptedInputs) {

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -226,7 +226,7 @@ describe('BSON Double Precision', function () {
       });
     });
 
-    describe('fromString', () => {
+    describe.only('fromString', () => {
       const acceptedInputs = [
         ['zero', '0', 0],
         ['non-leading zeros', '45000000', 45000000],
@@ -246,7 +246,8 @@ describe('BSON Double Precision', function () {
         ['exponentiation notation', '1.34e16', 1.34e16],
         ['exponentiation notation with negative exponent', '1.34e-16', 1.34e-16],
         ['exponentiation notation with explicit positive exponent', '1.34e+16', 1.34e16],
-        ['exponentiation notation with negative base', '-1.34e16', -1.34e16]
+        ['exponentiation notation with negative base', '-1.34e16', -1.34e16],
+        ['exponentiation notation with capital E', '-1.34E16', -1.34e16]
       ];
 
       const errorInputs = [
@@ -273,7 +274,7 @@ describe('BSON Double Precision', function () {
             if (value === 'NaN') {
               expect(isNaN(Double.fromString(value))).to.be.true;
             } else {
-              expect(Double.fromString(value).value).to.equal(expectedDouble);
+              expect(Double.fromString(value).value).to.deep.equal(expectedDouble);
             }
           });
         });

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -242,21 +242,24 @@ describe('BSON Double Precision', function () {
         ['negative zero', '-0', -0],
         ['explicit plus zero', '+0', 0],
         ['explicit plus decimal', '+78.23456', 78.23456],
-        ['explicit plus leading zeros', '+00000000000001.11', 1.11]
+        ['explicit plus leading zeros', '+00000000000001.11', 1.11],
+        ['exponentiation notation', '1.34e16', 1.34e16],
+        ['exponentiation notation with negative exponent', '1.34e-16', 1.34e-16],
+        ['exponentiation notation with explicit positive exponent', '1.34e+16', 1.34e16],
+        ['exponentiation notation with negative base', '-1.34e16', -1.34e16]
       ];
 
       const errorInputs = [
-        ['commas', '34,450', 'contains invalid characters'],
-        ['exponentiation notation', '1.34e16', 'contains invalid characters'],
-        ['octal', '0o1', 'contains invalid characters'],
-        ['binary', '0b1', 'contains invalid characters'],
-        ['hex', '0x1', 'contains invalid characters'],
+        ['commas', '34,450', 'is not representable as a Double'],
+        ['octal', '0o1', 'is not in decimal or exponential notation'],
+        ['binary', '0b1', 'is not in decimal or exponential notation'],
+        ['hex', '0x1', 'is not in decimal or exponential notation'],
         ['empty string', '', 'is an empty string'],
         ['leading and trailing whitespace', '    89   ', 'contains whitespace'],
         ['fake positive infinity', '2e308', 'is not representable as a Double'],
         ['fake negative infinity', '-2e308', 'is not representable as a Double'],
-        ['fraction', '3/4', 'contains invalid characters'],
-        ['foo', 'foo', 'contains invalid characters'],
+        ['fraction', '3/4', 'is not representable as a Double'],
+        ['foo', 'foo', 'is not representable as a Double'],
         [
           'malformed number without invalid characters',
           '9.0.+76',

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -226,7 +226,7 @@ describe('BSON Double Precision', function () {
       });
     });
 
-    describe.only('fromString', () => {
+    describe('fromString', () => {
       const acceptedInputs = [
         ['zero', '0', 0],
         ['non-leading zeros', '45000000', 45000000],

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -226,7 +226,7 @@ describe('BSON Double Precision', function () {
       });
     });
 
-    describe('fromString', () => {
+    describe.only('fromString', () => {
       const acceptedInputs = [
         ['zero', '0', 0],
         ['non-leading zeros', '45000000', 45000000],
@@ -239,7 +239,10 @@ describe('BSON Double Precision', function () {
         ['-Infinity', '-Infinity', -Infinity],
         ['NaN', 'NaN', NaN],
         ['basic floating point', '-4.556000', -4.556],
-        ['negative zero', '-0', -0]
+        ['negative zero', '-0', -0],
+        ['explicit plus zero', '+0', 0],
+        ['explicit plus decimal', '+78.23456', 78.23456],
+        ['explicit plus leading zeros', '+00000000000001.11', 1.11]
       ];
 
       const errorInputs = [
@@ -250,10 +253,11 @@ describe('BSON Double Precision', function () {
         ['hex', '0x1', 'contains invalid characters'],
         ['empty string', '', 'is an empty string'],
         ['leading and trailing whitespace', '    89   ', 'contains whitespace'],
-        ['fake positive infinity', '2e308', 'contains invalid characters'],
-        ['fake negative infinity', '-2e308', 'contains invalid characters'],
+        ['fake positive infinity', '2e308', 'is not representable as a Double'],
+        ['fake negative infinity', '-2e308', 'is not representable as a Double'],
         ['fraction', '3/4', 'contains invalid characters'],
-        ['foo', 'foo', 'contains invalid characters']
+        ['foo', 'foo', 'contains invalid characters'],
+        ['malformed number without invalid characters', '9.0.+76', 'is not representable as a Double']
       ];
 
       for (const [testName, value, expectedDouble] of acceptedInputs) {


### PR DESCRIPTION
### Description
`Double.fromString` should allow `'+'` character in its input. 
`Double.fromString` should allow exponential format.

#### What is changing?
See above.  and also refactor some of the function to make the error messages more clear and the code's logic clearer as well. 

##### Is there new documentation needed for these changes?
No, bug fix on an unreleased feature.

#### What is the motivation for this change?
See description.

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
