### PR TITLE
fix(NODE-6123): utf8 validation is insufficiently strict

### DIFF
--- a/etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs
+++ b/etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs
@@ -5,7 +5,7 @@ const REQUIRE_WEB_UTILS_POLYFILLS =
 const { encode: btoa, decode: atob } = require('../vendor/base64');\n`
 
 const REQUIRE_VALIDATE_UTF8_POLYFILLS = 
-  `const { TextEncoder } = require('../vendor/text-encoding');`;
+  `const { TextDecoder } = require('../vendor/text-encoding');`;
 
 export class RequireVendor {
   /**

--- a/etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs
+++ b/etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs
@@ -1,8 +1,11 @@
 import MagicString from 'magic-string';
 
-const REQUIRE_POLYFILLS =
-  `const { TextEncoder, TextDecoder } = require('../vendor/text-encoding');
+const REQUIRE_WEB_UTILS_POLYFILLS =
+  `const { TextEncoder } = require('../vendor/text-encoding');
 const { encode: btoa, decode: atob } = require('../vendor/base64');\n`
+
+const REQUIRE_VALIDATE_UTF8_POLYFILLS = 
+  `const { TextEncoder } = require('../vendor/text-encoding');`;
 
 export class RequireVendor {
   /**
@@ -14,17 +17,24 @@ export class RequireVendor {
    * @returns {{ code: string; map: import('magic-string').SourceMap }}
    */
   transform(code, id) {
-    if (!id.includes('validate_utf8')) {
-      return;
+    if (id.includes('validate_utf8')) {
+      // MagicString lets us edit the source code and still generate an accurate source map
+      const magicString = new MagicString(code);
+      magicString.prepend(REQUIRE_VALIDATE_UTF8_POLYFILLS);
+
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap({ hires: true })
+      };
+    } else if (id.includes('web_byte_utils')) {
+      // MagicString lets us edit the source code and still generate an accurate source map
+      const magicString = new MagicString(code);
+      magicString.prepend(REQUIRE_WEB_UTILS_POLYFILLS);
+
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap({ hires: true })
+      };
     }
-
-    // MagicString lets us edit the source code and still generate an accurate source map
-    const magicString = new MagicString(code);
-    magicString.prepend(REQUIRE_POLYFILLS);
-
-    return {
-      code: magicString.toString(),
-      map: magicString.generateMap({ hires: true })
-    };
   }
 }

--- a/etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs
+++ b/etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs
@@ -14,7 +14,7 @@ export class RequireVendor {
    * @returns {{ code: string; map: import('magic-string').SourceMap }}
    */
   transform(code, id) {
-    if (!id.includes('web_byte_utils')) {
+    if (!id.includes('validate_utf8')) {
       return;
     }
 

--- a/etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs
+++ b/etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs
@@ -4,8 +4,8 @@ const REQUIRE_WEB_UTILS_POLYFILLS =
   `const { TextEncoder } = require('../vendor/text-encoding');
 const { encode: btoa, decode: atob } = require('../vendor/base64');\n`
 
-const REQUIRE_VALIDATE_UTF8_POLYFILLS = 
-  `const { TextDecoder } = require('../vendor/text-encoding');`;
+const REQUIRE_PARSE_UTF8_POLYFILLS = 
+  `const { TextDecoder } = require('../vendor/text-encoding');\n`;
 
 export class RequireVendor {
   /**
@@ -17,10 +17,10 @@ export class RequireVendor {
    * @returns {{ code: string; map: import('magic-string').SourceMap }}
    */
   transform(code, id) {
-    if (id.includes('validate_utf8')) {
+    if (id.includes('parse_utf8')) {
       // MagicString lets us edit the source code and still generate an accurate source map
       const magicString = new MagicString(code);
-      magicString.prepend(REQUIRE_VALIDATE_UTF8_POLYFILLS);
+      magicString.prepend(REQUIRE_PARSE_UTF8_POLYFILLS);
 
       return {
         code: magicString.toString(),

--- a/src/parse_utf8.ts
+++ b/src/parse_utf8.ts
@@ -23,8 +23,8 @@ let TextDecoderNonFatal: TextDecoder;
  */
 export function parseUtf8(buffer: Uint8Array, start: number, end: number, fatal: boolean): string {
   if (fatal) {
+    TextDecoderFatal ??= new TextDecoder('utf8', { fatal: true });
     try {
-      TextDecoderFatal ??= new TextDecoder('utf8', { fatal: true });
       return TextDecoderFatal.decode(buffer.subarray(start, end));
     } catch (cause) {
       throw new BSONError('Invalid UTF-8 string in BSON document', { cause });

--- a/src/parse_utf8.ts
+++ b/src/parse_utf8.ts
@@ -10,18 +10,8 @@ type TextDecoderConstructor = {
   new (label: 'utf8', options: { fatal: boolean; ignoreBOM?: boolean }): TextDecoder;
 };
 
-type TextEncoder = {
-  readonly encoding: string;
-  encode(input?: string): Uint8Array;
-};
-type TextEncoderConstructor = {
-  new (): TextEncoder;
-};
-
-// validate utf8 globals
+// parse utf8 globals
 declare const TextDecoder: TextDecoderConstructor;
-declare const TextEncoder: TextEncoderConstructor;
-
 let TextDecoderFatal: TextDecoder;
 let TextDecoderNonFatal: TextDecoder;
 
@@ -31,20 +21,15 @@ let TextDecoderNonFatal: TextDecoder;
  * @param start - The index to start validating
  * @param end - The index to end validating
  */
-export function validateUtf8(
-  buffer: Uint8Array,
-  start: number,
-  end: number,
-  fatal: boolean
-): string {
+export function parseUtf8(buffer: Uint8Array, start: number, end: number, fatal: boolean): string {
   if (fatal) {
     try {
       TextDecoderFatal ??= new TextDecoder('utf8', { fatal: true });
-      return TextDecoderFatal.decode(buffer.slice(start, end));
+      return TextDecoderFatal.decode(buffer.subarray(start, end));
     } catch (cause) {
       throw new BSONError('Invalid UTF-8 string in BSON document', { cause });
     }
   }
   TextDecoderNonFatal ??= new TextDecoder('utf8', { fatal: false });
-  return TextDecoderNonFatal.decode(buffer.slice(start, end));
+  return TextDecoderNonFatal.decode(buffer.subarray(start, end));
 }

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -16,7 +16,6 @@ import { BSONSymbol } from '../symbol';
 import { Timestamp } from '../timestamp';
 import { ByteUtils } from '../utils/byte_utils';
 import { NumberUtils } from '../utils/number_utils';
-import { validateUtf8 } from '../validate_utf8';
 
 /** @public */
 export interface DeserializeOptions {
@@ -604,12 +603,12 @@ function deserializeObject(
       )
         throw new BSONError('bad string length in bson');
       // Namespace
-      if (validation != null && validation.utf8) {
-        if (!validateUtf8(buffer, index, index + stringSize - 1)) {
-          throw new BSONError('Invalid UTF-8 string in BSON document');
-        }
-      }
-      const namespace = ByteUtils.toUTF8(buffer, index, index + stringSize - 1, false);
+      const namespace = ByteUtils.toUTF8(
+        buffer,
+        index,
+        index + stringSize - 1,
+        validation != null && (validation.utf8 as boolean)
+      );
       // Update parse index position
       index = index + stringSize;
 

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -603,12 +603,7 @@ function deserializeObject(
       )
         throw new BSONError('bad string length in bson');
       // Namespace
-      const namespace = ByteUtils.toUTF8(
-        buffer,
-        index,
-        index + stringSize - 1,
-        validation != null && (validation.utf8 as boolean)
-      );
+      const namespace = ByteUtils.toUTF8(buffer, index, index + stringSize - 1, shouldValidateKey);
       // Update parse index position
       index = index + stringSize;
 

--- a/src/utils/node_byte_utils.ts
+++ b/src/utils/node_byte_utils.ts
@@ -1,5 +1,5 @@
 import { BSONError } from '../error';
-import { validateUtf8 } from '../validate_utf8';
+import { parseUtf8 } from '../parse_utf8';
 import { tryReadBasicLatin, tryWriteBasicLatin } from './latin';
 
 type NodeJsEncoding = 'base64' | 'hex' | 'utf8' | 'binary';
@@ -136,12 +136,9 @@ export const nodeJsByteUtils = {
 
     const string = nodeJsByteUtils.toLocalBufferType(buffer).toString('utf8', start, end);
     if (fatal) {
-      // TODO(NODE-4930): Insufficiently strict BSON UTF8 validation
       for (let i = 0; i < string.length; i++) {
         if (string.charCodeAt(i) === 0xfffd) {
-          if (!validateUtf8(buffer, start, end, fatal)) {
-            throw new BSONError('Invalid UTF-8 string in BSON document');
-          }
+          parseUtf8(buffer, start, end, true);
           break;
         }
       }

--- a/src/utils/node_byte_utils.ts
+++ b/src/utils/node_byte_utils.ts
@@ -139,7 +139,7 @@ export const nodeJsByteUtils = {
       // TODO(NODE-4930): Insufficiently strict BSON UTF8 validation
       for (let i = 0; i < string.length; i++) {
         if (string.charCodeAt(i) === 0xfffd) {
-          if (!validateUtf8(buffer, start, end)) {
+          if (!validateUtf8(buffer, start, end, fatal)) {
             throw new BSONError('Invalid UTF-8 string in BSON document');
           }
           break;

--- a/src/utils/web_byte_utils.ts
+++ b/src/utils/web_byte_utils.ts
@@ -1,5 +1,6 @@
 import { BSONError } from '../error';
 import { tryReadBasicLatin } from './latin';
+import { validateUtf8 } from '../validate_utf8';
 
 type TextDecoder = {
   readonly encoding: string;
@@ -179,14 +180,7 @@ export const webByteUtils = {
       return basicLatin;
     }
 
-    if (fatal) {
-      try {
-        return new TextDecoder('utf8', { fatal }).decode(uint8array.slice(start, end));
-      } catch (cause) {
-        throw new BSONError('Invalid UTF-8 string in BSON document', { cause });
-      }
-    }
-    return new TextDecoder('utf8', { fatal }).decode(uint8array.slice(start, end));
+    return validateUtf8(uint8array, start, end, fatal);
   },
 
   utf8ByteLength(input: string): number {

--- a/src/utils/web_byte_utils.ts
+++ b/src/utils/web_byte_utils.ts
@@ -1,6 +1,6 @@
 import { BSONError } from '../error';
 import { tryReadBasicLatin } from './latin';
-import { validateUtf8 } from '../validate_utf8';
+import { parseUtf8 } from '../parse_utf8';
 
 type TextDecoder = {
   readonly encoding: string;
@@ -180,7 +180,7 @@ export const webByteUtils = {
       return basicLatin;
     }
 
-    return validateUtf8(uint8array, start, end, fatal);
+    return parseUtf8(uint8array, start, end, fatal);
   },
 
   utf8ByteLength(input: string): number {

--- a/src/validate_utf8.ts
+++ b/src/validate_utf8.ts
@@ -18,9 +18,12 @@ type TextEncoderConstructor = {
   new (): TextEncoder;
 };
 
-// Node byte utils global
+// validate utf8 globals
 declare const TextDecoder: TextDecoderConstructor;
 declare const TextEncoder: TextEncoderConstructor;
+
+const TextDecoderFatal: TextDecoder = new TextDecoder('utf8', { fatal: true });
+const TextDecoderNonFatal: TextDecoder = new TextDecoder('utf8', { fatal: false });
 
 /**
  * Determines if the passed in bytes are valid utf8
@@ -36,10 +39,10 @@ export function validateUtf8(
 ): string {
   if (fatal) {
     try {
-      return new TextDecoder('utf8', { fatal }).decode(buffer.slice(start, end));
+      return TextDecoderFatal.decode(buffer.slice(start, end));
     } catch (cause) {
       throw new BSONError('Invalid UTF-8 string in BSON document', { cause });
     }
   }
-  return new TextDecoder('utf8', { fatal }).decode(buffer.slice(start, end));
+  return TextDecoderNonFatal.decode(buffer.slice(start, end));
 }

--- a/src/validate_utf8.ts
+++ b/src/validate_utf8.ts
@@ -22,8 +22,8 @@ type TextEncoderConstructor = {
 declare const TextDecoder: TextDecoderConstructor;
 declare const TextEncoder: TextEncoderConstructor;
 
-const TextDecoderFatal: TextDecoder = new TextDecoder('utf8', { fatal: true });
-const TextDecoderNonFatal: TextDecoder = new TextDecoder('utf8', { fatal: false });
+let TextDecoderFatal: TextDecoder;
+let TextDecoderNonFatal: TextDecoder;
 
 /**
  * Determines if the passed in bytes are valid utf8
@@ -39,10 +39,12 @@ export function validateUtf8(
 ): string {
   if (fatal) {
     try {
+      TextDecoderFatal ??= new TextDecoder('utf8', { fatal: true });
       return TextDecoderFatal.decode(buffer.slice(start, end));
     } catch (cause) {
       throw new BSONError('Invalid UTF-8 string in BSON document', { cause });
     }
   }
+  TextDecoderNonFatal ??= new TextDecoder('utf8', { fatal: false });
   return TextDecoderNonFatal.decode(buffer.slice(start, end));
 }

--- a/test/node/byte_utils.test.ts
+++ b/test/node/byte_utils.test.ts
@@ -531,49 +531,70 @@ const randomBytesTests: ByteUtilTest<'randomBytes'>[] = [
   }
 ];
 
-// extra error cases copied from Web platform specs
-const toUTF8ErrorCaseTests = [
-  { input: [0xff], name: 'invalid code' },
-  { input: [0xc0], name: 'ends early' },
-  { input: [0xe0], name: 'ends early 2' },
-  { input: [0xc0, 0x00], name: 'invalid trail' },
-  { input: [0xc0, 0xc0], name: 'invalid trail 2' },
-  { input: [0xe0, 0x00], name: 'invalid trail 3' },
-  { input: [0xe0, 0xc0], name: 'invalid trail 4' },
-  { input: [0xe0, 0x80, 0x00], name: 'invalid trail 5' },
-  { input: [0xe0, 0x80, 0xc0], name: 'invalid trail 6' },
-  { input: [0xfc, 0x80, 0x80, 0x80, 0x80, 0x80], name: '> 0x10ffff' },
-  { input: [0xfe, 0x80, 0x80, 0x80, 0x80, 0x80], name: 'obsolete lead byte' },
+// extra error cases copied from wpt/encoding/textdecoder-fatal.any.js
+// commit sha: 7c9f867
+const toUTF8WebPlatformSpecTests = [
+  { encoding: 'utf-8', input: [0xff], name: 'invalid code' },
+  { encoding: 'utf-8', input: [0xc0], name: 'ends early' },
+  { encoding: 'utf-8', input: [0xe0], name: 'ends early 2' },
+  { encoding: 'utf-8', input: [0xc0, 0x00], name: 'invalid trail' },
+  { encoding: 'utf-8', input: [0xc0, 0xc0], name: 'invalid trail 2' },
+  { encoding: 'utf-8', input: [0xe0, 0x00], name: 'invalid trail 3' },
+  { encoding: 'utf-8', input: [0xe0, 0xc0], name: 'invalid trail 4' },
+  { encoding: 'utf-8', input: [0xe0, 0x80, 0x00], name: 'invalid trail 5' },
+  { encoding: 'utf-8', input: [0xe0, 0x80, 0xc0], name: 'invalid trail 6' },
+  { encoding: 'utf-8', input: [0xfc, 0x80, 0x80, 0x80, 0x80, 0x80], name: '> 0x10ffff' },
+  { encoding: 'utf-8', input: [0xfe, 0x80, 0x80, 0x80, 0x80, 0x80], name: 'obsolete lead byte' },
 
   // Overlong encodings
-  { input: [0xc0, 0x80], name: 'overlong U+0000 - 2 bytes' },
-  { input: [0xe0, 0x80, 0x80], name: 'overlong U+0000 - 3 bytes' },
-  { input: [0xf0, 0x80, 0x80, 0x80], name: 'overlong U+0000 - 4 bytes' },
-  { input: [0xf8, 0x80, 0x80, 0x80, 0x80], name: 'overlong U+0000 - 5 bytes' },
-  { input: [0xfc, 0x80, 0x80, 0x80, 0x80, 0x80], name: 'overlong U+0000 - 6 bytes' },
+  { encoding: 'utf-8', input: [0xc0, 0x80], name: 'overlong U+0000 - 2 bytes' },
+  { encoding: 'utf-8', input: [0xe0, 0x80, 0x80], name: 'overlong U+0000 - 3 bytes' },
+  { encoding: 'utf-8', input: [0xf0, 0x80, 0x80, 0x80], name: 'overlong U+0000 - 4 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x80, 0x80, 0x80, 0x80], name: 'overlong U+0000 - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x80, 0x80, 0x80, 0x80],
+    name: 'overlong U+0000 - 6 bytes'
+  },
 
-  { input: [0xc1, 0xbf], name: 'overlong U+007f - 2 bytes' },
-  { input: [0xe0, 0x81, 0xbf], name: 'overlong U+007f - 3 bytes' },
-  { input: [0xf0, 0x80, 0x81, 0xbf], name: 'overlong U+007f - 4 bytes' },
-  { input: [0xf8, 0x80, 0x80, 0x81, 0xbf], name: 'overlong U+007f - 5 bytes' },
-  { input: [0xfc, 0x80, 0x80, 0x80, 0x81, 0xbf], name: 'overlong U+007f - 6 bytes' },
+  { encoding: 'utf-8', input: [0xc1, 0xbf], name: 'overlong U+007f - 2 bytes' },
+  { encoding: 'utf-8', input: [0xe0, 0x81, 0xbf], name: 'overlong U+007f - 3 bytes' },
+  { encoding: 'utf-8', input: [0xf0, 0x80, 0x81, 0xbf], name: 'overlong U+007f - 4 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x80, 0x80, 0x81, 0xbf], name: 'overlong U+007f - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x80, 0x80, 0x81, 0xbf],
+    name: 'overlong U+007f - 6 bytes'
+  },
 
-  { input: [0xe0, 0x9f, 0xbf], name: 'overlong U+07ff - 3 bytes' },
-  { input: [0xf0, 0x80, 0x9f, 0xbf], name: 'overlong U+07ff - 4 bytes' },
-  { input: [0xf8, 0x80, 0x80, 0x9f, 0xbf], name: 'overlong U+07ff - 5 bytes' },
-  { input: [0xfc, 0x80, 0x80, 0x80, 0x9f, 0xbf], name: 'overlong U+07ff - 6 bytes' },
+  { encoding: 'utf-8', input: [0xe0, 0x9f, 0xbf], name: 'overlong U+07ff - 3 bytes' },
+  { encoding: 'utf-8', input: [0xf0, 0x80, 0x9f, 0xbf], name: 'overlong U+07ff - 4 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x80, 0x80, 0x9f, 0xbf], name: 'overlong U+07ff - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x80, 0x80, 0x9f, 0xbf],
+    name: 'overlong U+07ff - 6 bytes'
+  },
 
-  { input: [0xf0, 0x8f, 0xbf, 0xbf], name: 'overlong U+ffff - 4 bytes' },
-  { input: [0xf8, 0x80, 0x8f, 0xbf, 0xbf], name: 'overlong U+ffff - 5 bytes' },
-  { input: [0xfc, 0x80, 0x80, 0x8f, 0xbf, 0xbf], name: 'overlong U+ffff - 6 bytes' },
+  { encoding: 'utf-8', input: [0xf0, 0x8f, 0xbf, 0xbf], name: 'overlong U+ffff - 4 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x80, 0x8f, 0xbf, 0xbf], name: 'overlong U+ffff - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x80, 0x8f, 0xbf, 0xbf],
+    name: 'overlong U+ffff - 6 bytes'
+  },
 
-  { input: [0xf8, 0x84, 0x8f, 0xbf, 0xbf], name: 'overlong U+10ffff - 5 bytes' },
-  { input: [0xfc, 0x80, 0x84, 0x8f, 0xbf, 0xbf], name: 'overlong U+10ffff - 6 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x84, 0x8f, 0xbf, 0xbf], name: 'overlong U+10ffff - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x84, 0x8f, 0xbf, 0xbf],
+    name: 'overlong U+10ffff - 6 bytes'
+  },
 
   // UTf-16 surrogates encoded as code points in UTf-8
-  { input: [0xed, 0xa0, 0x80], name: 'lead surrogate' },
-  { input: [0xed, 0xb0, 0x80], name: 'trail surrogate' },
-  { input: [0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80], name: 'surrogate pair' }
+  { encoding: 'utf-8', input: [0xed, 0xa0, 0x80], name: 'lead surrogate' },
+  { encoding: 'utf-8', input: [0xed, 0xb0, 0x80], name: 'trail surrogate' },
+  { encoding: 'utf-8', input: [0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80], name: 'surrogate pair' }
 ];
 
 const utils = new Map([
@@ -882,7 +903,7 @@ describe('ByteUtils', () => {
           });
         }
         if (utility === 'toUTF8')
-          for (const test of toUTF8ErrorCaseTests) {
+          for (const test of toUTF8WebPlatformSpecTests) {
             it(`throws error when fatal is set and provided ${test.name} as input`, () => {
               expect(() =>
                 byteUtils[utility](Uint8Array.from(test.input), 0, test.input.length, true)

--- a/test/node/byte_utils.test.ts
+++ b/test/node/byte_utils.test.ts
@@ -533,6 +533,7 @@ const randomBytesTests: ByteUtilTest<'randomBytes'>[] = [
 
 // extra error cases copied from wpt/encoding/textdecoder-fatal.any.js
 // commit sha: 7c9f867
+// link: https://github.com/web-platform-tests/wpt/commit/7c9f8674d9809731e8919073d957d6233f6e0544
 const toUTF8WebPlatformSpecTests = [
   { encoding: 'utf-8', input: [0xff], name: 'invalid code' },
   { encoding: 'utf-8', input: [0xc0], name: 'ends early' },

--- a/test/node/data/utf8_wpt_error_cases.ts
+++ b/test/node/data/utf8_wpt_error_cases.ts
@@ -1,0 +1,67 @@
+// extra error cases copied from wpt/encoding/textdecoder-fatal.any.js
+// commit sha: 7c9f867
+// link: https://github.com/web-platform-tests/wpt/commit/7c9f8674d9809731e8919073d957d6233f6e0544
+
+export const utf8WebPlatformSpecTests = [
+  { encoding: 'utf-8', input: [0xff], name: 'invalid code' },
+  { encoding: 'utf-8', input: [0xc0], name: 'ends early' },
+  { encoding: 'utf-8', input: [0xe0], name: 'ends early 2' },
+  { encoding: 'utf-8', input: [0xc0, 0x00], name: 'invalid trail' },
+  { encoding: 'utf-8', input: [0xc0, 0xc0], name: 'invalid trail 2' },
+  { encoding: 'utf-8', input: [0xe0, 0x00], name: 'invalid trail 3' },
+  { encoding: 'utf-8', input: [0xe0, 0xc0], name: 'invalid trail 4' },
+  { encoding: 'utf-8', input: [0xe0, 0x80, 0x00], name: 'invalid trail 5' },
+  { encoding: 'utf-8', input: [0xe0, 0x80, 0xc0], name: 'invalid trail 6' },
+  { encoding: 'utf-8', input: [0xfc, 0x80, 0x80, 0x80, 0x80, 0x80], name: '> 0x10ffff' },
+  { encoding: 'utf-8', input: [0xfe, 0x80, 0x80, 0x80, 0x80, 0x80], name: 'obsolete lead byte' },
+
+  // Overlong encodings
+  { encoding: 'utf-8', input: [0xc0, 0x80], name: 'overlong U+0000 - 2 bytes' },
+  { encoding: 'utf-8', input: [0xe0, 0x80, 0x80], name: 'overlong U+0000 - 3 bytes' },
+  { encoding: 'utf-8', input: [0xf0, 0x80, 0x80, 0x80], name: 'overlong U+0000 - 4 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x80, 0x80, 0x80, 0x80], name: 'overlong U+0000 - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x80, 0x80, 0x80, 0x80],
+    name: 'overlong U+0000 - 6 bytes'
+  },
+
+  { encoding: 'utf-8', input: [0xc1, 0xbf], name: 'overlong U+007f - 2 bytes' },
+  { encoding: 'utf-8', input: [0xe0, 0x81, 0xbf], name: 'overlong U+007f - 3 bytes' },
+  { encoding: 'utf-8', input: [0xf0, 0x80, 0x81, 0xbf], name: 'overlong U+007f - 4 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x80, 0x80, 0x81, 0xbf], name: 'overlong U+007f - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x80, 0x80, 0x81, 0xbf],
+    name: 'overlong U+007f - 6 bytes'
+  },
+
+  { encoding: 'utf-8', input: [0xe0, 0x9f, 0xbf], name: 'overlong U+07ff - 3 bytes' },
+  { encoding: 'utf-8', input: [0xf0, 0x80, 0x9f, 0xbf], name: 'overlong U+07ff - 4 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x80, 0x80, 0x9f, 0xbf], name: 'overlong U+07ff - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x80, 0x80, 0x9f, 0xbf],
+    name: 'overlong U+07ff - 6 bytes'
+  },
+
+  { encoding: 'utf-8', input: [0xf0, 0x8f, 0xbf, 0xbf], name: 'overlong U+ffff - 4 bytes' },
+  { encoding: 'utf-8', input: [0xf8, 0x80, 0x8f, 0xbf, 0xbf], name: 'overlong U+ffff - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x80, 0x8f, 0xbf, 0xbf],
+    name: 'overlong U+ffff - 6 bytes'
+  },
+
+  { encoding: 'utf-8', input: [0xf8, 0x84, 0x8f, 0xbf, 0xbf], name: 'overlong U+10ffff - 5 bytes' },
+  {
+    encoding: 'utf-8',
+    input: [0xfc, 0x80, 0x84, 0x8f, 0xbf, 0xbf],
+    name: 'overlong U+10ffff - 6 bytes'
+  },
+
+  // UTf-16 surrogates encoded as code points in UTf-8
+  { encoding: 'utf-8', input: [0xed, 0xa0, 0x80], name: 'lead surrogate' },
+  { encoding: 'utf-8', input: [0xed, 0xb0, 0x80], name: 'trail surrogate' },
+  { encoding: 'utf-8', input: [0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80], name: 'surrogate pair' }
+];

--- a/test/node/release.test.ts
+++ b/test/node/release.test.ts
@@ -50,7 +50,7 @@ const REQUIRED_FILES = [
   'src/utils/number_utils.ts',
   'src/utils/web_byte_utils.ts',
   'src/utils/latin.ts',
-  'src/validate_utf8.ts',
+  'src/parse_utf8.ts',
   'vendor/base64/base64.js',
   'vendor/base64/package.json',
   'vendor/base64/LICENSE-MIT.txt',


### PR DESCRIPTION
### Description
Outside of web, our `toUtf8` function was insufficiently strict and allowed overlong encodings. 

#### What is changing?
Change our functionality to use  js`TextDecoder` to double check utf8 input when a replacement character is detected. 

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
Drivers wide initiative to make UTF-8 validation strict and consistent. 

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

<!-- RELEASE_HIGHLIGHT_START -->

### UTF-8 validation now throws a `BSONError` on overlong encodings in Node.js
Specifically, this affects `deserialize` when utf8 validation is enabled, which is the default.

An overlong encoding is when the number of bytes in an encoding is inflated by padding the code point with leading 0s ([see here for more information](https://en.wikipedia.org/wiki/UTF-8#Overlong_encodings)).

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
