### PR TITLE
fix(NODE-6144): Long.fromString incorrectly coerces valid inputs to Long.ZERO in special cases

### DIFF
--- a/src/long.ts
+++ b/src/long.ts
@@ -406,7 +406,11 @@ export class Long extends BSONValue {
       unsigned = !!unsignedOrRadix;
     }
     radix ??= 10;
-    if (str === 'NaN' || str === 'Infinity' || str === '+Infinity' || str === '-Infinity') {
+    if (str === 'NaN' && radix < 24) {
+      // radix does not support n, so coerce to zero
+      return Long.ZERO;
+    } else if ((str === 'Infinity' || str === '+Infinity' || str === '-Infinity') && radix < 35) {
+      // radix does not support y, so coerce to zero
       return Long.ZERO;
     }
     return Long._fromString(str, unsigned, radix);

--- a/src/long.ts
+++ b/src/long.ts
@@ -371,12 +371,28 @@ export class Long extends BSONValue {
 
   /**
    * Returns a signed Long representation of the given string, written using radix 10.
+   *
+   * If the input string is empty, this function will throw a BSONError.
+   *
+   * If input string does not have valid signed 64-bit Long representation, this method will return a coerced value:
+   * - inputs that overflow 64-bit signed long will be coerced to Long.MAX_VALUE and Long.MIN_VALUE respectively
+   * - 'NaN' or '+/-Infinity' are coerced to Long.ZERO
+   * - other invalid characters sequences have variable behavior
+   *
    * @param str - The textual representation of the Long
    * @returns The corresponding Long value
    */
   static fromString(str: string): Long;
   /**
-   * Returns a signed Long representation of the given string, written using radix 10.
+   * Returns a signed Long representation of the given string, written using the provided radix.
+   *
+   * If the input string is empty or a provided radix is not within (2-36), this function will throw a BSONError.
+   *
+   * If input parameters do not have valid signed 64-bit Long representation, this method will return a coerced value:
+   * - inputs that overflow 64-bit signed long will be coerced to Long.MAX_VALUE and Long.MIN_VALUE respectively
+   * - if the radix is less than 24, 'NaN' is coerced to Long.ZERO
+   * - if the radix is less than 35, '+/-Infinity' inputs are coerced to Long.ZERO
+   * - other invalid characters sequences have variable behavior
    * @param str - The textual representation of the Long
    * @param radix - The radix in which the text is written (2-36), defaults to 10
    * @returns The corresponding Long value
@@ -384,6 +400,14 @@ export class Long extends BSONValue {
   static fromString(str: string, radix?: number): Long;
   /**
    * Returns a Long representation of the given string, written using radix 10.
+   *
+   * If the input string is empty, this function will throw a BSONError.
+   *
+   * If input parameters do not have a valid 64-bit Long representation, this method will return a coerced value:
+   * - inputs that overflow 64-bit long will be coerced to max or min (if signed) values
+   * - if the radix is less than 24, 'NaN' is coerced to Long.ZERO
+   * - if the radix is less than 35, '+/-Infinity' inputs are coerced to Long.ZERO
+   * - other invalid characters sequences have variable behavior
    * @param str - The textual representation of the Long
    * @param unsigned - Whether unsigned or not, defaults to signed
    * @returns The corresponding Long value
@@ -391,6 +415,14 @@ export class Long extends BSONValue {
   static fromString(str: string, unsigned?: boolean): Long;
   /**
    * Returns a Long representation of the given string, written using the specified radix.
+   *
+   * If the input string is empty or a provided radix is not within (2-36), this function will throw a BSONError.
+   *
+   * If input parameters do not have a valid 64-bit Long representation, this method will return a coerced value:
+   * - inputs that overflow 64-bit long will be coerced to max or min (if signed) values
+   * - if the radix is less than 24, 'NaN' is coerced to Long.ZERO
+   * - if the radix is less than 35, '+/-Infinity' inputs are coerced to Long.ZERO
+   * - other invalid characters sequences have variable behavior
    * @param str - The textual representation of the Long
    * @param unsigned - Whether unsigned or not, defaults to signed
    * @param radix - The radix in which the text is written (2-36), defaults to 10

--- a/test/node/long.test.ts
+++ b/test/node/long.test.ts
@@ -172,10 +172,14 @@ describe('Long', function () {
       radix: number | undefined,
       expectedStr?: string
     ][] = [
-      ['Infinity', 'Infinity', false, 34, '0'],
-      ['-Infinity', '-Infinity', false, 23, '0'],
-      ['+Infinity', '+Infinity', false, 12, '0'],
-      ['NaN', 'NaN', false, 16, '0']
+      ['radix 36 Infinity', 'Infinity', false, 36],
+      ['radix 36 -Infinity', '-Infinity', false, 36],
+      ['radix 36 +Infinity', '+Infinity', false, 36, 'infinity'],
+      ['radix < 35 Infinity', 'Infinity', false, 34, '0'],
+      ['radix < 35 -Infinity', '-Infinity', false, 23, '0'],
+      ['radix < 35 +Infinity', '+Infinity', false, 12, '0'],
+      ['radix < 24 NaN', 'NaN', false, 16, '0'],
+      ['radix > 24 NaN', 'NaN', false, 25]
     ];
 
     for (const [testName, str, unsigned, radix, expectedStr] of successInputs) {

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -1,6 +1,7 @@
 import * as BSON from '../../register-bson';
 import { expect } from 'chai';
-import { bufferFromHexArray } from '../tools/utils';
+import { bufferFromHexArray, int32LEToHex } from '../tools/utils';
+import { utf8WebPlatformSpecTests } from '../data/utf8_wpt_error_cases';
 
 describe('deserializer()', () => {
   describe('when the fieldsAsRaw options is present and has a value that corresponds to a key in the object', () => {
@@ -57,5 +58,47 @@ describe('deserializer()', () => {
       );
       expect(resultCodeWithScope).to.have.deep.nested.property('a.scope', { b: true });
     });
+  });
+  describe('utf8 validation', () => {
+    for (const test of utf8WebPlatformSpecTests) {
+      const inputStringSize = int32LEToHex(test.input.length + 1); // int32 size of string
+      const inputHexString = Buffer.from(test.input).toString('hex');
+      const buffer = bufferFromHexArray([
+        '02', // string
+        '6100', // 'a' key with null terminator
+        inputStringSize,
+        inputHexString,
+        '00'
+      ]);
+      context(`when utf8 validation is on and input is ${test.name}`, () => {
+        it(`throws error containing 'Invalid UTF-8'`, () => {
+          // global case
+          expect(() => BSON.deserialize(buffer, { validation: { utf8: true } })).to.throw(
+            BSON.BSONError,
+            /Invalid UTF-8 string in BSON document/i
+          );
+
+          // specific case
+          expect(() => BSON.deserialize(buffer, { validation: { utf8: { a: true } } })).to.throw(
+            BSON.BSONError,
+            /Invalid UTF-8 string in BSON document/i
+          );
+        });
+      });
+
+      context(`when utf8 validation is off and input is ${test.name}`, () => {
+        it('returns a string containing at least 1 replacement character', () => {
+          // global case
+          expect(BSON.deserialize(buffer, { validation: { utf8: false } }))
+            .to.have.property('a')
+            .that.includes('\uFFFD');
+
+          // specific case
+          expect(BSON.deserialize(buffer, { validation: { utf8: { a: false } } }))
+            .to.have.property('a')
+            .that.includes('\uFFFD');
+        });
+      });
+    }
   });
 });

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -1,7 +1,6 @@
 import * as BSON from '../../register-bson';
 import { expect } from 'chai';
-import { bufferFromHexArray, int32LEToHex } from '../tools/utils';
-import { utf8WebPlatformSpecTests } from '../data/utf8_wpt_error_cases';
+import { bufferFromHexArray } from '../tools/utils';
 
 describe('deserializer()', () => {
   describe('when the fieldsAsRaw options is present and has a value that corresponds to a key in the object', () => {
@@ -58,48 +57,5 @@ describe('deserializer()', () => {
       );
       expect(resultCodeWithScope).to.have.deep.nested.property('a.scope', { b: true });
     });
-  });
-
-  describe('utf8 validation', () => {
-    for (const test of utf8WebPlatformSpecTests) {
-      const inputStringSize = int32LEToHex(test.input.length + 1); // int32 size of string
-      const inputHexString = Buffer.from(test.input).toString('hex');
-      const buffer = bufferFromHexArray([
-        '02', // string
-        '6100', // 'a' key with null terminator
-        inputStringSize,
-        inputHexString,
-        '00'
-      ]);
-      context(`when utf8 validation is on and input is ${test.name}`, () => {
-        it(`throws error containing 'Invalid UTF-8'`, () => {
-          // global case
-          expect(() => BSON.deserialize(buffer, { validation: { utf8: true } })).to.throw(
-            BSON.BSONError,
-            /Invalid UTF-8 string in BSON document/i
-          );
-
-          // specific case
-          expect(() => BSON.deserialize(buffer, { validation: { utf8: { a: true } } })).to.throw(
-            BSON.BSONError,
-            /Invalid UTF-8 string in BSON document/i
-          );
-        });
-      });
-
-      context(`when utf8 validation is off and input is ${test.name}`, () => {
-        it('returns a string containing at least 1 replacement character', () => {
-          // global case
-          expect(BSON.deserialize(buffer, { validation: { utf8: false } }))
-            .to.have.property('a')
-            .that.includes('\uFFFD');
-
-          // specific case
-          expect(BSON.deserialize(buffer, { validation: { utf8: { a: false } } }))
-            .to.have.property('a')
-            .that.includes('\uFFFD');
-        });
-      });
-    }
   });
 });

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -59,6 +59,7 @@ describe('deserializer()', () => {
       expect(resultCodeWithScope).to.have.deep.nested.property('a.scope', { b: true });
     });
   });
+
   describe('utf8 validation', () => {
     for (const test of utf8WebPlatformSpecTests) {
       const inputStringSize = int32LEToHex(test.input.length + 1); // int32 size of string


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `Long.fromString` takes radix into account before coercing '+/-Infinity' and 'NaN' to `Long.ZERO`
`Long.fromString` no longer coerces the following cases to `Long.ZERO` when the provided radix supports all characters in the string:
- `'+Infinity'`, `'-Infinity'`, or `'Infinity'` when 35 <= radix  <= 36
- `'NaN'` when 24 <= radix  <= 36

``` typescript
// when writing in radix 27, 'n' and 'a' are valid characters, so 'NaN' represents the decimal number 17060
Long.fromString('NaN', 27); // new Long(17060)
Long.fromString('NaN', 10); // new Long(0) <-- Since 'NaN' is not a valid input in base 10, it gets coerced to Long.ZERO
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
