### PR TITLE
perf(NODE-6126): improve Long.fromBigInt performance

### DIFF
--- a/src/long.ts
+++ b/src/long.ts
@@ -166,20 +166,17 @@ export class Long extends BSONValue {
     unsigned?: boolean
   ) {
     super();
-    unsigned = typeof highOrUnsigned === 'boolean' ? highOrUnsigned : !!unsigned;
+    unsigned = typeof highOrUnsigned === 'boolean' ? highOrUnsigned : Boolean(unsigned);
     const high = typeof highOrUnsigned === 'number' ? highOrUnsigned : 0;
-    if (typeof lowOrValue === 'bigint') {
-      const longFromBigInt = Long.fromBigInt(lowOrValue, unsigned);
-      this.low = longFromBigInt.low;
-      this.high = longFromBigInt.high;
-      this.unsigned = longFromBigInt.unsigned;
-    } else if (typeof lowOrValue === 'string') {
-      Object.assign(this, Long.fromString(lowOrValue, unsigned));
-    } else {
-      this.low = lowOrValue | 0;
-      this.high = high | 0;
-      this.unsigned = !!unsigned;
-    }
+    const res =
+      typeof lowOrValue === 'string'
+        ? Long.fromString(lowOrValue, unsigned)
+        : typeof lowOrValue === 'bigint'
+          ? Long.fromBigInt(lowOrValue, unsigned)
+          : { low: lowOrValue | 0, high: high | 0, unsigned };
+    this.low = res.low;
+    this.high = res.high;
+    this.unsigned = res.unsigned;
   }
 
   static TWO_PWR_24 = Long.fromInt(TWO_PWR_24_DBL);

--- a/src/long.ts
+++ b/src/long.ts
@@ -243,7 +243,20 @@ export class Long extends BSONValue {
    * @returns The corresponding Long value
    */
   static fromBigInt(value: bigint, unsigned?: boolean): Long {
-    return Long.fromString(value.toString(), unsigned);
+    const byteStr = value.toString(16);
+    const isNeg = byteStr[0] === '-';
+    const startIndex = isNeg ? 1 : 0;
+    const lowByteString =
+      byteStr.length - startIndex > 8
+        ? byteStr.substring(byteStr.length - 8, byteStr.length)
+        : isNeg
+          ? byteStr.slice(1)
+          : byteStr;
+    const highByteString =
+      byteStr.length - startIndex > 8 ? byteStr.substring(startIndex, byteStr.length - 8) : 0;
+    return isNeg
+      ? new Long(Number('0x' + lowByteString), Number('0x' + highByteString), unsigned).neg()
+      : new Long(Number('0x' + lowByteString), Number('0x' + highByteString), unsigned);
   }
 
   /**

--- a/src/long.ts
+++ b/src/long.ts
@@ -119,17 +119,17 @@ export class Long extends BSONValue {
   /**
    * The high 32 bits as a signed value.
    */
-  high!: number;
+  high: number;
 
   /**
    * The low 32 bits as a signed value.
    */
-  low!: number;
+  low: number;
 
   /**
    * Whether unsigned or not.
    */
-  unsigned!: boolean;
+  unsigned: boolean;
 
   /**
    * Constructs a 64 bit two's-complement integer, given its low and high 32 bit values as *signed* integers.
@@ -149,13 +149,6 @@ export class Long extends BSONValue {
   /**
    * Constructs a 64 bit two's-complement integer, given a string representation.
    *
-   * @param value - 32 bit number representation of the Long
-   * @param unsigned - Whether unsigned or not, defaults to signed
-   */
-  constructor(value: number, unsigned?: boolean);
-  /**
-   * Constructs a 64 bit two's-complement integer, given a string representation.
-   *
    * @param value - String representation of the long value
    * @param unsigned - Whether unsigned or not, defaults to signed
    */
@@ -166,14 +159,14 @@ export class Long extends BSONValue {
     unsigned?: boolean
   ) {
     super();
-    unsigned = typeof highOrUnsigned === 'boolean' ? highOrUnsigned : Boolean(unsigned);
+    const unsignedBool = typeof highOrUnsigned === 'boolean' ? highOrUnsigned : Boolean(unsigned);
     const high = typeof highOrUnsigned === 'number' ? highOrUnsigned : 0;
     const res =
       typeof lowOrValue === 'string'
-        ? Long.fromString(lowOrValue, unsigned)
+        ? Long.fromString(lowOrValue, unsignedBool)
         : typeof lowOrValue === 'bigint'
-          ? Long.fromBigInt(lowOrValue, unsigned)
-          : { low: lowOrValue | 0, high: high | 0, unsigned };
+          ? Long.fromBigInt(lowOrValue, unsignedBool)
+          : { low: lowOrValue | 0, high: high | 0, unsigned: unsignedBool };
     this.low = res.low;
     this.high = res.high;
     this.unsigned = res.unsigned;
@@ -1085,6 +1078,7 @@ export class Long extends BSONValue {
   /** Converts the Long to a BigInt (arbitrary precision). */
   toBigInt(): bigint {
     // eslint-disable-next-line no-restricted-globals -- This is allowed here as it is explicitly requesting a bigint
+
     return BigInt(this.toString());
   }
 

--- a/src/long.ts
+++ b/src/long.ts
@@ -243,13 +243,8 @@ export class Long extends BSONValue {
    * @returns The corresponding Long value
    */
   static fromBigInt(value: bigint, unsigned?: boolean): Long {
-    /* eslint-disable no-bigint-usage/no-bigint-literals */
-    const bit32Mask = 0xffffffffn;
-
-    const lowBits = value & bit32Mask;
-    const highBits = (value >> 32n) & bit32Mask;
-    /* eslint-enable no-bigint-usage/no-bigint-literals */
-    return new Long(Number(lowBits), Number(highBits), unsigned);
+    // eslint-disable-next-line no-bigint-usage/no-bigint-literals
+    return new Long(Number(value & 0xffffffffn), Number((value >> 32n) & 0xffffffffn), unsigned);
   }
 
   /**

--- a/src/long.ts
+++ b/src/long.ts
@@ -1078,7 +1078,6 @@ export class Long extends BSONValue {
   /** Converts the Long to a BigInt (arbitrary precision). */
   toBigInt(): bigint {
     // eslint-disable-next-line no-restricted-globals -- This is allowed here as it is explicitly requesting a bigint
-
     return BigInt(this.toString());
   }
 

--- a/src/long.ts
+++ b/src/long.ts
@@ -177,6 +177,17 @@ export class Long extends BSONValue {
   static MIN_VALUE = Long.fromBits(0, 0x80000000 | 0, false);
 
   /**
+   * @internal
+   * bit mask used for fromBigInt method, lazy loaded
+   */
+  static FROM_BIGINT_BIT_MASK: bigint;
+
+  /**
+   * @internal
+   * bit shift used for fromBigInt method, lazy loaded */
+  static FROM_BIGINT_BIT_SHIFT: bigint;
+
+  /**
    * Returns a Long representing the 64 bit integer that comes by concatenating the given low and high bits.
    * Each is assumed to use 32 bits.
    * @param lowBits - The low 32 bits
@@ -243,8 +254,15 @@ export class Long extends BSONValue {
    * @returns The corresponding Long value
    */
   static fromBigInt(value: bigint, unsigned?: boolean): Long {
-    // eslint-disable-next-line no-bigint-usage/no-bigint-literals
-    return new Long(Number(value & 0xffffffffn), Number((value >> 32n) & 0xffffffffn), unsigned);
+    // eslint-disable-next-line no-restricted-globals
+    Long.FROM_BIGINT_BIT_MASK ??= BigInt(0xffffffff);
+    // eslint-disable-next-line no-restricted-globals
+    Long.FROM_BIGINT_BIT_SHIFT ??= BigInt(32);
+    return new Long(
+      Number(value & Long.FROM_BIGINT_BIT_MASK),
+      Number((value >> Long.FROM_BIGINT_BIT_SHIFT) & Long.FROM_BIGINT_BIT_MASK),
+      unsigned
+    );
   }
 
   /**

--- a/src/long.ts
+++ b/src/long.ts
@@ -243,20 +243,13 @@ export class Long extends BSONValue {
    * @returns The corresponding Long value
    */
   static fromBigInt(value: bigint, unsigned?: boolean): Long {
-    const byteStr = value.toString(16);
-    const isNeg = byteStr[0] === '-';
-    const startIndex = isNeg ? 1 : 0;
-    const lowByteString =
-      byteStr.length - startIndex > 8
-        ? byteStr.substring(byteStr.length - 8, byteStr.length)
-        : isNeg
-          ? byteStr.slice(1)
-          : byteStr;
-    const highByteString =
-      byteStr.length - startIndex > 8 ? byteStr.substring(startIndex, byteStr.length - 8) : 0;
-    return isNeg
-      ? new Long(Number('0x' + lowByteString), Number('0x' + highByteString), unsigned).neg()
-      : new Long(Number('0x' + lowByteString), Number('0x' + highByteString), unsigned);
+    /* eslint-disable no-bigint-usage/no-bigint-literals */
+    const bit32Mask = 0xffffffffn;
+
+    const lowBits = value & bit32Mask;
+    const highBits = (value >> 32n) & bit32Mask;
+    /* eslint-enable no-bigint-usage/no-bigint-literals */
+    return new Long(Number(lowBits), Number(highBits), unsigned);
   }
 
   /**

--- a/test/node/bson_type_classes.test.ts
+++ b/test/node/bson_type_classes.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { inspect } from 'node:util';
-import { __isWeb__ } from '../register-bson';
+import { __isWeb__, __noBigInt__ } from '../register-bson';
 import {
   Binary,
   BSONRegExp,
@@ -44,7 +44,7 @@ const BSONTypeClassCtors = new Map<string, () => BSONValue>([
   ['Decimal128', () => new Decimal128('1.23')],
   ['Double', () => new Double(1.23)],
   ['Int32', () => new Int32(1)],
-  ['Long', () => new Long(1n)],
+  ['Long', () => (__noBigInt__ ? new Long(1) : new Long(1n))],
   ['MinKey', () => new MinKey()],
   ['MaxKey', () => new MaxKey()],
   ['ObjectId', () => new ObjectId('00'.repeat(12))],

--- a/test/node/long.test.ts
+++ b/test/node/long.test.ts
@@ -17,14 +17,15 @@ describe('Long', function () {
   it('accepts BigInts in Long constructor', function () {
     if (__noBigInt__) {
       this.currentTest?.skip();
+    } else {
+      expect(new Long(0n).toString()).to.equal('0');
+      expect(new Long(-1n).toString()).to.equal('-1');
+      expect(new Long(-1n, true).toString()).to.equal('18446744073709551615');
+      expect(new Long(123456789123456789n).toString()).to.equal('123456789123456789');
+      expect(new Long(123456789123456789n, true).toString()).to.equal('123456789123456789');
+      expect(new Long(13835058055282163712n).toString()).to.equal('-4611686018427387904');
+      expect(new Long(13835058055282163712n, true).toString()).to.equal('13835058055282163712');
     }
-    expect(new Long(0n).toString()).to.equal('0');
-    expect(new Long(-1n).toString()).to.equal('-1');
-    expect(new Long(-1n, true).toString()).to.equal('18446744073709551615');
-    expect(new Long(123456789123456789n).toString()).to.equal('123456789123456789');
-    expect(new Long(123456789123456789n, true).toString()).to.equal('123456789123456789');
-    expect(new Long(13835058055282163712n).toString()).to.equal('-4611686018427387904');
-    expect(new Long(13835058055282163712n, true).toString()).to.equal('13835058055282163712');
   });
 
   describe('static fromExtendedJSON()', function () {
@@ -190,6 +191,12 @@ describe('Long', function () {
       ['max int32 unsigned', BigInt(BSON_INT32_MAX), true, BSON_INT32_MAX.toString(10)],
       ['min int32', BigInt(BSON_INT32_MIN), false, BSON_INT32_MIN.toString(10)]
     ];
+
+    beforeEach(function () {
+      if (__noBigInt__) {
+        this.currentTest?.skip();
+      }
+    });
 
     for (const [testName, num, unsigned, expectedStr] of inputs) {
       context(`when the input is ${testName}`, () => {

--- a/test/node/long.test.ts
+++ b/test/node/long.test.ts
@@ -171,25 +171,30 @@ describe('Long', function () {
       name: string,
       input: bigint,
       unsigned: boolean | undefined,
-      expectedStr?: string
+      expectedLong?: Long
     ][] = [
-      ['0', BigInt('0'), false, '0'],
-      ['-0 (bigint coerces this to 0)', BigInt('-0'), false, '0'],
+      ['0', BigInt('0'), false, Long.ZERO],
+      ['-0 (bigint coerces this to 0)', BigInt('-0'), false, Long.ZERO],
       [
         'max unsigned input',
         BigInt(Long.MAX_UNSIGNED_VALUE.toString(10)),
         true,
-        Long.MAX_UNSIGNED_VALUE.toString(10)
+        Long.MAX_UNSIGNED_VALUE
       ],
-      ['max signed input', BigInt(Long.MAX_VALUE.toString(10)), false, Long.MAX_VALUE.toString(10)],
-      ['min signed input', BigInt(Long.MIN_VALUE.toString(10)), false, Long.MIN_VALUE.toString(10)],
-      ['negative greater than 32 bits', BigInt(-9228915101), false, '-9228915101'],
-      ['less than 32 bits', BigInt(245666), false, '245666'],
-      ['unsigned less than 32 bits', BigInt(245666), true, '245666'],
-      ['negative less than 32 bits', BigInt(-245666), false, '-245666'],
-      ['max int32', BigInt(BSON_INT32_MAX), false, BSON_INT32_MAX.toString(10)],
-      ['max int32 unsigned', BigInt(BSON_INT32_MAX), true, BSON_INT32_MAX.toString(10)],
-      ['min int32', BigInt(BSON_INT32_MIN), false, BSON_INT32_MIN.toString(10)]
+      ['max signed input', BigInt(Long.MAX_VALUE.toString(10)), false, Long.MAX_VALUE],
+      ['min signed input', BigInt(Long.MIN_VALUE.toString(10)), false, Long.MIN_VALUE],
+      [
+        'negative greater than 32 bits',
+        BigInt(-9228915101),
+        false,
+        Long.fromBits(0xd9e9ee63, 0xfffffffd)
+      ],
+      ['less than 32 bits', BigInt(245666), false, new Long(245666)],
+      ['unsigned less than 32 bits', BigInt(245666), true, new Long(245666, true)],
+      ['negative less than 32 bits', BigInt(-245666), false, new Long(-245666, -1)],
+      ['max int32', BigInt(BSON_INT32_MAX), false, new Long(BSON_INT32_MAX)],
+      ['max int32 unsigned', BigInt(BSON_INT32_MAX), true, new Long(BSON_INT32_MAX, 0, true)],
+      ['min int32', BigInt(BSON_INT32_MIN), false, new Long(BSON_INT32_MIN, -1)]
     ];
 
     beforeEach(function () {
@@ -198,10 +203,10 @@ describe('Long', function () {
       }
     });
 
-    for (const [testName, num, unsigned, expectedStr] of inputs) {
+    for (const [testName, num, unsigned, expectedLong] of inputs) {
       context(`when the input is ${testName}`, () => {
         it(`should return a Long representation of the input`, () => {
-          expect(Long.fromBigInt(num, unsigned).toString(10)).to.equal(expectedStr);
+          expect(Long.fromBigInt(num, unsigned)).to.deep.equal(expectedLong);
         });
       });
     }

--- a/test/node/long.test.ts
+++ b/test/node/long.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { Long, BSONError, __noBigInt__ } from '../register-bson';
+import { BSON_INT32_MAX, BSON_INT32_MIN } from '../../src/constants';
 
 describe('Long', function () {
   it('accepts strings in the constructor', function () {
@@ -162,6 +163,41 @@ describe('Long', function () {
         });
       });
     });
+  });
+
+  describe('static fromBigInt()', function () {
+    const inputs: [
+      name: string,
+      input: bigint,
+      unsigned: boolean | undefined,
+      expectedStr?: string
+    ][] = [
+      ['0', BigInt('0'), false, '0'],
+      ['-0 (bigint coerces this to 0)', BigInt('-0'), false, '0'],
+      [
+        'max unsigned input',
+        BigInt(Long.MAX_UNSIGNED_VALUE.toString(10)),
+        true,
+        Long.MAX_UNSIGNED_VALUE.toString(10)
+      ],
+      ['max signed input', BigInt(Long.MAX_VALUE.toString(10)), false, Long.MAX_VALUE.toString(10)],
+      ['min signed input', BigInt(Long.MIN_VALUE.toString(10)), false, Long.MIN_VALUE.toString(10)],
+      ['negative greater than 32 bits', BigInt(-9228915101), false, '-9228915101'],
+      ['less than 32 bits', BigInt(245666), false, '245666'],
+      ['unsigned less than 32 bits', BigInt(245666), true, '245666'],
+      ['negative less than 32 bits', BigInt(-245666), false, '-245666'],
+      ['max int32', BigInt(BSON_INT32_MAX), false, BSON_INT32_MAX.toString(10)],
+      ['max int32 unsigned', BigInt(BSON_INT32_MAX), true, BSON_INT32_MAX.toString(10)],
+      ['min int32', BigInt(BSON_INT32_MIN), false, BSON_INT32_MIN.toString(10)]
+    ];
+
+    for (const [testName, num, unsigned, expectedStr] of inputs) {
+      context(`when the input is ${testName}`, () => {
+        it(`should return a Long representation of the input`, () => {
+          expect(Long.fromBigInt(num, unsigned).toString(10)).to.equal(expectedStr);
+        });
+      });
+    }
   });
 
   describe('static fromString()', function () {

--- a/test/node/timestamp.test.ts
+++ b/test/node/timestamp.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as BSON from '../register-bson';
-import { Timestamp } from '../register-bson';
+import { Timestamp, __noBigInt__ } from '../register-bson';
 
 describe('Timestamp', () => {
   describe('static MAX_VALUE', () => {
@@ -10,11 +10,14 @@ describe('Timestamp', () => {
   });
 
   it('should always be an unsigned value', () => {
+    let bigIntInputs: Timestamp[] = [];
+    if (!__noBigInt__) {
+      bigIntInputs = [new BSON.Timestamp(0xffffffffffn), new BSON.Timestamp(0xffffffffffffffffn)];
+    }
     const table = [
       // @ts-expect-error: Not advertized by the types, but constructs a 0 timestamp
       new BSON.Timestamp(),
-      new BSON.Timestamp(0xffffffffffn),
-      new BSON.Timestamp(0xffffffffffffffffn),
+      ...bigIntInputs,
       new BSON.Timestamp(new BSON.Long(0xffff_ffff, 0xffff_ffff, false)),
       new BSON.Timestamp(new BSON.Long(0xffff_ffff, 0xffff_ffff, true)),
       new BSON.Timestamp({ t: 0xffff_ffff, i: 0xffff_ffff }),
@@ -29,22 +32,29 @@ describe('Timestamp', () => {
   });
 
   context('output formats', () => {
-    const timestamp = new BSON.Timestamp(0xffffffffffffffffn);
+    beforeEach(function () {
+      if (__noBigInt__) {
+        this.currentTest?.skip();
+      }
+    });
 
     context('when converting toString', () => {
       it('exports an unsigned number', () => {
+        const timestamp = new BSON.Timestamp(0xffffffffffffffffn);
         expect(timestamp.toString()).to.equal('18446744073709551615');
       });
     });
 
     context('when converting toJSON', () => {
       it('exports an unsigned number', () => {
+        const timestamp = new BSON.Timestamp(0xffffffffffffffffn);
         expect(timestamp.toJSON()).to.deep.equal({ $timestamp: '18446744073709551615' });
       });
     });
 
     context('when converting toExtendedJSON', () => {
       it('exports an unsigned number', () => {
+        const timestamp = new BSON.Timestamp(0xffffffffffffffffn);
         expect(timestamp.toExtendedJSON()).to.deep.equal({
           $timestamp: { t: 4294967295, i: 4294967295 }
         });


### PR DESCRIPTION
### Description
Refactor `Long.fromBigInt` to only use bit math, and refactor the `Long` constructor to have cleaner logic + remove `Object.assign` calls

#### What is changing?
Improve performance of `Long.fromBigInt`

##### Is there new documentation needed for these changes?
No.

#### What is the motivation for this change?
Use a more efficient algorithm for `Long.fromBigInt`

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Optimize performance of `Long.fromBigInt`

Internally fromBigInt was originally implemented using toString of the bigint value. Now, `Long.fromBigInt` has been refactored to use bitwise operations greatly improving performance.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
