### PR TITLE
feat(NODE-6156): Sign Release Artifacts

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,3 +13,9 @@ runs:
       shell: bash
     - run: npm clean-install
       shell: bash
+    - uses: drivers-github-tools/garasign/setup/action.yml
+      with: 
+        garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+        garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+        artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
+        artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,6 @@ runs:
       shell: bash
     - run: npm clean-install
       shell: bash
-    - uses: mongodb-labs/drivers-github-tools/garasign/setup@main
       with: 
         garasign_username: 'aditi.khare' #${{ secrets.GRS_CONFIG_USER1_USERNAME }}
         garasign_password: 'passwordabc' #${{ secrets.GRS_CONFIG_USER1_PASSWORD }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ description: 'Installs node, driver dependencies, and builds source'
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
         cache: 'npm'
@@ -13,8 +13,3 @@ runs:
       shell: bash
     - run: npm clean-install
       shell: bash
-      with: 
-        garasign_username: 'aditi.khare' #${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-        garasign_password: 'passwordabc' #${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-        artifactory_username: 'username' #${{ secrets.ARTIFACTORY_USER }}
-        artifactory_password: 'password123' #${{ secrets.ARTIFACTORY_PASSWORD }}  

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
     - run: npm clean-install
       shell: bash
-    - uses: drivers-github-tools/garasign/setup/action.yml
+    - uses: mongodb-labs/drivers-github-tools/setup/git-sign@main
       with: 
         garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
         garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
     - uses: mongodb-labs/drivers-github-tools/garasign/setup@main
       with: 
-        garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-        garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-        artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-        artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        garasign_username: 'aditi.khare' #${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+        garasign_password: 'passwordabc' #${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+        artifactory_username: 'username' #${{ secrets.ARTIFACTORY_USER }}
+        artifactory_password: 'password123' #${{ secrets.ARTIFACTORY_PASSWORD }}  

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
     - run: npm clean-install
       shell: bash
-    - uses: mongodb-labs/drivers-github-tools/setup/git-sign@main
+    - uses: mongodb-labs/drivers-github-tools/garasign/setup@main
       with: 
         garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
         garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}

--- a/.github/workflows/create-sign-and-commit-tarball.sh
+++ b/.github/workflows/create-sign-and-commit-tarball.sh
@@ -11,10 +11,8 @@ echo "Create release tarball"
 npm pack
 echo package version: $PACKAGE_VERSION
 echo gpg key id: $GPG_KEY_ID
-# mv "bson-${PACKAGE_VERSION}.tgz" "bson-${PACKAGE_VERSION}.tgz.${GPG_KEY_ID}"
-
-# git add .
+mv "bson-${PACKAGE_VERSION}.tgz" "bson-${PACKAGE_VERSION}.tgz.${GPG_KEY_ID}"
 
 # Create signed "Package x.y.z" commit
 echo "Create package commit"
-# git commit -m "Package ${PACKAGE_VERSION}" -s --gpg-sign=${GPG_KEY_ID} 
+git commit -m "Package ${PACKAGE_VERSION}" -s --gpg-sign=${GPG_KEY_ID} 

--- a/.github/workflows/create-sign-and-commit-tarball.sh
+++ b/.github/workflows/create-sign-and-commit-tarball.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+PACKAGE_VERSION=$1
+GPG_KEY_ID=$2
+
+gpgloader
+
+# Create signed "Release x.y.z" tarball
+echo "Create release tarball"
+npm pack
+mv "bson-${PACKAGE_VERSION}.tgz" "bson-${PACKAGE_VERSION}.tgz.${GPG_KEY_ID}"
+
+git add .
+
+# Create signed "Package x.y.z" commit
+echo "Create package commit"
+git commit -m "Package ${PACKAGE_VERSION}" -s --gpg-sign=${GPG_KEY_ID} 

--- a/.github/workflows/create-sign-and-commit-tarball.sh
+++ b/.github/workflows/create-sign-and-commit-tarball.sh
@@ -9,10 +9,12 @@ gpgloader
 # Create signed "Release x.y.z" tarball
 echo "Create release tarball"
 npm pack
-mv "bson-${PACKAGE_VERSION}.tgz" "bson-${PACKAGE_VERSION}.tgz.${GPG_KEY_ID}"
+echo package version: $PACKAGE_VERSION
+echo gpg key id: $GPG_KEY_ID
+# mv "bson-${PACKAGE_VERSION}.tgz" "bson-${PACKAGE_VERSION}.tgz.${GPG_KEY_ID}"
 
-git add .
+# git add .
 
 # Create signed "Package x.y.z" commit
 echo "Create package commit"
-git commit -m "Package ${PACKAGE_VERSION}" -s --gpg-sign=${GPG_KEY_ID} 
+# git commit -m "Package ${PACKAGE_VERSION}" -s --gpg-sign=${GPG_KEY_ID} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
   
 
       - if: true
-        run: echo '$MY_SECRETS'
+        run: echo '$garasign_username'
       # If release-please created a release, publish to npm
       - if: true  
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
   
 
       - if: true
-        run: echo '$garasign_username'
+        run: echo $garasign_username
       # If release-please created a release, publish to npm
       - if: true  
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       # If release-please created a release, publish to npm
       - if: true
-        run: echo 'secrets printing nowwww' ${{ secrets.NPM_TOKEN }} ${{ secrets.GRS_CONFIG_USER1_USERNAME }}  ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}  ${{ secrets.ARTIFACTORY_USER }}  ${{ secrets.ARTIFACTORY_PASSWORD }} 
+        run: echo 'secrets printing nowwww  ${{ secrets.NPM_TOKEN }}'
       - if: true  
         uses: actions/checkout@v3
       - if: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,6 @@ name: release
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    env:
-        garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-        garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-        artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-        artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v3
@@ -30,10 +25,10 @@ jobs:
           pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
           changelog-path: HISTORY.md
           default-branch: main     
-  
 
       - if: true
-        run: echo $garasign_username
+        # prints nothing atm :(
+        run: echo $secrets.GRS_CONFIG_USER1_USERNAME
       # If release-please created a release, publish to npm
       - if: true  
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ name: release
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    env:
+          MY_SECRETS: ${{ secrets }}
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v3
@@ -27,10 +29,6 @@ jobs:
           default-branch: main     
   
 
-      - if: true
-        run: echo 'abt to set secrets'
-        env:
-          MY_SECRETS: ${{ secrets }}
       - if: true
         run: echo '$MY_SECRETS'
       # If release-please created a release, publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
 
       # If release-please created a release, publish to npm
       - if: true
+        run: echo 'secrets printing nowwww' ${{ secrets }}
+      - if: true 
         uses: actions/checkout@v3
       - if: true
         name: actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,5 +44,5 @@ jobs:
       - if: ${{ steps.release.outputs.release_created }}
         run: echo 'done'
         #run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        #env:
+          #NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
           default-branch: main     
 
       # If release-please created a release, publish to npm
-      - if: true
-        run: echo 'secrets printing nowwww  ${{ secrets.NPM_TOKEN }}'
       - if: true  
         uses: actions/checkout@v3
       - if: true
@@ -39,12 +37,12 @@ jobs:
         uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
         with: 
           command: "$(pwd)/.github/workflows/create-sign-and-commit-tarball.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }}"
-          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}  
+          garasign_username: 'aditi.khare' #${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+          garasign_password: 'passwordabc' #${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+          artifactory_username: 'username' #${{ secrets.ARTIFACTORY_USER }}
+          artifactory_password: 'password123' #${{ secrets.ARTIFACTORY_PASSWORD }}  
       - if: true
-        run: echo 'done'
-        #run: npm publish --provenance
-        #env:
+        run: echo 'done!!!!!!!!!!!'
+        # run: npm publish --provenance
+        # env:
           #NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,12 @@ jobs:
           default-branch: main     
 
       # If release-please created a release, publish to npm
+      - if: true
         uses: actions/checkout@v3
+      - if: true
         name: actions/setup
         uses: ./.github/actions/setup
+      - if: true
         name: Create, sign, and commit signed tarball
         uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
         with: 
@@ -38,6 +41,7 @@ jobs:
           garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
           artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
           artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}  
+      - if: true
         run: echo 'done'
         #run: npm publish --provenance
         #env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ jobs:
   
 
       - if: true
+        run: echo 'abt to set secrets'
         env:
           MY_SECRETS: ${{ secrets }}
+      - if: true
         run: echo '$MY_SECRETS'
       # If release-please created a release, publish to npm
       - if: true  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,10 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     env:
-          MY_SECRETS: ${{ secrets }}
+        garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+        garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+        artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
+        artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
     steps:
       - id: release
         uses: google-github-actions/release-please-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,10 @@ jobs:
           pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
           changelog-path: HISTORY.md
           default-branch: main     
-
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  
+      - env:
+        MY_SECRETS: ${{ secrets }}
+      - run: echo MY_SECRETS
       # If release-please created a release, publish to npm
       - if: true  
         uses: actions/checkout@v3
@@ -42,7 +43,7 @@ jobs:
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
           garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
           artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}  
+          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       - if: true
         run: echo 'done!!!!!!!!!!!'
         # run: npm publish --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           changelog-path: HISTORY.md
           default-branch: main     
 
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # If release-please created a release, publish to npm
       - if: true  
         uses: actions/checkout@v3
@@ -44,5 +46,3 @@ jobs:
       - if: true
         run: echo 'done!!!!!!!!!!!'
         # run: npm publish --provenance
-        # env:
-          #NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
 
       # If release-please created a release, publish to npm
       - if: true
-        run: echo 'secrets printing nowwww' ${{ secrets }}
-      - if: true 
+        run: echo 'secrets printing nowwww' ${{ secrets.NPM_TOKEN }} ${{ secrets.GRS_CONFIG_USER1_USERNAME }}  ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}  ${{ secrets.ARTIFACTORY_USER }}  ${{ secrets.ARTIFACTORY_PASSWORD }} 
+      - if: true  
         uses: actions/checkout@v3
       - if: true
         name: actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,29 @@ jobs:
           changelog-path: HISTORY.md
           default-branch: main
 
+      - id: prepare-garasign
+        uses: drivers-github-tools/garasign/setup/action.yml
+        with: 
+          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
+          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}       
+
       # If release-please created a release, publish to npm
       - if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v3
       - if: ${{ steps.release.outputs.release_created }}
         name: actions/setup
         uses: ./.github/actions/setup
+      -  if: ${{ steps.release.outputs.release_created }}
+        name: Create, sign, and commit signed tarball
+        uses: drivers-github-tools/garasign/git-sign/action.yml
+        with: 
+          command: "$(pwd)/.github/workflows/create-sign-and-commit-tarball.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }}"
+          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
+          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}  
       - if: ${{ steps.release.outputs.release_created }}
         run: npm publish --provenance
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/setup
       - if: ${{ steps.release.outputs.release_created }}
         name: Create, sign, and commit signed tarball
-        uses: drivers-github-tools/garasign/git-sign/action.yml
+        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
         with: 
           command: "$(pwd)/.github/workflows/create-sign-and-commit-tarball.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }}"
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,11 @@ jobs:
           changelog-path: HISTORY.md
           default-branch: main     
   
-      - env:
-        MY_SECRETS: ${{ secrets }}
-      - run: echo MY_SECRETS
+
+      - if: true
+        env:
+          MY_SECRETS: ${{ secrets }}
+        run: echo MY_SECRETS
       # If release-please created a release, publish to npm
       - if: true  
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
         uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
         with: 
           command: "$(pwd)/.github/workflows/create-sign-and-commit-tarball.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }}"
-          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          garasign_username: ${{ garasign_username }}
+          garasign_password: ${{ garasign_password }}
+          artifactory_username: ${{ artifactory_username }}
+          artifactory_password: ${{ artifactory_password }}
       - if: true
         run: echo 'done!!!!!!!!!!!'
         # run: npm publish --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - if: true
         env:
           MY_SECRETS: ${{ secrets }}
-        run: echo MY_SECRETS
+        run: echo '$MY_SECRETS'
       # If release-please created a release, publish to npm
       - if: true  
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,9 @@ jobs:
           default-branch: main     
 
       # If release-please created a release, publish to npm
-      - if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v3
-      - if: ${{ steps.release.outputs.release_created }}
         name: actions/setup
         uses: ./.github/actions/setup
-      - if: ${{ steps.release.outputs.release_created }}
         name: Create, sign, and commit signed tarball
         uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
         with: 
@@ -41,7 +38,6 @@ jobs:
           garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
           artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
           artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}  
-      - if: ${{ steps.release.outputs.release_created }}
         run: echo 'done'
         #run: npm publish --provenance
         #env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,6 @@ jobs:
           changelog-path: HISTORY.md
           default-branch: main     
 
-      - if: true
-        # prints nothing atm :(
-        run: echo $secrets.GRS_CONFIG_USER1_USERNAME
       # If release-please created a release, publish to npm
       - if: true  
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,10 @@ jobs:
         uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
         with: 
           command: "$(pwd)/.github/workflows/create-sign-and-commit-tarball.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }}"
-          garasign_username: 'aditi.khare' #${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: 'passwordabc' #${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: 'username' #${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: 'password123' #${{ secrets.ARTIFACTORY_PASSWORD }}  
+          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
+          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}  
       - if: true
         run: echo 'done!!!!!!!!!!!'
         # run: npm publish --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - if: ${{ steps.release.outputs.release_created }}
         name: actions/setup
         uses: ./.github/actions/setup
-      -  if: ${{ steps.release.outputs.release_created }}
+      - if: ${{ steps.release.outputs.release_created }}
         name: Create, sign, and commit signed tarball
         uses: drivers-github-tools/garasign/git-sign/action.yml
         with: 
@@ -42,6 +42,7 @@ jobs:
           artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
           artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}  
       - if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance
+        run: echo 'done'
+        #run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,7 @@ jobs:
           pull-request-title-pattern: 'chore${scope}: release ${version} [skip-ci]'
           pull-request-header: 'Please run the release_notes action before releasing to generate release highlights'
           changelog-path: HISTORY.md
-          default-branch: main
-
-      - id: prepare-garasign
-        uses: drivers-github-tools/garasign/setup/action.yml
-        with: 
-          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
-          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
-          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}       
+          default-branch: main     
 
       # If release-please created a release, publish to npm
       - if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
         uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
         with: 
           command: "$(pwd)/.github/workflows/create-sign-and-commit-tarball.sh ${{ env.PACKAGE_VERSION }} ${{ vars.GPG_KEY_ID }}"
-          garasign_username: ${{ garasign_username }}
-          garasign_password: ${{ garasign_password }}
-          artifactory_username: ${{ artifactory_username }}
-          artifactory_password: ${{ artifactory_password }}
+          garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
+          garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
+          artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
+          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       - if: true
         run: echo 'done!!!!!!!!!!!'
         # run: npm publish --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}
           garasign_password: ${{ secrets.GRS_CONFIG_USER1_PASSWORD }}
           artifactory_username: ${{ secrets.ARTIFACTORY_USER }}
-          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          artifactory_password: ${{ secrets.TEMP_ARTIFACTORY_TOKEN }}
       - if: true
         run: echo 'done!!!!!!!!!!!'
         # run: npm publish --provenance


### PR DESCRIPTION
### Description
Aditi's attempt at signing release artifacts for BSON. The garasign script currently fails when "Writing manifest to image destination" stage is done - likely because I do not have permissions to the default image. 

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
