### PR TITLE
docs(NODE-6235): update release integrity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ You can learn more about it in [the specification](http://bsonspec.org).
 
 ### Release Integrity
 
+Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided packages, download the key and import it using gpg:
+
+```shell
+gpg --import node-driver.asc
+```
+
 The GitHub release contains a detached signature file for the NPM package (named
 `bson-X.Y.Z.tgz.sig`).
 
@@ -29,6 +35,8 @@ To verify the integrity of the downloaded package, run the following command:
 gpg --verify bson-X.Y.Z.tgz.sig bson-X.Y.Z.tgz
 ```
 
+>[!Note]
+No verification is done when using npm to install the package. To ensure release integrity when using npm, download the tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball using `npm install bson-X.Y.Z.tgz`.
 
 ## Bugs / Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ gpg --verify bson-X.Y.Z.tgz.sig bson-X.Y.Z.tgz
 ```
 
 >[!Note]
-No verification is done when using npm to install the package. To ensure release integrity when using npm, download the tarball manually from the GitHub release, verify the signature, then install the package from the downloaded tarball using `npm install bson-X.Y.Z.tgz`.
+No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
 
 ## Bugs / Feature Requests
 


### PR DESCRIPTION
### Description

Updates the release integrity section with links to the GPG key and npm note.

#### What is changing?

README.md

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6235

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
