### PR TITLE
perf(NODE-6246): Significantly improve memory usage and performance of ObjectId

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -83,7 +83,7 @@ export class ObjectId extends BSONValue {
    *
    * @param inputId - A 12 byte binary Buffer.
    */
-  constructor(inputId: Uint8Array);
+  constructor(inputId: Uint8Array, offset?: number);
   /** To generate a new ObjectId, use ObjectId() with no argument. */
   constructor();
   /**
@@ -99,7 +99,7 @@ export class ObjectId extends BSONValue {
    */
   constructor(
     inputId?: string | number | ObjectId | ObjectIdLike | Uint8Array,
-    _internalFlag?: symbol
+    option?: symbol | number
   ) {
     let bufferCache: Uint8Array | undefined;
     super();
@@ -111,7 +111,7 @@ export class ObjectId extends BSONValue {
       }
       if ('toHexString' in inputId && typeof inputId.toHexString === 'function') {
         workingId = inputId.toHexString();
-        _internalFlag = OID_SKIP_VALIDATE;
+        option = OID_SKIP_VALIDATE;
       } else {
         workingId = inputId.id;
       }
@@ -121,7 +121,7 @@ export class ObjectId extends BSONValue {
 
     // The following cases use workingId to construct an ObjectId
     if (typeof workingId === 'string') {
-      if (_internalFlag === OID_SKIP_VALIDATE) {
+      if (option === OID_SKIP_VALIDATE) {
         this.__id = workingId;
       } else {
         const validString = ObjectId.validateHexString(workingId);
@@ -137,10 +137,11 @@ export class ObjectId extends BSONValue {
       // The most common use case (blank id, new objectId instance)
       // Generate a new id
       this.__id = ObjectId.generate(typeof workingId === 'number' ? workingId : undefined);
-    } else if (ArrayBuffer.isView(workingId) && workingId.byteLength === 12) {
+    } else if (ArrayBuffer.isView(workingId)) {
       // If intstanceof matches we can escape calling ensure buffer in Node.js environments
       bufferCache = ByteUtils.toLocalBufferType(workingId);
-      this.__id = ByteUtils.toHex(bufferCache);
+      const offset = (option as number) || 0;
+      this.__id = ByteUtils.toHex(bufferCache, offset, offset + 12);
     } else {
       throw new BSONError('Argument passed in does not match the accepted types');
     }

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -40,7 +40,10 @@ export class ObjectId extends BSONValue {
   /** @deprecated Hex string is always cached */
   static cacheHexString: boolean;
 
-  /** Cache buffer internally, Uses much more memory but can speed up performance of some operations like getTimestamp */
+  /**
+   * Cache buffer internally
+   * Uses much more memory but can speed up performance if performing lots of buffer specific tasks
+   */
   static cacheBuffer: boolean;
 
   /** ObjectId Bytes @internal */
@@ -278,11 +281,7 @@ export class ObjectId extends BSONValue {
 
   /** Returns the generation date (accurate up to the second) that this ID was generated. */
   getTimestamp(): Date {
-    const buffer = this.buffer || ByteUtils.fromHex(this.__id);
-    const timestamp = new Date();
-    const time = NumberUtils.getUint32BE(buffer, 0);
-    timestamp.setTime(Math.floor(time) * 1000);
-    return timestamp;
+    return new Date(parseInt(this.__id.substring(0, 8), 16) * 1000);
   }
 
   /** @internal */

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -5,10 +5,12 @@ import { ByteUtils } from './utils/byte_utils';
 import { NumberUtils } from './utils/number_utils';
 
 // Regular expression that checks for hex value
-const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
+const checkForHexRegExp = new RegExp('^[0-9a-f]{24}$');
 
 // Unique sequence for the current process (initialized on first use)
 let PROCESS_UNIQUE: Uint8Array | null = null;
+
+const OID_SKIP_VALIDATE = Symbol();
 
 /** @public */
 export interface ObjectIdLike {
@@ -35,12 +37,16 @@ export class ObjectId extends BSONValue {
   /** @internal */
   private static index = Math.floor(Math.random() * 0xffffff);
 
+  /** @deprecated Hex string is always cached */
   static cacheHexString: boolean;
 
+  /** Cache buffer internally, Uses much more memory but can speed up performance of some operations like getTimestamp */
+  static cacheBuffer: boolean;
+
   /** ObjectId Bytes @internal */
-  private buffer!: Uint8Array;
+  private buffer?: Uint8Array;
   /** ObjectId hexString cache @internal */
-  private __id?: string;
+  private __id!: string;
 
   /**
    * Create ObjectId from a number.
@@ -55,6 +61,8 @@ export class ObjectId extends BSONValue {
    * @param inputId - A 24 character hex string.
    */
   constructor(inputId: string);
+  /** @internal */
+  constructor(inputId: string, _internalFlag?: symbol);
   /**
    * Create ObjectId from the BSON ObjectId type.
    *
@@ -86,7 +94,11 @@ export class ObjectId extends BSONValue {
    *
    * @param inputId - An input value to create a new ObjectId from.
    */
-  constructor(inputId?: string | number | ObjectId | ObjectIdLike | Uint8Array) {
+  constructor(
+    inputId?: string | number | ObjectId | ObjectIdLike | Uint8Array,
+    _internalFlag?: symbol
+  ) {
+    let bufferCache: Uint8Array | undefined;
     super();
     // workingId is set based on type of input and whether valid id exists for the input
     let workingId;
@@ -95,7 +107,7 @@ export class ObjectId extends BSONValue {
         throw new BSONError('Argument passed in must have an id that is of type string or Buffer');
       }
       if ('toHexString' in inputId && typeof inputId.toHexString === 'function') {
-        workingId = ByteUtils.fromHex(inputId.toHexString());
+        workingId = inputId.toHexString();
       } else {
         workingId = inputId.id;
       }
@@ -104,27 +116,34 @@ export class ObjectId extends BSONValue {
     }
 
     // The following cases use workingId to construct an ObjectId
-    if (workingId == null || typeof workingId === 'number') {
+    if (typeof workingId === 'string') {
+      if (_internalFlag === OID_SKIP_VALIDATE) {
+        this.__id = workingId;
+      } else {
+        const validString = ObjectId.validateHexString(workingId);
+        if (validString) {
+          this.__id = validString;
+        } else {
+          throw new BSONError(
+            'input must be a 24 character hex string, 12 byte Uint8Array, or an integer'
+          );
+        }
+      }
+    } else if (workingId == null || typeof workingId === 'number') {
       // The most common use case (blank id, new objectId instance)
       // Generate a new id
-      this.buffer = ObjectId.generate(typeof workingId === 'number' ? workingId : undefined);
+      bufferCache = ObjectId.generate(typeof workingId === 'number' ? workingId : undefined);
+      this.__id = ByteUtils.toHex(bufferCache);
     } else if (ArrayBuffer.isView(workingId) && workingId.byteLength === 12) {
       // If intstanceof matches we can escape calling ensure buffer in Node.js environments
-      this.buffer = ByteUtils.toLocalBufferType(workingId);
-    } else if (typeof workingId === 'string') {
-      if (workingId.length === 24 && checkForHexRegExp.test(workingId)) {
-        this.buffer = ByteUtils.fromHex(workingId);
-      } else {
-        throw new BSONError(
-          'input must be a 24 character hex string, 12 byte Uint8Array, or an integer'
-        );
-      }
+      bufferCache = ByteUtils.toLocalBufferType(workingId);
+      this.__id = ByteUtils.toHex(bufferCache);
     } else {
       throw new BSONError('Argument passed in does not match the accepted types');
     }
-    // If we are caching the hex string
-    if (ObjectId.cacheHexString) {
-      this.__id = ByteUtils.toHex(this.id);
+    // If we are caching the buffer
+    if (ObjectId.cacheBuffer) {
+      this.buffer = bufferCache || ByteUtils.fromHex(this.__id);
     }
   }
 
@@ -133,29 +152,31 @@ export class ObjectId extends BSONValue {
    * @readonly
    */
   get id(): Uint8Array {
-    return this.buffer;
+    return this.buffer || ByteUtils.fromHex(this.__id);
   }
 
   set id(value: Uint8Array) {
-    this.buffer = value;
-    if (ObjectId.cacheHexString) {
-      this.__id = ByteUtils.toHex(value);
-    }
+    this.__id = ByteUtils.toHex(value);
   }
 
   /** Returns the ObjectId id as a 24 lowercase character hex string representation */
   toHexString(): string {
-    if (ObjectId.cacheHexString && this.__id) {
-      return this.__id;
-    }
+    return this.__id;
+  }
 
-    const hexString = ByteUtils.toHex(this.id);
-
-    if (ObjectId.cacheHexString && !this.__id) {
-      this.__id = hexString;
-    }
-
-    return hexString;
+  /**
+   * @internal
+   * Validates the input string is a valid hex representation of an ObjectId.
+   * If valid, returns the input string. Otherwise, returns false.
+   * Returned string is lowercase.
+   */
+  private static validateHexString(input: string): false | string {
+    if (input == null) return false;
+    if (input.length !== 24) return false;
+    if (checkForHexRegExp.test(input)) return input;
+    const inputLower = input.toLowerCase();
+    if (checkForHexRegExp.test(inputLower)) return inputLower;
+    return false;
   }
 
   /**
@@ -209,13 +230,13 @@ export class ObjectId extends BSONValue {
   toString(encoding?: 'hex' | 'base64'): string {
     // Is the id a buffer then use the buffer toString method to return the format
     if (encoding === 'base64') return ByteUtils.toBase64(this.id);
-    if (encoding === 'hex') return this.toHexString();
-    return this.toHexString();
+    if (encoding === 'hex') return this.__id;
+    return this.__id;
   }
 
   /** Converts to its JSON the 24 character hex string representation. */
   toJSON(): string {
-    return this.toHexString();
+    return this.__id;
   }
 
   /** @internal */
@@ -239,18 +260,16 @@ export class ObjectId extends BSONValue {
     }
 
     if (ObjectId.is(otherId)) {
-      return (
-        this.buffer[11] === otherId.buffer[11] && ByteUtils.equals(this.buffer, otherId.buffer)
-      );
+      return this.__id === otherId.__id;
     }
 
     if (typeof otherId === 'string') {
-      return otherId.toLowerCase() === this.toHexString();
+      return otherId === this.__id || otherId.toLowerCase() === this.__id;
     }
 
     if (typeof otherId === 'object' && typeof otherId.toHexString === 'function') {
       const otherIdString = otherId.toHexString();
-      const thisIdString = this.toHexString();
+      const thisIdString = this.__id;
       return typeof otherIdString === 'string' && otherIdString.toLowerCase() === thisIdString;
     }
 
@@ -259,8 +278,9 @@ export class ObjectId extends BSONValue {
 
   /** Returns the generation date (accurate up to the second) that this ID was generated. */
   getTimestamp(): Date {
+    const buffer = this.buffer || ByteUtils.fromHex(this.__id);
     const timestamp = new Date();
-    const time = NumberUtils.getUint32BE(this.buffer, 0);
+    const time = NumberUtils.getUint32BE(buffer, 0);
     timestamp.setTime(Math.floor(time) * 1000);
     return timestamp;
   }
@@ -272,18 +292,19 @@ export class ObjectId extends BSONValue {
 
   /** @internal */
   serializeInto(uint8array: Uint8Array, index: number): 12 {
-    uint8array[index] = this.buffer[0];
-    uint8array[index + 1] = this.buffer[1];
-    uint8array[index + 2] = this.buffer[2];
-    uint8array[index + 3] = this.buffer[3];
-    uint8array[index + 4] = this.buffer[4];
-    uint8array[index + 5] = this.buffer[5];
-    uint8array[index + 6] = this.buffer[6];
-    uint8array[index + 7] = this.buffer[7];
-    uint8array[index + 8] = this.buffer[8];
-    uint8array[index + 9] = this.buffer[9];
-    uint8array[index + 10] = this.buffer[10];
-    uint8array[index + 11] = this.buffer[11];
+    const buffer = this.buffer || ByteUtils.fromHex(this.__id);
+    uint8array[index] = buffer[0];
+    uint8array[index + 1] = buffer[1];
+    uint8array[index + 2] = buffer[2];
+    uint8array[index + 3] = buffer[3];
+    uint8array[index + 4] = buffer[4];
+    uint8array[index + 5] = buffer[5];
+    uint8array[index + 6] = buffer[6];
+    uint8array[index + 7] = buffer[7];
+    uint8array[index + 8] = buffer[8];
+    uint8array[index + 9] = buffer[9];
+    uint8array[index + 10] = buffer[10];
+    uint8array[index + 11] = buffer[11];
     return 12;
   }
 
@@ -293,7 +314,7 @@ export class ObjectId extends BSONValue {
    * @param time - an integer number representing a number of seconds.
    */
   static createFromTime(time: number): ObjectId {
-    const buffer = ByteUtils.allocate(12);
+    const buffer = ByteUtils.allocateUnsafe(12);
     for (let i = 11; i >= 4; i--) buffer[i] = 0;
     // Encode time into first 4 bytes
     NumberUtils.setInt32BE(buffer, 0, time);
@@ -311,7 +332,7 @@ export class ObjectId extends BSONValue {
       throw new BSONError('hex string must be 24 characters');
     }
 
-    return new ObjectId(ByteUtils.fromHex(hexString));
+    return new ObjectId(hexString);
   }
 
   /** Creates an ObjectId instance from a base64 string */
@@ -329,6 +350,7 @@ export class ObjectId extends BSONValue {
    */
   static isValid(id: string | number | ObjectId | ObjectIdLike | Uint8Array): boolean {
     if (id == null) return false;
+    if (typeof id === 'string') return !!ObjectId.validateHexString(id);
 
     try {
       new ObjectId(id);
@@ -340,13 +362,12 @@ export class ObjectId extends BSONValue {
 
   /** @internal */
   toExtendedJSON(): ObjectIdExtended {
-    if (this.toHexString) return { $oid: this.toHexString() };
-    return { $oid: this.toString('hex') };
+    return { $oid: this.__id };
   }
 
   /** @internal */
   static fromExtendedJSON(doc: ObjectIdExtended): ObjectId {
-    return new ObjectId(doc.$oid);
+    return new ObjectId(doc.$oid, OID_SKIP_VALIDATE);
   }
 
   /**
@@ -356,6 +377,6 @@ export class ObjectId extends BSONValue {
    */
   inspect(depth?: number, options?: unknown, inspect?: InspectFn): string {
     inspect ??= defaultInspect;
-    return `new ObjectId(${inspect(this.toHexString(), options)})`;
+    return `new ObjectId(${inspect(this.__id, options)})`;
   }
 }

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -329,12 +329,8 @@ export class ObjectId extends BSONValue {
    * @param time - an integer number representing a number of seconds.
    */
   static createFromTime(time: number): ObjectId {
-    const buffer = ByteUtils.allocateUnsafe(12);
-    for (let i = 11; i >= 4; i--) buffer[i] = 0;
-    // Encode time into first 4 bytes
-    NumberUtils.setInt32BE(buffer, 0, time);
     // Return the new objectId
-    return new ObjectId(buffer);
+    return new ObjectId(time);
   }
 
   /**

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -307,19 +307,26 @@ export class ObjectId extends BSONValue {
 
   /** @internal */
   serializeInto(uint8array: Uint8Array, index: number): 12 {
-    const buffer = this.buffer || ByteUtils.fromHex(this.__id);
-    uint8array[index] = buffer[0];
-    uint8array[index + 1] = buffer[1];
-    uint8array[index + 2] = buffer[2];
-    uint8array[index + 3] = buffer[3];
-    uint8array[index + 4] = buffer[4];
-    uint8array[index + 5] = buffer[5];
-    uint8array[index + 6] = buffer[6];
-    uint8array[index + 7] = buffer[7];
-    uint8array[index + 8] = buffer[8];
-    uint8array[index + 9] = buffer[9];
-    uint8array[index + 10] = buffer[10];
-    uint8array[index + 11] = buffer[11];
+    let temp = parseInt(this.__id.substring(0, 8), 16);
+
+    uint8array[index + 3] = temp & 0xff;
+    uint8array[index + 2] = (temp >> 8) & 0xff;
+    uint8array[index + 1] = (temp >> 16) & 0xff;
+    uint8array[index + 0] = (temp >> 24) & 0xff;
+
+    temp = parseInt(this.__id.substring(8, 16), 16);
+
+    uint8array[index + 7] = temp & 0xff;
+    uint8array[index + 6] = (temp >> 8) & 0xff;
+    uint8array[index + 5] = (temp >> 16) & 0xff;
+    uint8array[index + 4] = (temp >> 24) & 0xff;
+
+    temp = parseInt(this.__id.substring(16, 24), 16);
+
+    uint8array[index + 11] = temp & 0xff;
+    uint8array[index + 10] = (temp >> 8) & 0xff;
+    uint8array[index + 9] = (temp >> 16) & 0xff;
+    uint8array[index + 8] = (temp >> 24) & 0xff;
     return 12;
   }
 

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -263,9 +263,7 @@ function deserializeObject(
       value = ByteUtils.toUTF8(buffer, index, index + stringSize - 1, shouldValidateKey);
       index = index + stringSize;
     } else if (elementType === constants.BSON_DATA_OID) {
-      const oid = ByteUtils.allocateUnsafe(12);
-      for (let i = 0; i < 12; i++) oid[i] = buffer[index + i];
-      value = new ObjectId(oid);
+      value = new ObjectId(buffer, index);
       index = index + 12;
     } else if (elementType === constants.BSON_DATA_INT && promoteValues === false) {
       value = new Int32(NumberUtils.getInt32LE(buffer, index));
@@ -608,9 +606,7 @@ function deserializeObject(
       index = index + stringSize;
 
       // Read the oid
-      const oidBuffer = ByteUtils.allocateUnsafe(12);
-      for (let i = 0; i < 12; i++) oidBuffer[i] = buffer[index + i];
-      const oid = new ObjectId(oidBuffer);
+      const oid = new ObjectId(buffer, index);
 
       // Update the index
       index = index + 12;

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -231,10 +231,9 @@ function serializeObjectId(buffer: Uint8Array, key: string, value: ObjectId, ind
   // Write the type
   buffer[index++] = constants.BSON_DATA_OID;
   // Number of written bytes
-  const numberOfWrittenBytes = ByteUtils.encodeUTF8Into(buffer, key, index);
+  index += ByteUtils.encodeUTF8Into(buffer, key, index);
 
   // Encode the name
-  index = index + numberOfWrittenBytes;
   buffer[index++] = 0;
 
   index += value.serializeInto(buffer, index);
@@ -647,6 +646,8 @@ export function serializeInto(
         index = serializeNull(buffer, key, value, index);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index);
+      } else if (value._bsontype === 'ObjectId') {
+        index = serializeObjectId(buffer, key, value, index);
       } else if (isUint8Array(value)) {
         index = serializeBuffer(buffer, key, value, index);
       } else if (value instanceof RegExp || isRegExp(value)) {
@@ -668,8 +669,6 @@ export function serializeInto(
         value[Symbol.for('@@mdb.bson.version')] !== constants.BSON_MAJOR_VERSION
       ) {
         throw new BSONVersionError();
-      } else if (value._bsontype === 'ObjectId') {
-        index = serializeObjectId(buffer, key, value, index);
       } else if (value._bsontype === 'Decimal128') {
         index = serializeDecimal128(buffer, key, value, index);
       } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
@@ -757,6 +756,8 @@ export function serializeInto(
         index = serializeDate(buffer, key, value, index);
       } else if (value === null || (value === undefined && ignoreUndefined === false)) {
         index = serializeNull(buffer, key, value, index);
+      } else if (value._bsontype === 'ObjectId') {
+        index = serializeObjectId(buffer, key, value, index);
       } else if (isUint8Array(value)) {
         index = serializeBuffer(buffer, key, value, index);
       } else if (value instanceof RegExp || isRegExp(value)) {
@@ -778,8 +779,6 @@ export function serializeInto(
         value[Symbol.for('@@mdb.bson.version')] !== constants.BSON_MAJOR_VERSION
       ) {
         throw new BSONVersionError();
-      } else if (value._bsontype === 'ObjectId') {
-        index = serializeObjectId(buffer, key, value, index);
       } else if (type === 'object' && value._bsontype === 'Decimal128') {
         index = serializeDecimal128(buffer, key, value, index);
       } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
@@ -867,6 +866,8 @@ export function serializeInto(
         if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index);
+      } else if (value._bsontype === 'ObjectId') {
+        index = serializeObjectId(buffer, key, value, index);
       } else if (isUint8Array(value)) {
         index = serializeBuffer(buffer, key, value, index);
       } else if (value instanceof RegExp || isRegExp(value)) {
@@ -888,8 +889,6 @@ export function serializeInto(
         value[Symbol.for('@@mdb.bson.version')] !== constants.BSON_MAJOR_VERSION
       ) {
         throw new BSONVersionError();
-      } else if (value._bsontype === 'ObjectId') {
-        index = serializeObjectId(buffer, key, value, index);
       } else if (type === 'object' && value._bsontype === 'Decimal128') {
         index = serializeDecimal128(buffer, key, value, index);
       } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {

--- a/src/utils/byte_utils.ts
+++ b/src/utils/byte_utils.ts
@@ -30,7 +30,7 @@ export type ByteUtils = {
   /** Create a Uint8Array from a hex string */
   fromHex: (hex: string) => Uint8Array;
   /** Create a lowercase hex string from bytes */
-  toHex: (buffer: Uint8Array) => string;
+  toHex: (buffer: Uint8Array, start?: number, end?: number) => string;
   /** Create a string from utf8 code units, fatal=true will throw an error if UTF-8 bytes are invalid, fatal=false will insert replacement characters */
   toUTF8: (buffer: Uint8Array, start: number, end: number, fatal: boolean) => string;
   /** Get the utf8 code unit count from a string if it were to be transformed to utf8 */

--- a/src/utils/node_byte_utils.ts
+++ b/src/utils/node_byte_utils.ts
@@ -124,8 +124,8 @@ export const nodeJsByteUtils = {
     return Buffer.from(hex, 'hex');
   },
 
-  toHex(buffer: Uint8Array): string {
-    return nodeJsByteUtils.toLocalBufferType(buffer).toString('hex');
+  toHex(buffer: NodeJsBuffer, start?: number, end?: number): string {
+    return nodeJsByteUtils.toLocalBufferType(buffer).toString('hex', start, end);
   },
 
   toUTF8(buffer: Uint8Array, start: number, end: number, fatal: boolean): string {

--- a/src/utils/string_utils.ts
+++ b/src/utils/string_utils.ts
@@ -42,3 +42,17 @@ export function validateStringCharacters(str: string, radix?: number): false | s
   const regex = new RegExp(`[^-+${validCharacters}]`, 'i');
   return regex.test(str) ? false : str;
 }
+
+/**
+ * @internal
+ * "flattens" a string that was created through concatenation of multiple strings.
+ * Most engines will try to optimize concatenation of strings using a "rope" graph of the substrings,
+ * This can lead to increased memory usage with extra pointers and performance issues when operating on these strings.
+ * `string.charAt(0)` forces the engine to flatten the string before performing the operation.
+ * See https://en.wikipedia.org/wiki/Rope_(data_structure)
+ * See https://docs.google.com/document/d/1o-MJPAddpfBfDZCkIHNKbMiM86iDFld7idGbNQLuKIQ
+ */
+export function flattenString(str: string): string {
+  str.charAt(0);
+  return str;
+}

--- a/src/utils/web_byte_utils.ts
+++ b/src/utils/web_byte_utils.ts
@@ -170,7 +170,7 @@ export const webByteUtils = {
     return Uint8Array.from(buffer);
   },
 
-  toHex(uint8array: Uint8Array): string {
+  toHex(uint8array: Uint8Array, _start?: number, _end?: number): string {
     return Array.from(uint8array, byte => byte.toString(16).padStart(2, '0')).join('');
   },
 

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1661,18 +1661,12 @@ describe('BSON', function () {
     expect(__id).to.equal(a.toHexString());
 
     // number
-    var genTime = a.generationTime;
-    a = new ObjectId(genTime);
+    a = new ObjectId(Date.now());
     __id = a.__id;
     expect(__id).to.equal(a.toHexString());
 
-    // generationTime
-    delete a.__id;
-    a.generationTime = genTime;
-    expect(__id).to.equal(a.toHexString());
-
     // createFromTime
-    a = ObjectId.createFromTime(genTime);
+    a = ObjectId.createFromTime(Date.now());
     __id = a.__id;
     expect(__id).to.equal(a.toHexString());
     ObjectId.cacheHexString = false;


### PR DESCRIPTION
### Description

This MR refactors ObjectId class to persist strings instead of a raw Buffer, which **greatly** reduces memory usage and improves performance of ObjectIds.

### Why?
- Buffer (or TypedArray) is inefficient at storing small amount of data 
- Buffer of size 12 takes **96 bytes** in v8! ObjectId with buffer is **128 bytes** each
- string of size 24 takes **40 bytes**. ObjectId with String is **72 bytes**

### Performance Improvements

| Operation            | ObjectId (ops/sec) | ObjectId STRING (ops/sec) | Relative Improvement (%) |
|----------------------|----------------|-------------------|--------------------------|
| new ObjectId()       | 10,398,719     | 11,263,765         | **8.32%**                  |
| new ObjectId(string) | 4,965,933      | 14,869,618        | **199.43%**                  |
| deserialize          | 6,955,399      | 6,431,123        | **-7.54%**                  |
| serialize            | 3,881,206     |  3,247,690        | **-16.32%**                  |
| fromExtendedJSON          | 4,821,665      | 50,886,088        | **955.36%**                  |
| toExtendedJSON            | 10,988,941     | 134,783,499        | **1126.54%**                  |
| toHexString          | 10,899,295     | 131,767,192        | **616.63%**                  |
| .equals(objectId)     | 39,653,912     | 44,413,312        | **12.00%**                   |
| .equals(string)   | 7,691,853 | 55,222,764 | **617.94%** |
| .isValid(string) | 137,247 | 21,470,293 | **15543.49%** |


### Real world use cases

In the benchmarks above you can see there are some performance regressions with the raw serialize/deserializing BSON. This is because we now need to convert buffer to/from string instead of just copying bytes, but this regression seems to be moot during "real world" benchmarks. 

I believe the 2 most common use cases are 
- 1. Retrieving documents from the DB and returning them to the user. 
- 2. Creating a new document and persisting to the DB

Using the [MFlix Sample Dataset](https://www.mongodb.com/docs/atlas/sample-data/sample-mflix/) "Comments" documents.

| Operation            | ObjectId (ops/sec) | ObjectId STRING (ops/sec) | Relative Improvement (%) |
|----------------------|----------------|-------------------|--------------------------|
| GET 100 docs (deserialize + stringily)       | 3,762     | 3,855         | **2.46%**                  |
| Create new doc (create + serialize) | 673,069      | 710,472        | **5.56%**                  |

### Memory Improvements

With this change, retained memory usage is reduced by **~45%** (ObjectId size decreases from 128 bytes to 72 bytes). I've also removed an extra buffer allocation during deserialization which reduces the strain on the buffer pool, reducing the likelihood of the internal buffer pool having to allocate another block of `Buffer.poolSize`. 

By reducing the amount of memory that needs to be allocated we are further improving performance since garbage collection is quite expensive.

![image](https://github.com/mongodb/js-bson/assets/2258445/a353b6bb-40d8-472a-abb0-2032138646ea)

#### Example
Using the [MFlix Sample Dataset](https://www.mongodb.com/docs/atlas/sample-data/sample-mflix/) "Comments" collection. Grabbing 1 million documents

```ts
const bef = process.memoryUsage().rss;
const docs = await comments.find({}, { limit: 1000000 }).toArray() // lets grab 1 million documents
const aft = process.memoryUsage().rss;
console.log(`Memory used: ${Math.floor((aft - bef) / 1024 / 1024)}MB`);
```

**BEFORE: 654 MB used**

**AFTER: 343 MB used**

**-47% reduction in memory usage** 

#### cacheBuffer Option

Similar to the previous `cacheHexString` static variable, this MR adds `cacheBuffer` option that also persists the `Buffer` on the ObjectId to speed up some operations that require buffer, such as `.id`

Previous ObjectID w/ cacheHexString VS New ObjectId w/ cacheBuffer

| Operation               | bson (ops/sec) | bsonSTR (ops/sec) | Relative Improvement (%) |
|-------------------------|----------------|-------------------|--------------------------|
| new ObjectId()          | 5,535,118      | 5,481,568         | -0.97%                   |
| new ObjectId() + serialize | 5,621,583    | 5,635,728         | 0.25%                    |
| new ObjectId(string)    | 3,794,209      | 5,363,446         | 41.36%                   |
| deserialize             | 3,788,455      | 6,131,230         | 61.85%                   |
| serialize               | 67,014,370     | 80,864,967        | 20.65%                   |
| toHexString             | 71,372,677     | 79,949,268        | 12.02%                   |
| equals                  | 40,714,896     | 45,167,881        | 10.95%                   |
| equals-string           | 20,697,929     | 42,426,021        | 105.00%                  |
| getTimestamp            | 10,554,392     | 10,591,691        | 0.35%                    |
| createFromTime          | 6,479,506      | 5,801,031         | -10.47%                  |
| isValid                 | 128,998        | 20,637,794        | 15895.85%                |


#### What is changing?

##### Is there new documentation needed for these changes?

This MR deprecates `cacheHexString` which may need to be documented. 

This MR adds `cacheBuffer` which may need to be documented

#### What is the motivation for this change?

We are been running into memory issues while pulling large Mongo result sets into memory, and after lots of memory profiling the issue seems to be related to ObjectId, specifically how memory inefficient Buffer/ArrayBuffer is when storing lots of small Buffers.

We were expecting an ObjectId to consume ~12bytes of memory (+ some overhead), but in reality this consumes 128 bytes per ObjectId (96 bytes for just the Buffer).

I opened an issue with the NodeJS Performance team but this appears to be working as designed: https://github.com/nodejs/performance/issues/173

Storing a string in Node/V8 is much more memory efficient since it's a primitive. A 24 character hex string only consumes 40 bytes of memory, AND it's much faster to serialize/deserialize.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
