### PR TITLE
perf(NODE-6344): Improve ObjectId.isValid(string) performance

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -4,9 +4,6 @@ import { type InspectFn, defaultInspect } from './parser/utils';
 import { ByteUtils } from './utils/byte_utils';
 import { NumberUtils } from './utils/number_utils';
 
-// Regular expression that checks for hex value
-const checkForHexRegExp = new RegExp('^[0-9a-fA-F]{24}$');
-
 // Unique sequence for the current process (initialized on first use)
 let PROCESS_UNIQUE: Uint8Array | null = null;
 
@@ -147,9 +144,23 @@ export class ObjectId extends BSONValue {
    * @internal
    * Validates the input string is a valid hex representation of an ObjectId.
    */
-  private static validateHexString(input: string): boolean {
-    if (input == null || input.length !== 24) return false;
-    return checkForHexRegExp.test(input);
+  private static validateHexString(string: string): boolean {
+    if (string?.length !== 24) return false;
+    for (let i = 0; i < 24; i++) {
+      const char = string.charCodeAt(i);
+      if (
+        // Check for ASCII 0-9
+        (char >= 48 && char <= 57) ||
+        // Check for ASCII a-f
+        (char >= 97 && char <= 102) ||
+        // Check for ASCII A-F
+        (char >= 65 && char <= 70)
+      ) {
+        continue;
+      }
+      return false;
+    }
+    return true;
   }
 
   /** Returns the ObjectId id as a 24 lowercase character hex string representation */

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -112,7 +112,7 @@ export class ObjectId extends BSONValue {
       // If intstanceof matches we can escape calling ensure buffer in Node.js environments
       this.buffer = ByteUtils.toLocalBufferType(workingId);
     } else if (typeof workingId === 'string') {
-      if (workingId.length === 24 && checkForHexRegExp.test(workingId)) {
+      if (ObjectId.validateHexString(workingId)) {
         this.buffer = ByteUtils.fromHex(workingId);
       } else {
         throw new BSONError(
@@ -141,6 +141,15 @@ export class ObjectId extends BSONValue {
     if (ObjectId.cacheHexString) {
       this.__id = ByteUtils.toHex(value);
     }
+  }
+
+  /**
+   * @internal
+   * Validates the input string is a valid hex representation of an ObjectId.
+   */
+  private static validateHexString(input: string): boolean {
+    if (input == null || input.length !== 24) return false;
+    return checkForHexRegExp.test(input);
   }
 
   /** Returns the ObjectId id as a 24 lowercase character hex string representation */
@@ -329,6 +338,7 @@ export class ObjectId extends BSONValue {
    */
   static isValid(id: string | number | ObjectId | ObjectIdLike | Uint8Array): boolean {
     if (id == null) return false;
+    if (typeof id === 'string') return ObjectId.validateHexString(id);
 
     try {
       new ObjectId(id);


### PR DESCRIPTION
### Description

This MR improves performance of using `ObjectId.isValid('some string')` to check if a string is a valid hex representation of an ObjectId. We frequently call this function to check if a user's input is valid (for example, when creating a document that links to other document(s)).

### Performance tests

| Test                        | Ops/s (Main)         | Ops/s (New)          | % Improvement   |
|-----------------------------|----------------------|----------------------|-----------------|
| bson#new ObjectId(string)    | 3,173,643 ops/sec    | 3,299,153 ops/sec    | 3.95%           |
| bson#isValid                | 5,513,041 ops/sec    | 22,529,639 ops/sec   | 308.66%         |
| bson#isValid uppercase      | 5,498,098 ops/sec    | 21,776,208 ops/sec   | 296.07%         |
| bson#isValid invalid end       | 131,657 ops/sec      | 22,592,719 ops/sec   | 17,060.24%      |
| bson#isValid invalid start  | 132,751 ops/sec      | 152,311,298 ops/sec  | 114,634.47%     |

There is a drastic performance improvement when checking for invalid strings since throwing/catching errors is expensive.

#### What is changing?

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
