### PR TITLE
perf(NODE-6356): Improve serialization performance

### DIFF
--- a/src/bson_value.ts
+++ b/src/bson_value.ts
@@ -1,5 +1,6 @@
 import { BSON_MAJOR_VERSION } from './constants';
 import { type InspectFn } from './parser/utils';
+import { BSON_VERSION_SYMBOL } from './constants';
 
 /** @public */
 export abstract class BSONValue {
@@ -7,7 +8,7 @@ export abstract class BSONValue {
   public abstract get _bsontype(): string;
 
   /** @internal */
-  get [Symbol.for('@@mdb.bson.version')](): typeof BSON_MAJOR_VERSION {
+  get [BSON_VERSION_SYMBOL](): typeof BSON_MAJOR_VERSION {
     return BSON_MAJOR_VERSION;
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,9 @@
 export const BSON_MAJOR_VERSION = 6;
 
 /** @internal */
+export const BSON_VERSION_SYMBOL = Symbol.for('@@mdb.bson.version');
+
+/** @internal */
 export const BSON_INT32_MAX = 0x7fffffff;
 /** @internal */
 export const BSON_INT32_MIN = -0x80000000;

--- a/src/decimal128.ts
+++ b/src/decimal128.ts
@@ -142,7 +142,7 @@ export class Decimal128 extends BSONValue {
     super();
     if (typeof bytes === 'string') {
       this.bytes = Decimal128.fromString(bytes).bytes;
-    } else if (isUint8Array(bytes)) {
+    } else if (bytes instanceof Uint8Array || isUint8Array(bytes)) {
       if (bytes.byteLength !== 16) {
         throw new BSONError('Decimal128 must take a Buffer of 16 bytes');
       }

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -6,7 +6,8 @@ import {
   BSON_INT32_MIN,
   BSON_INT64_MAX,
   BSON_INT64_MIN,
-  BSON_MAJOR_VERSION
+  BSON_MAJOR_VERSION,
+  BSON_VERSION_SYMBOL
 } from './constants';
 import { DBRef, isDBRefLike } from './db_ref';
 import { Decimal128 } from './decimal128';
@@ -358,7 +359,7 @@ function serializeDocument(doc: any, options: EJSONSerializeOptions) {
     doc != null &&
     typeof doc === 'object' &&
     typeof doc._bsontype === 'string' &&
-    doc[Symbol.for('@@mdb.bson.version')] !== BSON_MAJOR_VERSION
+    doc[BSON_VERSION_SYMBOL] !== BSON_MAJOR_VERSION
   ) {
     throw new BSONVersionError();
   } else if (isBSONType(doc)) {

--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -81,7 +81,7 @@ function calculateElement(
       if (
         value != null &&
         typeof value._bsontype === 'string' &&
-        value[Symbol.for('@@mdb.bson.version')] !== constants.BSON_MAJOR_VERSION
+        value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION
       ) {
         throw new BSONVersionError();
       } else if (value == null || value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -633,77 +633,81 @@ export function serializeInto(
         value = value.toBSON();
       }
 
-      if (typeof value === 'string') {
-        index = serializeString(buffer, key, value, index);
-      } else if (typeof value === 'number') {
-        index = serializeNumber(buffer, key, value, index);
-      } else if (typeof value === 'bigint') {
-        index = serializeBigInt(buffer, key, value, index);
-      } else if (typeof value === 'boolean') {
-        index = serializeBoolean(buffer, key, value, index);
-      } else if (value instanceof Date || isDate(value)) {
-        index = serializeDate(buffer, key, value, index);
-      } else if (value === undefined) {
+      // Check the type of the value
+      const type = typeof value;
+
+      if (value === undefined) {
         index = serializeNull(buffer, key, value, index);
       } else if (value === null) {
         index = serializeNull(buffer, key, value, index);
-      } else if (isUint8Array(value)) {
-        index = serializeBuffer(buffer, key, value, index);
-      } else if (value instanceof RegExp || isRegExp(value)) {
-        index = serializeRegExp(buffer, key, value, index);
-      } else if (typeof value === 'object' && value._bsontype == null) {
-        index = serializeObject(
-          buffer,
-          key,
-          value,
-          index,
-          checkKeys,
-          depth,
-          serializeFunctions,
-          ignoreUndefined,
-          path
-        );
-      } else if (
-        typeof value === 'object' &&
-        value[Symbol.for('@@mdb.bson.version')] !== constants.BSON_MAJOR_VERSION
-      ) {
-        throw new BSONVersionError();
-      } else if (value._bsontype === 'ObjectId') {
-        index = serializeObjectId(buffer, key, value, index);
-      } else if (value._bsontype === 'Decimal128') {
-        index = serializeDecimal128(buffer, key, value, index);
-      } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
-        index = serializeLong(buffer, key, value, index);
-      } else if (value._bsontype === 'Double') {
-        index = serializeDouble(buffer, key, value, index);
-      } else if (typeof value === 'function' && serializeFunctions) {
+      } else if (type === 'string') {
+        index = serializeString(buffer, key, value, index);
+      } else if (type === 'number') {
+        index = serializeNumber(buffer, key, value, index);
+      } else if (type === 'bigint') {
+        index = serializeBigInt(buffer, key, value, index);
+      } else if (type === 'boolean') {
+        index = serializeBoolean(buffer, key, value, index);
+      } else if (type === 'object' && value._bsontype == null) {
+        if (value instanceof Date || isDate(value)) {
+          index = serializeDate(buffer, key, value, index);
+        } else if (value instanceof Uint8Array || isUint8Array(value)) {
+          index = serializeBuffer(buffer, key, value, index);
+        } else if (value instanceof RegExp || isRegExp(value)) {
+          index = serializeRegExp(buffer, key, value, index);
+        } else {
+          index = serializeObject(
+            buffer,
+            key,
+            value,
+            index,
+            checkKeys,
+            depth,
+            serializeFunctions,
+            ignoreUndefined,
+            path
+          );
+        }
+      } else if (type === 'object') {
+        if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
+          throw new BSONVersionError();
+        } else if (value._bsontype === 'ObjectId') {
+          index = serializeObjectId(buffer, key, value, index);
+        } else if (value._bsontype === 'Decimal128') {
+          index = serializeDecimal128(buffer, key, value, index);
+        } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
+          index = serializeLong(buffer, key, value, index);
+        } else if (value._bsontype === 'Double') {
+          index = serializeDouble(buffer, key, value, index);
+        } else if (value._bsontype === 'Code') {
+          index = serializeCode(
+            buffer,
+            key,
+            value,
+            index,
+            checkKeys,
+            depth,
+            serializeFunctions,
+            ignoreUndefined,
+            path
+          );
+        } else if (value._bsontype === 'Binary') {
+          index = serializeBinary(buffer, key, value, index);
+        } else if (value._bsontype === 'BSONSymbol') {
+          index = serializeSymbol(buffer, key, value, index);
+        } else if (value._bsontype === 'DBRef') {
+          index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
+        } else if (value._bsontype === 'BSONRegExp') {
+          index = serializeBSONRegExp(buffer, key, value, index);
+        } else if (value._bsontype === 'Int32') {
+          index = serializeInt32(buffer, key, value, index);
+        } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
+          index = serializeMinMax(buffer, key, value, index);
+        } else if (typeof value._bsontype !== 'undefined') {
+          throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
+        }
+      } else if (type === 'function' && serializeFunctions) {
         index = serializeFunction(buffer, key, value, index);
-      } else if (value._bsontype === 'Code') {
-        index = serializeCode(
-          buffer,
-          key,
-          value,
-          index,
-          checkKeys,
-          depth,
-          serializeFunctions,
-          ignoreUndefined,
-          path
-        );
-      } else if (value._bsontype === 'Binary') {
-        index = serializeBinary(buffer, key, value, index);
-      } else if (value._bsontype === 'BSONSymbol') {
-        index = serializeSymbol(buffer, key, value, index);
-      } else if (value._bsontype === 'DBRef') {
-        index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
-      } else if (value._bsontype === 'BSONRegExp') {
-        index = serializeBSONRegExp(buffer, key, value, index);
-      } else if (value._bsontype === 'Int32') {
-        index = serializeInt32(buffer, key, value, index);
-      } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
-        index = serializeMinMax(buffer, key, value, index);
-      } else if (typeof value._bsontype !== 'undefined') {
-        throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
       }
     }
   } else if (object instanceof Map || isMap(object)) {
@@ -745,7 +749,11 @@ export function serializeInto(
         }
       }
 
-      if (type === 'string') {
+      if (value === undefined) {
+        if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
+      } else if (value === null) {
+        index = serializeNull(buffer, key, value, index);
+      } else if (type === 'string') {
         index = serializeString(buffer, key, value, index);
       } else if (type === 'number') {
         index = serializeNumber(buffer, key, value, index);
@@ -753,67 +761,66 @@ export function serializeInto(
         index = serializeBigInt(buffer, key, value, index);
       } else if (type === 'boolean') {
         index = serializeBoolean(buffer, key, value, index);
-      } else if (value instanceof Date || isDate(value)) {
-        index = serializeDate(buffer, key, value, index);
-      } else if (value === null || (value === undefined && ignoreUndefined === false)) {
-        index = serializeNull(buffer, key, value, index);
-      } else if (isUint8Array(value)) {
-        index = serializeBuffer(buffer, key, value, index);
-      } else if (value instanceof RegExp || isRegExp(value)) {
-        index = serializeRegExp(buffer, key, value, index);
       } else if (type === 'object' && value._bsontype == null) {
-        index = serializeObject(
-          buffer,
-          key,
-          value,
-          index,
-          checkKeys,
-          depth,
-          serializeFunctions,
-          ignoreUndefined,
-          path
-        );
-      } else if (
-        typeof value === 'object' &&
-        value[Symbol.for('@@mdb.bson.version')] !== constants.BSON_MAJOR_VERSION
-      ) {
-        throw new BSONVersionError();
-      } else if (value._bsontype === 'ObjectId') {
-        index = serializeObjectId(buffer, key, value, index);
-      } else if (type === 'object' && value._bsontype === 'Decimal128') {
-        index = serializeDecimal128(buffer, key, value, index);
-      } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
-        index = serializeLong(buffer, key, value, index);
-      } else if (value._bsontype === 'Double') {
-        index = serializeDouble(buffer, key, value, index);
-      } else if (value._bsontype === 'Code') {
-        index = serializeCode(
-          buffer,
-          key,
-          value,
-          index,
-          checkKeys,
-          depth,
-          serializeFunctions,
-          ignoreUndefined,
-          path
-        );
-      } else if (typeof value === 'function' && serializeFunctions) {
+        if (value instanceof Date || isDate(value)) {
+          index = serializeDate(buffer, key, value, index);
+        } else if (value instanceof Uint8Array || isUint8Array(value)) {
+          index = serializeBuffer(buffer, key, value, index);
+        } else if (value instanceof RegExp || isRegExp(value)) {
+          index = serializeRegExp(buffer, key, value, index);
+        } else {
+          index = serializeObject(
+            buffer,
+            key,
+            value,
+            index,
+            checkKeys,
+            depth,
+            serializeFunctions,
+            ignoreUndefined,
+            path
+          );
+        }
+      } else if (type === 'object') {
+        if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
+          throw new BSONVersionError();
+        } else if (value._bsontype === 'ObjectId') {
+          index = serializeObjectId(buffer, key, value, index);
+        } else if (value._bsontype === 'Decimal128') {
+          index = serializeDecimal128(buffer, key, value, index);
+        } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
+          index = serializeLong(buffer, key, value, index);
+        } else if (value._bsontype === 'Double') {
+          index = serializeDouble(buffer, key, value, index);
+        } else if (value._bsontype === 'Code') {
+          index = serializeCode(
+            buffer,
+            key,
+            value,
+            index,
+            checkKeys,
+            depth,
+            serializeFunctions,
+            ignoreUndefined,
+            path
+          );
+        } else if (value._bsontype === 'Binary') {
+          index = serializeBinary(buffer, key, value, index);
+        } else if (value._bsontype === 'BSONSymbol') {
+          index = serializeSymbol(buffer, key, value, index);
+        } else if (value._bsontype === 'DBRef') {
+          index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
+        } else if (value._bsontype === 'BSONRegExp') {
+          index = serializeBSONRegExp(buffer, key, value, index);
+        } else if (value._bsontype === 'Int32') {
+          index = serializeInt32(buffer, key, value, index);
+        } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
+          index = serializeMinMax(buffer, key, value, index);
+        } else if (typeof value._bsontype !== 'undefined') {
+          throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
+        }
+      } else if (type === 'function' && serializeFunctions) {
         index = serializeFunction(buffer, key, value, index);
-      } else if (value._bsontype === 'Binary') {
-        index = serializeBinary(buffer, key, value, index);
-      } else if (value._bsontype === 'BSONSymbol') {
-        index = serializeSymbol(buffer, key, value, index);
-      } else if (value._bsontype === 'DBRef') {
-        index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
-      } else if (value._bsontype === 'BSONRegExp') {
-        index = serializeBSONRegExp(buffer, key, value, index);
-      } else if (value._bsontype === 'Int32') {
-        index = serializeInt32(buffer, key, value, index);
-      } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
-        index = serializeMinMax(buffer, key, value, index);
-      } else if (typeof value._bsontype !== 'undefined') {
-        throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
       }
     }
   } else {
@@ -853,7 +860,11 @@ export function serializeInto(
         }
       }
 
-      if (type === 'string') {
+      if (value === undefined) {
+        if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
+      } else if (value === null) {
+        index = serializeNull(buffer, key, value, index);
+      } else if (type === 'string') {
         index = serializeString(buffer, key, value, index);
       } else if (type === 'number') {
         index = serializeNumber(buffer, key, value, index);
@@ -861,69 +872,66 @@ export function serializeInto(
         index = serializeBigInt(buffer, key, value, index);
       } else if (type === 'boolean') {
         index = serializeBoolean(buffer, key, value, index);
-      } else if (value instanceof Date || isDate(value)) {
-        index = serializeDate(buffer, key, value, index);
-      } else if (value === undefined) {
-        if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
-      } else if (value === null) {
-        index = serializeNull(buffer, key, value, index);
-      } else if (isUint8Array(value)) {
-        index = serializeBuffer(buffer, key, value, index);
-      } else if (value instanceof RegExp || isRegExp(value)) {
-        index = serializeRegExp(buffer, key, value, index);
       } else if (type === 'object' && value._bsontype == null) {
-        index = serializeObject(
-          buffer,
-          key,
-          value,
-          index,
-          checkKeys,
-          depth,
-          serializeFunctions,
-          ignoreUndefined,
-          path
-        );
-      } else if (
-        typeof value === 'object' &&
-        value[Symbol.for('@@mdb.bson.version')] !== constants.BSON_MAJOR_VERSION
-      ) {
-        throw new BSONVersionError();
-      } else if (value._bsontype === 'ObjectId') {
-        index = serializeObjectId(buffer, key, value, index);
-      } else if (type === 'object' && value._bsontype === 'Decimal128') {
-        index = serializeDecimal128(buffer, key, value, index);
-      } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
-        index = serializeLong(buffer, key, value, index);
-      } else if (value._bsontype === 'Double') {
-        index = serializeDouble(buffer, key, value, index);
-      } else if (value._bsontype === 'Code') {
-        index = serializeCode(
-          buffer,
-          key,
-          value,
-          index,
-          checkKeys,
-          depth,
-          serializeFunctions,
-          ignoreUndefined,
-          path
-        );
-      } else if (typeof value === 'function' && serializeFunctions) {
+        if (value instanceof Date || isDate(value)) {
+          index = serializeDate(buffer, key, value, index);
+        } else if (value instanceof Uint8Array || isUint8Array(value)) {
+          index = serializeBuffer(buffer, key, value, index);
+        } else if (value instanceof RegExp || isRegExp(value)) {
+          index = serializeRegExp(buffer, key, value, index);
+        } else {
+          index = serializeObject(
+            buffer,
+            key,
+            value,
+            index,
+            checkKeys,
+            depth,
+            serializeFunctions,
+            ignoreUndefined,
+            path
+          );
+        }
+      } else if (type === 'object') {
+        if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
+          throw new BSONVersionError();
+        } else if (value._bsontype === 'ObjectId') {
+          index = serializeObjectId(buffer, key, value, index);
+        } else if (value._bsontype === 'Decimal128') {
+          index = serializeDecimal128(buffer, key, value, index);
+        } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
+          index = serializeLong(buffer, key, value, index);
+        } else if (value._bsontype === 'Double') {
+          index = serializeDouble(buffer, key, value, index);
+        } else if (value._bsontype === 'Code') {
+          index = serializeCode(
+            buffer,
+            key,
+            value,
+            index,
+            checkKeys,
+            depth,
+            serializeFunctions,
+            ignoreUndefined,
+            path
+          );
+        } else if (value._bsontype === 'Binary') {
+          index = serializeBinary(buffer, key, value, index);
+        } else if (value._bsontype === 'BSONSymbol') {
+          index = serializeSymbol(buffer, key, value, index);
+        } else if (value._bsontype === 'DBRef') {
+          index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
+        } else if (value._bsontype === 'BSONRegExp') {
+          index = serializeBSONRegExp(buffer, key, value, index);
+        } else if (value._bsontype === 'Int32') {
+          index = serializeInt32(buffer, key, value, index);
+        } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
+          index = serializeMinMax(buffer, key, value, index);
+        } else if (typeof value._bsontype !== 'undefined') {
+          throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
+        }
+      } else if (type === 'function' && serializeFunctions) {
         index = serializeFunction(buffer, key, value, index);
-      } else if (value._bsontype === 'Binary') {
-        index = serializeBinary(buffer, key, value, index);
-      } else if (value._bsontype === 'BSONSymbol') {
-        index = serializeSymbol(buffer, key, value, index);
-      } else if (value._bsontype === 'DBRef') {
-        index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
-      } else if (value._bsontype === 'BSONRegExp') {
-        index = serializeBSONRegExp(buffer, key, value, index);
-      } else if (value._bsontype === 'Int32') {
-        index = serializeInt32(buffer, key, value, index);
-      } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
-        index = serializeMinMax(buffer, key, value, index);
-      } else if (typeof value._bsontype !== 'undefined') {
-        throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
       }
     }
   }

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -1,31 +1,54 @@
+const map = new WeakMap<object, string>();
+
+/**
+ * Retrieves the prototype.toString() of a value.
+ * If the value is an object, it will cache the result in a WeakMap for future use.
+ */
+function getPrototypeString(value: unknown): string {
+  let str = map.get(value as object);
+
+  if (!str) {
+    str = Object.prototype.toString.call(value);
+    if (value !== null && typeof value === 'object') {
+      map.set(value, str);
+    }
+  }
+  return str;
+}
+
 export function isAnyArrayBuffer(value: unknown): value is ArrayBuffer {
-  return ['[object ArrayBuffer]', '[object SharedArrayBuffer]'].includes(
-    Object.prototype.toString.call(value)
-  );
+  const type = getPrototypeString(value);
+  return ['[object ArrayBuffer]', '[object SharedArrayBuffer]'].includes(type);
 }
 
 export function isUint8Array(value: unknown): value is Uint8Array {
-  return Object.prototype.toString.call(value) === '[object Uint8Array]';
+  const type = getPrototypeString(value);
+  return type === '[object Uint8Array]';
 }
 
 export function isBigInt64Array(value: unknown): value is BigInt64Array {
-  return Object.prototype.toString.call(value) === '[object BigInt64Array]';
+  const type = getPrototypeString(value);
+  return type === '[object BigInt64Array]';
 }
 
 export function isBigUInt64Array(value: unknown): value is BigUint64Array {
-  return Object.prototype.toString.call(value) === '[object BigUint64Array]';
+  const type = getPrototypeString(value);
+  return type === '[object BigUint64Array]';
 }
 
 export function isRegExp(d: unknown): d is RegExp {
-  return Object.prototype.toString.call(d) === '[object RegExp]';
+  const type = getPrototypeString(d);
+  return type === '[object RegExp]';
 }
 
 export function isMap(d: unknown): d is Map<unknown, unknown> {
-  return Object.prototype.toString.call(d) === '[object Map]';
+  const type = getPrototypeString(d);
+  return type === '[object Map]';
 }
 
 export function isDate(d: unknown): d is Date {
-  return Object.prototype.toString.call(d) === '[object Date]';
+  const type = getPrototypeString(d);
+  return type === '[object Date]';
 }
 
 export type InspectFn = (x: unknown, options?: unknown) => string;

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -1,5 +1,16 @@
 const map = new WeakMap<object, string>();
 
+const TYPES = {
+  ArrayBuffer: '[object ArrayBuffer]',
+  SharedArrayBuffer: '[object SharedArrayBuffer]',
+  Uint8Array: '[object Uint8Array]',
+  BigInt64Array: '[object BigInt64Array]',
+  BigUint64Array: '[object BigUint64Array]',
+  RegExp: '[object RegExp]',
+  Map: '[object Map]',
+  Date: '[object Date]'
+};
+
 /**
  * Retrieves the prototype.toString() of a value.
  * If the value is an object, it will cache the result in a WeakMap for future use.
@@ -18,37 +29,37 @@ function getPrototypeString(value: unknown): string {
 
 export function isAnyArrayBuffer(value: unknown): value is ArrayBuffer {
   const type = getPrototypeString(value);
-  return ['[object ArrayBuffer]', '[object SharedArrayBuffer]'].includes(type);
+  return type === TYPES.ArrayBuffer || type === TYPES.SharedArrayBuffer;
 }
 
 export function isUint8Array(value: unknown): value is Uint8Array {
   const type = getPrototypeString(value);
-  return type === '[object Uint8Array]';
+  return type === TYPES.Uint8Array;
 }
 
 export function isBigInt64Array(value: unknown): value is BigInt64Array {
   const type = getPrototypeString(value);
-  return type === '[object BigInt64Array]';
+  return type === TYPES.BigInt64Array;
 }
 
 export function isBigUInt64Array(value: unknown): value is BigUint64Array {
   const type = getPrototypeString(value);
-  return type === '[object BigUint64Array]';
+  return type === TYPES.BigUint64Array;
 }
 
 export function isRegExp(d: unknown): d is RegExp {
   const type = getPrototypeString(d);
-  return type === '[object RegExp]';
+  return type === TYPES.RegExp;
 }
 
 export function isMap(d: unknown): d is Map<unknown, unknown> {
   const type = getPrototypeString(d);
-  return type === '[object Map]';
+  return type === TYPES.Map;
 }
 
 export function isDate(d: unknown): d is Date {
   const type = getPrototypeString(d);
-  return type === '[object Date]';
+  return type === TYPES.Date;
 }
 
 export type InspectFn = (x: unknown, options?: unknown) => string;


### PR DESCRIPTION
### Description

This MR improves serialization (and `calculateSize`) performance by up to 20-40% in my tests using MFlix documents.

| Test Case               | Ops/sec (previous) | Ops/sec (new) | Improvement (%) |
|-------------------------|----------------|-------------------|-----------------|
| `serialize`             | 3,102,374      | 3,752,681         | 20.96%          |
| `calculateSize`         | 23,983,120     | 33,635,923        | 40.25%          |
| `serialize large doc`   | 719,650        | 926,643           | 28.76%          |


- `Object.prototype.toString.call(x)` seems to be quite expensive
- Re-order serialization type checks to move these calls out of hot paths
- Add WeakMap cache for repeated calls (ie. calling isDate(x), isRegExp(x), isUint8Array(x) will only result in 1 `Object.prototype.toString.call(x)`)
- Add global symbol constant so it doesn't have to search the symbol registry for every property

#### What is changing?

It may look like a lot of changes, but most of the changes here are just re-ordering the type checks during serialization. There shouldn't be any functionality changes here and all tests are passing.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Serialization performance improved.

Optimizations have been implemented with respect to BSON serialization across the board, resulting in up to 20% gains in serialization with a sample of [MFlix](https://www.mongodb.com/docs/atlas/sample-data/sample-mflix/) documents. Many thanks to @SeanReece for the contribution.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
