### PR TITLE
test(NODE-6358): perf test against current branch

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -230,7 +230,7 @@ tasks:
         vars:
           TS_VERSION: "next"
           TRY_COMPILING_LIBRARY: "false"
-  - name: run-granular-benchmarks-node-18
+  - name: run-granular-benchmarks
     commands:
       - func: fetch source
         vars:
@@ -246,7 +246,7 @@ tasks:
       - command: perf.send
         params:
           file: src/test/bench/etc/resultsCollectedMeans.json
-  - name: run-spec-benchmarks-node-18
+  - name: run-spec-benchmarks
     commands:
       - func: fetch source
         vars:
@@ -298,5 +298,5 @@ buildvariants:
     display_name: RHEL 9.0 perf
     run_on: rhel90-dbx-perf-large
     tasks:
-      - run-granular-benchmarks-node-18
-      - run-spec-benchmarks-node-18
+      - run-granular-benchmarks
+      - run-spec-benchmarks

--- a/.evergreen/run-granular-benchmarks.sh
+++ b/.evergreen/run-granular-benchmarks.sh
@@ -5,4 +5,4 @@ set -o xtrace
 WARMUP=$WARMUP
 ITERATIONS=$ITERATIONS
 
-WARMUP=$WARMUP ITERATIONS=$ITERATIONS npm run check:granular-bench
+WARMUP=$WARMUP ITERATIONS=$ITERATIONS LIBRARY=$(pwd) npm run check:granular-bench

--- a/package-lock.json
+++ b/package-lock.json
@@ -2909,10 +2909,11 @@
       }
     },
     "node_modules/dbx-js-tools": {
-      "resolved": "git+ssh://git@github.com/mongodb-js/dbx-js-tools.git#ff17fe959a3d5df34418fc7bfe61a12bcfdc7c0e",
+      "resolved": "git+ssh://git@github.com/mongodb-js/dbx-js-tools.git#043a59032103b41c1244134554861850f5a82681",
       "dev": true,
       "workspaces": [
-        "packages/bson-bench"
+        "packages/bson-bench",
+        "packages/driver-bench"
       ]
     },
     "node_modules/debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "benchmark": "^2.1.4",
         "chai": "^4.4.1",
         "chalk": "^5.3.0",
-        "dbx-js-tools": "github:mongodb-js/dbx-js-tools#NODE-6358",
+        "dbx-js-tools": "github:mongodb-js/dbx-js-tools",
         "eslint": "^9.8.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-no-bigint-usage": "file:etc/eslint/no-bigint-usage",
@@ -2909,7 +2909,7 @@
       }
     },
     "node_modules/dbx-js-tools": {
-      "resolved": "git+ssh://git@github.com/mongodb-js/dbx-js-tools.git#dae74f9c58ffc657c3c827d5f9bd8edb019c1ac9",
+      "resolved": "git+ssh://git@github.com/mongodb-js/dbx-js-tools.git#b2d505fcfa6fc13566c0cb5ab0ff9741fc7580a1",
       "dev": true,
       "workspaces": [
         "packages/bson-bench",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "benchmark": "^2.1.4",
         "chai": "^4.4.1",
         "chalk": "^5.3.0",
-        "dbx-js-tools": "github:mongodb-js/dbx-js-tools",
+        "dbx-js-tools": "github:mongodb-js/dbx-js-tools#NODE-6358",
         "eslint": "^9.8.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-no-bigint-usage": "file:etc/eslint/no-bigint-usage",
@@ -2909,7 +2909,7 @@
       }
     },
     "node_modules/dbx-js-tools": {
-      "resolved": "git+ssh://git@github.com/mongodb-js/dbx-js-tools.git#043a59032103b41c1244134554861850f5a82681",
+      "resolved": "git+ssh://git@github.com/mongodb-js/dbx-js-tools.git#dae74f9c58ffc657c3c827d5f9bd8edb019c1ac9",
       "dev": true,
       "workspaces": [
         "packages/bson-bench",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "benchmark": "^2.1.4",
     "chai": "^4.4.1",
     "chalk": "^5.3.0",
-    "dbx-js-tools": "github:mongodb-js/dbx-js-tools",
+    "dbx-js-tools": "github:mongodb-js/dbx-js-tools#NODE-6358",
     "eslint": "^9.8.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-no-bigint-usage": "file:etc/eslint/no-bigint-usage",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "benchmark": "^2.1.4",
     "chai": "^4.4.1",
     "chalk": "^5.3.0",
-    "dbx-js-tools": "github:mongodb-js/dbx-js-tools#NODE-6358",
+    "dbx-js-tools": "github:mongodb-js/dbx-js-tools",
     "eslint": "^9.8.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-no-bigint-usage": "file:etc/eslint/no-bigint-usage",


### PR DESCRIPTION
### Description

Updates benchmarks to run against current branch.

#### What is changing?

- Sets `LIBRARY` in the environment to the current working directory.
- Updates dbx-js-tools to latest.
- Removes the Node version from the bench task names.

*NOTE* this PR will clear perf benchmark history.

Here's a run pointing at https://github.com/mongodb-js/dbx-js-tools/pull/20

https://spruce.mongodb.com/task/node_bson_perf_run_granular_benchmarks_patch_426c781b3f944bb100a3e70268f3a17210a1178f_66d87ce9c5ee6b0007ef93c4_24_09_04_15_29_49/logs?execution=0

That PR merged, new PR here:

https://spruce.mongodb.com/task/node_bson_perf_run_granular_benchmarks_patch_886391587154866befadc8dd44110411ed54d1ff_66d8e533246d3100075d3bec_24_09_04_22_54_45/logs?execution=0

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6358

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
