### PR TITLE
docs(NODE-6302): add SerializableTypes to migration guide

### DIFF
--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -10,6 +10,7 @@
 - [Other Changes](#other-changes)
   - [`serializeFunctions` bug fix](#serializefunctions-bug-fix)
   - [TS "target" set to es2020](#ts-target-set-to-es2020)
+  - [Removed SerializableTypes](#removed-serializabletypes)
 
 ## About
 
@@ -313,3 +314,15 @@ import { serialize } from 'bson5';
 serialize({ _id: new ObjectId() });
 // Uncaught BSONVersionError: Unsupported BSON version, bson types must be from bson 5.0 or later
 ```
+
+### Removed SerializableTypes
+
+```ts
+export type JSONPrimitive = string | number | boolean | null;
+export type SerializableTypes = Document | Array<JSONPrimitive | Document> | JSONPrimitive;
+```
+
+`SerializableTypes` is removed in v5 due to it inaccuracy and inconvenience when working with return type of `EJSON.parse()`.
+This type does not contain all possible outputs from this function and it cannot be conveniently related to a custom declared type.
+`EJSON.parse` and `EJSON.stringify` now accept `any` in alignment with `JSON`'s corresponding APIs.
+For users that desire type strictness it is recommended to wrap these APIs with type annotations that take/return `unknown` since that generally forces better narrowing logic than `SerializableTypes` would have prompted.

--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -322,7 +322,7 @@ export type JSONPrimitive = string | number | boolean | null;
 export type SerializableTypes = Document | Array<JSONPrimitive | Document> | JSONPrimitive;
 ```
 
-`SerializableTypes` is removed in v5 due to it inaccuracy and inconvenience when working with return type of `EJSON.parse()`.
+`SerializableTypes` is removed in v5 due to its inaccuracy and inconvenience when working with return type of `EJSON.parse()`.
 This type does not contain all possible outputs from this function and it cannot be conveniently related to a custom declared type.
 `EJSON.parse` and `EJSON.stringify` now accept `any` in alignment with `JSON`'s corresponding APIs.
 For users that desire type strictness it is recommended to wrap these APIs with type annotations that take/return `unknown` since that generally forces better narrowing logic than `SerializableTypes` would have prompted.


### PR DESCRIPTION
### Description

#### What is changing?

- Fix missing SerializableTypes section from v5 migration

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Adding this to the migration guide makes clear our motive and desired path forward

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
