### PR TITLE
chore(NODE-6382): add benchmarking for helpers

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -267,7 +267,7 @@ tasks:
       - func: run custom benchmarks
       - command: perf.send
         params:
-          file: src/results.json
+          file: src/customBenchmarkResults.json
   - name: run-spec-benchmarks
     commands:
       - func: fetch source

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -267,7 +267,7 @@ tasks:
       - func: run custom benchmarks
       - command: perf.send
         params:
-          file: results.json
+          file: src/results.json
   - name: run-spec-benchmarks
     commands:
       - func: fetch source

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -113,6 +113,15 @@ functions:
         add_expansions_to_env: true
         args:
           - .evergreen/run-granular-benchmarks.sh
+  run custom benchmarks:
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src
+        binary: bash
+        add_expansions_to_env: true
+        args:
+          - .evergreen/run-custom-benchmarks.sh
   run spec benchmarks:
     - command: subprocess.exec
       type: test
@@ -246,6 +255,19 @@ tasks:
       - command: perf.send
         params:
           file: src/test/bench/etc/resultsCollectedMeans.json
+  - name: run-custom-benchmarks
+    commands:
+      - func: fetch source
+        vars:
+          # This needs to stay pinned at Node v18.16.0 for consistency across perf runs.
+          NODE_LTS_VERSION: v18.16.0
+      - func: install dependencies
+        vars:
+          NPM_VERSION: 9
+      - func: run custom benchmarks
+      - command: perf.send
+        params:
+          file: results.json
   - name: run-spec-benchmarks
     commands:
       - func: fetch source
@@ -300,3 +322,4 @@ buildvariants:
     tasks:
       - run-granular-benchmarks
       - run-spec-benchmarks
+      - run-custom-benchmarks

--- a/.evergreen/run-custom-benchmarks.sh
+++ b/.evergreen/run-custom-benchmarks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source "${PROJECT_DIRECTORY}/.evergreen/init-node-and-npm-env.sh"
+set -o xtrace
+
+npm run check:custom-bench

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ docs/public
 .nvmrc
 
 benchmarks.json
-results.json
+customBenchmarkResults.json

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/public
 .nvmrc
 
 benchmarks.json
+results.json

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "check:web-no-bigint": "WEB=true NO_BIGINT=true mocha test/node",
     "check:granular-bench": "npm run build:bench && node ./test/bench/etc/run_granular_benchmarks.js",
     "check:spec-bench": "npm run build:bench && node ./test/bench/lib/spec/bsonBench.js",
+    "check:custom-bench": "npm run build && node ./test/bench/custom/main.mjs",
     "build:bench": "cd test/bench && npx tsc",
     "build:ts": "node ./node_modules/typescript/bin/tsc",
     "build:dts": "npm run build:ts && api-extractor run --typescript-compiler-folder node_modules/typescript --local && node etc/clean_definition_files.cjs",

--- a/test/bench/custom/benchmarks.mjs
+++ b/test/bench/custom/benchmarks.mjs
@@ -1,0 +1,20 @@
+/* eslint-disable strict */
+import { BSON } from '../../../lib/bson.mjs';
+
+const ObjectId_isValid = [
+  function objectid_isvalid_strlen() {
+    BSON.ObjectId.isValid('a');
+  },
+  function objectid_isvalid_bestcase_false() {
+    BSON.ObjectId.isValid('g6e84ebdc96f4c0772f0cbbf');
+  },
+  function objectid_isvalid_worstcase_false() {
+    BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbg');
+  },
+  function objectid_isvalid_true() {
+    BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbf');
+  }
+];
+
+// Add benchmarks here:
+export const benchmarks = [...ObjectId_isValid];

--- a/test/bench/custom/benchmarks.mjs
+++ b/test/bench/custom/benchmarks.mjs
@@ -5,10 +5,12 @@ const ObjectId_isValid = [
   function objectid_isvalid_strlen() {
     BSON.ObjectId.isValid('a');
   },
-  function objectid_isvalid_bestcase_false() {
+  /** wrong character at the start */
+  function objectid_isvalid_most_short_circuit_false() {
     BSON.ObjectId.isValid('g6e84ebdc96f4c0772f0cbbf');
   },
-  function objectid_isvalid_worstcase_false() {
+  /** wrong character at the end */
+  function objectid_isvalid_least_short_circuit_false() {
     BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbg');
   },
   function objectid_isvalid_true() {

--- a/test/bench/custom/benchmarks.mjs
+++ b/test/bench/custom/benchmarks.mjs
@@ -2,18 +2,18 @@
 import { BSON } from '../../../lib/bson.mjs';
 
 const ObjectId_isValid = [
-  function objectid_isvalid_strlen() {
+  function objectid_isvalid_wrong_string_length() {
     BSON.ObjectId.isValid('a');
   },
-  /** wrong character at the start */
-  function objectid_isvalid_most_short_circuit_false() {
+  /** wrong character at the start, could be the most short circuited code path */
+  function objectid_isvalid_invalid_hex_at_start() {
     BSON.ObjectId.isValid('g6e84ebdc96f4c0772f0cbbf');
   },
-  /** wrong character at the end */
-  function objectid_isvalid_least_short_circuit_false() {
+  /** wrong character at the end, could be the least short circuited code path */
+  function objectid_isvalid_invalid_hex_at_end() {
     BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbg');
   },
-  function objectid_isvalid_true() {
+  function objectid_isvalid_valid_hex_string() {
     BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbf');
   }
 ];

--- a/test/bench/custom/main.mjs
+++ b/test/bench/custom/main.mjs
@@ -1,0 +1,56 @@
+/* eslint-disable strict */
+
+import util from 'node:util';
+import fs from 'node:fs';
+import os from 'node:os';
+import benchmark from 'benchmark';
+import { BSON } from '../../../lib/bson.mjs';
+
+const hw = os.cpus();
+const ram = os.totalmem() / 1024 ** 3;
+const platform = { name: hw[0].model, cores: hw.length, ram: `${ram}GB` };
+
+const systemInfo = () =>
+  [
+    `\n- cpu: ${platform.name}`,
+    `- cores: ${platform.cores}`,
+    `- arch: ${os.arch()}`,
+    `- os: ${process.platform} (${os.release()})`,
+    `- ram: ${platform.ram}\n`
+  ].join('\n');
+console.log(systemInfo());
+
+const suite = new benchmark.Suite();
+
+benchmark.options = {
+  async: false,
+  defer: false,
+  initCount: 1000,
+  minSamples: 1000
+};
+
+suite
+  .add('objectid_isvalid_strlen', function objectid_isvalid_strlen() {
+    BSON.ObjectId.isValid('a');
+  })
+  .add('objectid_isvalid_bestcase_false', function objectid_isvalid_bestcase_false() {
+    BSON.ObjectId.isValid('g6e84ebdc96f4c0772f0cbbf');
+  })
+  .add('objectid_isvalid_worstcase_false', function objectid_isvalid_worstcase_false() {
+    BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbg');
+  })
+  .add('objectid_isvalid_true', function objectid_isvalid_true() {
+    BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbf');
+  })
+  .on('cycle', function logBenchmark(event) {
+    console.log(String(event.target));
+  })
+  .on('complete', function outputPerfSend() {
+    const data = Array.from(this).map(bench => ({
+      info: { test_name: bench.name },
+      metrics: [{ name: 'ops_per_sec', value: bench.hz }]
+    }));
+    console.log(util.inspect(data, { depth: Infinity, colors: true }));
+    fs.writeFileSync('results.json', JSON.stringify(data), 'utf8');
+  })
+  .run();

--- a/test/bench/custom/main.mjs
+++ b/test/bench/custom/main.mjs
@@ -34,6 +34,6 @@ suite
       metrics: [{ name: 'ops_per_sec', value: bench.hz }]
     }));
     console.log(util.inspect(data, { depth: Infinity, colors: true }));
-    fs.writeFileSync('results.json', JSON.stringify(data), 'utf8');
+    fs.writeFileSync('customBenchmarkResults.json', JSON.stringify(data), 'utf8');
   })
   .run();

--- a/test/bench/custom/main.mjs
+++ b/test/bench/custom/main.mjs
@@ -4,7 +4,7 @@ import util from 'node:util';
 import fs from 'node:fs';
 import os from 'node:os';
 import benchmark from 'benchmark';
-import { BSON } from '../../../lib/bson.mjs';
+import { benchmarks } from './benchmarks.mjs';
 
 const hw = os.cpus();
 const ram = os.totalmem() / 1024 ** 3;
@@ -22,26 +22,9 @@ console.log(systemInfo());
 
 const suite = new benchmark.Suite();
 
-benchmark.options = {
-  async: false,
-  defer: false,
-  initCount: 1000,
-  minSamples: 1000
-};
+for (const bench of benchmarks) suite.add(bench.name, bench);
 
 suite
-  .add('objectid_isvalid_strlen', function objectid_isvalid_strlen() {
-    BSON.ObjectId.isValid('a');
-  })
-  .add('objectid_isvalid_bestcase_false', function objectid_isvalid_bestcase_false() {
-    BSON.ObjectId.isValid('g6e84ebdc96f4c0772f0cbbf');
-  })
-  .add('objectid_isvalid_worstcase_false', function objectid_isvalid_worstcase_false() {
-    BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbg');
-  })
-  .add('objectid_isvalid_true', function objectid_isvalid_true() {
-    BSON.ObjectId.isValid('66e84ebdc96f4c0772f0cbbf');
-  })
   .on('cycle', function logBenchmark(event) {
     console.log(String(event.target));
   })

--- a/test/bench/custom/readme.md
+++ b/test/bench/custom/readme.md
@@ -1,0 +1,33 @@
+# Custom Benchmark Tests
+
+In this directory are tests for code paths not covered by our spec or granular (de)serialization benchmarks.
+
+## How to write your own
+
+In `main.mjs` call the `.add` function and pass it an underscore concatenated descriptive title.
+Try to fit the title into the format of: "subject area", "method or function" "test case that is being covered" (Ex. `objectid_isvalid_bestcase_false`).
+Copy the title to the name of the function to assist with debugging and flamegraph capturing.
+
+### Example
+
+```js
+.add('subject_function_testcase', function subject_function_testcase() {
+  BSON.ObjectId.isValid('g6e84ebdc96f4c0772f0cbbf');
+})
+```
+
+## Output
+
+The JSON emitted at the end of the benchmarks must follow our performance tracking format.
+
+The JSON must be an array of "`Test`"s:
+
+```ts
+type Metric = { name: string, value: number }
+type Test = {
+    info: { test_name: string },
+    metrics: Metric[]
+}
+```
+
+The metric collected is always "ops_per_sec" so higher is better.

--- a/test/bench/custom/readme.md
+++ b/test/bench/custom/readme.md
@@ -4,16 +4,21 @@ In this directory are tests for code paths not covered by our spec or granular (
 
 ## How to write your own
 
-In `main.mjs` call the `.add` function and pass it an underscore concatenated descriptive title.
-Try to fit the title into the format of: "subject area", "method or function" "test case that is being covered" (Ex. `objectid_isvalid_bestcase_false`).
-Copy the title to the name of the function to assist with debugging and flamegraph capturing.
+In `benchmarks.mjs` add a new test to an existing array or make a new array for a new subject area.
+Try to fit the name of the function into the format of: "subject area", "method or function" "test case that is being covered" (Ex. `objectid_isvalid_bestcase_false`).
+Make sure your test is added to the `benchmarks` export.
 
 ### Example
 
 ```js
-.add('subject_function_testcase', function subject_function_testcase() {
-  BSON.ObjectId.isValid('g6e84ebdc96f4c0772f0cbbf');
-})
+const ObjectId_isValid = [
+  function objectid_isvalid_strlen() {
+    BSON.ObjectId.isValid('a');
+  },
+  // ...
+];
+
+export const benchmarks = [...ObjectId_isValid];
 ```
 
 ## Output


### PR DESCRIPTION
### Description

#### What is changing?

- Adds a benchmark suite that will output to our trendcharting tool.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- There are a number of code paths that don't relate to serialize/deserialize but can still be useful for critical paths in an application. It would be useful to improve those where we can and ensure we maintain the improvements where they are made.
- Help with the change proposed: https://github.com/mongodb/js-bson/pull/708


### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
