### PR TITLE
chore(NODE-6018): run entire BSON suite on a big endian machine

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -50,16 +50,6 @@ functions:
         args:
           - .evergreen/run-tests.sh
 
-  run big endian tests:
-    - command: subprocess.exec
-      type: test
-      params:
-        working_dir: src
-        add_expansions_to_env: true
-        binary: bash
-        args:
-          - .evergreen/run-big-endian-test.sh
-
   run checks:
     - command: subprocess.exec
       type: test
@@ -165,6 +155,14 @@ tasks:
           NODE_LTS_VERSION: 20
       - func: install dependencies
       - func: run tests
+  - name: node-tests-v22
+    tags: ["node"]
+    commands:
+      - func: fetch source
+        vars:
+          NODE_LTS_VERSION: 22
+      - func: install dependencies
+      - func: run tests
   - name: node-tests-latest
     tags: ["node"]
     commands:
@@ -180,7 +178,7 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: 22
       - func: install dependencies
       - func: run tests
         vars:
@@ -189,7 +187,7 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: 22
       - func: install dependencies
       - func: run bundling
   - name: no-bigint-web-tests
@@ -197,7 +195,7 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: 22
       - func: install dependencies
       - func: run tests
         vars:
@@ -209,14 +207,14 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: 22
       - func: install dependencies
       - func: run checks
   - name: check-typescript-oldest
     commands:
       - func: fetch source
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: 22
       - func: install dependencies
       - func: "run typescript"
         vars:
@@ -226,7 +224,7 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: 22
       - func: install dependencies
       - func: "run typescript"
         vars:
@@ -236,7 +234,7 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: 22
       - func: install dependencies
       - func: "run typescript"
         vars:
@@ -288,18 +286,9 @@ tasks:
     commands:
       - func: fetch source
         vars:
-          NODE_LTS_VERSION: 20
+          NODE_LTS_VERSION: 22
       - func: install dependencies
       - func: run eslint plugin tests
-  - name: node-tests-big-endian
-    commands:
-      - func: fetch source
-        vars:
-          NODE_LTS_VERSION: 20
-      - func: install dependencies
-        vars:
-          NPM_OPTIONS: "--ignore-scripts"
-      - func: run big endian tests
 
 buildvariants:
   - name: linux
@@ -307,9 +296,9 @@ buildvariants:
     run_on: rhel80-small
     tasks: [".node", ".web", "check-eslint-plugin"]
   - name: linux-zseries
-    display_name: RHEL 8.3 zSeries
-    run_on: rhel83-zseries-small
-    tasks: ["node-tests-big-endian"]
+    display_name: RHEL 9.0 zSeries
+    run_on: rhel9-zseries-small
+    tasks: [".node", ".web"]
   - name: lint
     display_name: lint
     run_on: rhel80-small

--- a/test/node/big_endian.test.ts
+++ b/test/node/big_endian.test.ts
@@ -9,10 +9,10 @@ FLOAT[0] = -1;
 // Big endian    [191, 240, 0, 0, 0, 0, 0, 0]
 const isBigEndian = FLOAT_BYTES[7] === 0;
 
-context(`handles big endianness correctly`, () => {
+describe(`handles big endianness correctly`, () => {
   before(function () {
     if (!isBigEndian) {
-      throw new Error('expected to only run on big endian system');
+      this.skip();
     }
   });
 

--- a/test/node/double.test.ts
+++ b/test/node/double.test.ts
@@ -339,7 +339,9 @@ describe('BSON Double Precision', function () {
     expect(type).to.equal(BSON_DATA_NUMBER);
     expect(type).to.not.equal(BSON_DATA_INT);
     expect(serializedDouble.subarray(7, 15)).to.deep.equal(
-      new Uint8Array(new Float64Array([-0]).buffer)
+      // Use this on an LE system to re-create the following bytes:
+      // new Uint8Array(new Float64Array([-0]).buffer)
+      new Uint8Array([0, 0, 0, 0, 0, 0, 0, 128])
     );
   });
 

--- a/test/node/release.test.ts
+++ b/test/node/release.test.ts
@@ -66,6 +66,14 @@ const REQUIRED_FILES = [
 
 describe(`Release ${packFile}`, function () {
   let tarFileList;
+
+  before(function () {
+    if (process.arch !== 'x64') {
+      // This test doesn't need to run more than once on one of our platforms.
+      this.skip();
+    }
+  });
+
   before(function () {
     this.timeout(120_000); // npm pack can be slow
     expect(fs.existsSync(packFile), `expected ${packFile} to NOT exist`).to.equal(false);
@@ -81,7 +89,11 @@ describe(`Release ${packFile}`, function () {
   });
 
   after(() => {
-    fs.unlinkSync(packFile);
+    try {
+      fs.unlinkSync(packFile);
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
   });
 
   for (const requiredFile of REQUIRED_FILES) {


### PR DESCRIPTION
### Description

#### What is changing?

- Add entire suite to zSeries machines to get full coverage on a big endian machine
- Adds Node.js 22 to BSON CI and bump to 22 in tasks that are node version agnostic 
- Skip npm pack test (unnecessary to run on more than one platform)
- fix double test for big endian environment
- Upgraded to RHEL 9 on zSeries because rollup requires GLIBC 2.29+

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Prepare for future feature work that is endian sensitive.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
