### PR TITLE
fix(NODE-6536): Binary.read never returns number[] and reads beyond content

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -61,8 +61,47 @@ export class Binary extends BSONValue {
   /** User BSON type */
   static readonly SUBTYPE_USER_DEFINED = 128;
 
+  /**
+   * The bytes of the Binary value.
+   *
+   * The format of a Binary value in BSON is defined as:
+   * ```txt
+   * binary	::= int32 subtype (byte*)
+   * ```
+   *
+   * This `buffer` is the "(byte*)" segment.
+   *
+   * Unless the value is subtype 2, then deserialize will read the first 4 bytes as an int32 and set this to the remaining bytes.
+   *
+   * ```txt
+   * binary	::= int32 unsigned_byte(2) int32 (byte*)
+   * ```
+   *
+   * @see https://bsonspec.org/spec.html
+   */
   public buffer: Uint8Array;
+  /**
+   * The binary subtype.
+   *
+   * Current defined values are:
+   *
+   * - `unsigned_byte(0)` Generic binary subtype
+   * - `unsigned_byte(1)` Function
+   * - `unsigned_byte(2)` Binary (Deprecated)
+   * - `unsigned_byte(3)` UUID (Deprecated)
+   * - `unsigned_byte(4)` UUID
+   * - `unsigned_byte(5)` MD5
+   * - `unsigned_byte(6)` Encrypted BSON value
+   * - `unsigned_byte(7)` Compressed BSON column
+   * - `unsigned_byte(8)` Sensitive
+   * - `unsigned_byte(9)` Vector
+   * - `unsigned_byte(128)` - `unsigned_byte(255)` User defined
+   */
   public sub_type: number;
+  /**
+   * The Binary's `buffer` can be larger than the Binary's content.
+   * This property is used to determine where the content ends in the buffer.
+   */
   public position: number;
 
   /**

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -61,9 +61,9 @@ export class Binary extends BSONValue {
   /** User BSON type */
   static readonly SUBTYPE_USER_DEFINED = 128;
 
-  buffer!: Uint8Array;
-  sub_type!: number;
-  position!: number;
+  public buffer: Uint8Array;
+  public sub_type: number;
+  public position: number;
 
   /**
    * Create a new Binary instance.
@@ -160,16 +160,15 @@ export class Binary extends BSONValue {
   }
 
   /**
-   * Reads **length** bytes starting at **position**.
+   * Returns a view of **length** bytes starting at **position**.
    *
    * @param position - read from the given position in the Binary.
    * @param length - the number of bytes to read.
    */
-  read(position: number, length: number): BinarySequence {
+  read(position: number, length: number): Uint8Array {
     length = length && length > 0 ? length : this.position;
-
-    // Let's return the data based on the type we have
-    return this.buffer.slice(position, position + length);
+    const end = position + length;
+    return this.buffer.subarray(position, end > this.position ? this.position : end);
   }
 
   /** returns a view of the binary value as a Uint8Array */
@@ -219,7 +218,7 @@ export class Binary extends BSONValue {
 
   toUUID(): UUID {
     if (this.sub_type === Binary.SUBTYPE_UUID) {
-      return new UUID(this.buffer.slice(0, this.position));
+      return new UUID(this.buffer.subarray(0, this.position));
     }
 
     throw new BSONError(

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -85,3 +85,5 @@ expectNotDeprecated(new ObjectId(42 as string | number));
 
 // Timestamp accepts timestamp because constructor allows: {i:number, t:number}
 new Timestamp(new Timestamp(0n))
+
+expectType<(position: number, length: number) => Uint8Array>(Binary.prototype.read);


### PR DESCRIPTION
### Description

#### What is changing?

- Fix Binary.read return type to be correctly Uint8Array
- Use subarray instead of slice so there isn't inconsistent view/copy between node and web
- Prevent reading beyond serializable user data
- Remove dead code from deserializer (buffer.slice is always defined)
- Searched for our usages of slice when we mean to use subarray to get views not copies. This has no impact on Node, fixes browser environments making copies where we did not intend to

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Correctness and consistency

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Binary's `read()` returns a view of Uint8Array

Binary's `read()` return type claimed it would return `number[]` or Uint8Array which was true in previous BSON versions that didn't _always_ store a Uint8Array on the buffer property like `Binary` does today.

`read()`'s length parameter did not respect the position value allowing reading bytes beyond the data that is actually stored in the Binary. This has been corrected.

Additionally this method returned a view in Node.js environemnets and a copy in Web environments. it has been fixed to always return a view. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
