### PR TITLE
chore(NODE-6564): add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
### Description

Adds dependabot config to update Github Actions.

#### What is changing?

Adds dependabot config to update Github Actions.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6564

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
