### PR TITLE
fix(NODE-6735, NODE-6711): add BSON vector validation to EJSON stringification, serialization and conversion to native types

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -517,6 +517,12 @@ export function validateBinaryVector(vector: Binary): void {
     throw new BSONError('Invalid Vector: padding must be zero for int8 and float32 vectors');
   }
 
+  if (datatype === Binary.VECTOR_TYPE.Float32) {
+    if (size !== 0 && size - 2 !== 0 && (size - 2) % 4 !== 0) {
+      throw new BSONError('Invalid Vector: Float32 vector must contain a multiple of 4 bytes');
+    }
+  }
+
   if (datatype === Binary.VECTOR_TYPE.PackedBit && padding !== 0 && size === 2) {
     throw new BSONError(
       'Invalid Vector: padding must be zero for packed bit vectors that are empty'

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -341,6 +341,8 @@ export class Binary extends BSONValue {
       throw new BSONError('Binary datatype field is not Int8');
     }
 
+    validateBinaryVector(this);
+
     return new Int8Array(
       this.buffer.buffer.slice(this.buffer.byteOffset + 2, this.buffer.byteOffset + this.position)
     );
@@ -360,6 +362,8 @@ export class Binary extends BSONValue {
     if (this.buffer[0] !== Binary.VECTOR_TYPE.Float32) {
       throw new BSONError('Binary datatype field is not Float32');
     }
+
+    validateBinaryVector(this);
 
     const floatBytes = new Uint8Array(
       this.buffer.buffer.slice(this.buffer.byteOffset + 2, this.buffer.byteOffset + this.position)
@@ -386,6 +390,8 @@ export class Binary extends BSONValue {
     if (this.buffer[0] !== Binary.VECTOR_TYPE.PackedBit) {
       throw new BSONError('Binary datatype field is not packed bit');
     }
+
+    validateBinaryVector(this);
 
     return new Uint8Array(
       this.buffer.buffer.slice(this.buffer.byteOffset + 2, this.buffer.byteOffset + this.position)

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -415,6 +415,8 @@ export class Binary extends BSONValue {
       throw new BSONError('Binary datatype field is not packed bit');
     }
 
+    validateBinaryVector(this);
+
     const byteCount = this.length() - 2;
     const bitCount = byteCount * 8 - this.buffer[1];
     const bits = new Int8Array(bitCount);

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -442,7 +442,9 @@ export class Binary extends BSONValue {
     buffer[1] = 0;
     const intBytes = new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
     buffer.set(intBytes, 2);
-    return new this(buffer, this.SUBTYPE_VECTOR);
+    const bin = new this(buffer, this.SUBTYPE_VECTOR);
+    validateBinaryVector(bin);
+    return bin;
   }
 
   /** Constructs a Binary representing an Float32 Vector. */
@@ -456,7 +458,9 @@ export class Binary extends BSONValue {
 
     if (NumberUtils.isBigEndian) ByteUtils.swap32(new Uint8Array(binaryBytes.buffer, 2));
 
-    return new this(binaryBytes, this.SUBTYPE_VECTOR);
+    const bin = new this(binaryBytes, this.SUBTYPE_VECTOR);
+    validateBinaryVector(bin);
+    return bin;
   }
 
   /**
@@ -469,7 +473,9 @@ export class Binary extends BSONValue {
     buffer[0] = Binary.VECTOR_TYPE.PackedBit;
     buffer[1] = padding;
     buffer.set(array, 2);
-    return new this(buffer, this.SUBTYPE_VECTOR);
+    const bin = new this(buffer, this.SUBTYPE_VECTOR);
+    validateBinaryVector(bin);
+    return bin;
   }
 
   /**

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -52,10 +52,8 @@ function dtypeToHelper(dtype_hex: string) {
       return 'fromPackedBits';
     case '0x03' /* int8 */:
       return 'fromInt8Array';
-      break;
     case '0x27' /* float32 */:
       return 'fromFloat32Array';
-      break;
     default:
       throw new Error(`Unknown dtype_hex: ${dtype_hex}`);
   }

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -185,6 +185,22 @@ function testVectorInvalidBSONBytes(test: VectorTest, expectedErrorMessage: stri
       expect(thrownError?.message).to.match(new RegExp(expectedErrorMessage));
     });
 
+    if (toHelper === 'toPackedBits') {
+      it(`Binary.toBits() throw a BSONError`, function () {
+        let thrownError: Error | undefined;
+        const bin = BSON.deserialize(Buffer.from(test.canonical_bson!, 'hex'));
+
+        try {
+          bin.vector.toBits();
+        } catch (error) {
+          thrownError = error;
+        }
+
+        expect(thrownError, thrownError?.stack).to.be.instanceOf(BSONError);
+        expect(thrownError?.message).to.match(new RegExp(expectedErrorMessage));
+      });
+    }
+
     it(`EJSON.stringify() throw a BSONError`, function () {
       let thrownError: Error | undefined;
       const bin = BSON.deserialize(Buffer.from(test.canonical_bson!, 'hex'));

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -176,7 +176,7 @@ function testVectorInvalidInputValues(test: VectorTest, expectedErrorMessage: st
 }
 
 function testVectorInvalidBSONBytes(test: VectorTest, expectedErrorMessage: string) {
-  describe('when creating a Binary Vector instance from invalid bytes', () => {
+  describe('when encoding a Binary Vector made from invalid bytes', () => {
     it(`BSON.serialize() throw a BSONError`, function () {
       let thrownError: Error | undefined;
       const bin = BSON.deserialize(Buffer.from(test.canonical_bson!, 'hex'));

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -188,7 +188,7 @@ function testVectorInvalidBSONBytes(test: VectorTest, expectedErrorMessage: stri
   });
 }
 
-describe.only('BSON Binary Vector spec tests', () => {
+describe('BSON Binary Vector spec tests', () => {
   const tests: Record<string, VectorSuite> = Object.create(null);
 
   for (const file of fs.readdirSync(path.join(__dirname, 'specs/bson-binary-vector'))) {

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -121,45 +121,45 @@ function catchError<T>(
 }
 
 function testVectorInvalidInputValues(test: VectorTest, expectedErrorMessage: string) {
-  describe('when creating a BSON Vector given invalid input values', () => {
-    const binaryCreation = catchError(make.bind(null, test.vector!, test.dtype_hex, test.padding));
-    const bsonBytesCreation =
-      binaryCreation.status !== 'thrown'
-        ? catchError(BSON.serialize.bind(null, { bin: binaryCreation.result }))
-        : undefined;
-    const ejsonStringCreation =
-      binaryCreation.status !== 'thrown'
-        ? catchError(BSON.EJSON.stringify.bind(null, { bin: binaryCreation.result }))
-        : undefined;
+  const binaryCreation = catchError(make.bind(null, test.vector!, test.dtype_hex, test.padding));
+  const bsonBytesCreation =
+    binaryCreation.status !== 'thrown'
+      ? catchError(BSON.serialize.bind(null, { bin: binaryCreation.result }))
+      : undefined;
+  const ejsonStringCreation =
+    binaryCreation.status !== 'thrown'
+      ? catchError(BSON.EJSON.stringify.bind(null, { bin: binaryCreation.result }))
+      : undefined;
 
-    const binaryHelperValidations = [
-      'Padding specified with no vector data PACKED_BIT',
-      'Exceeding maximum padding PACKED_BIT',
-      'Negative padding PACKED_BIT',
-      ...Array.from(invalidTestExpectedError.entries())
-        .filter(([, v]) => v === 'unsupported_error')
-        .map(([k]) => k)
-    ];
+  const binaryHelperValidations = [
+    'Padding specified with no vector data PACKED_BIT',
+    'Exceeding maximum padding PACKED_BIT',
+    'Negative padding PACKED_BIT',
+    ...Array.from(invalidTestExpectedError.entries())
+      .filter(([, v]) => v === 'unsupported_error')
+      .map(([k]) => k)
+  ];
 
-    const errorType = expectedErrorMessage === 'unsupported_error' ? Error : BSONError;
-    const errorName = expectedErrorMessage === 'unsupported_error' ? 'Error' : 'BSONError';
+  const errorType = expectedErrorMessage === 'unsupported_error' ? Error : BSONError;
+  const errorName = expectedErrorMessage === 'unsupported_error' ? 'Error' : 'BSONError';
 
-    const check = outcome => {
-      expect(outcome).to.exist;
-      expect(outcome.status).to.equal('thrown');
-      expect(outcome.result).to.be.instanceOf(errorType);
-      expect(outcome.result)
-        .to.have.property('message')
-        .that.matches(new RegExp(expectedErrorMessage));
-    };
+  const check = outcome => {
+    expect(outcome).to.exist;
+    expect(outcome.status).to.equal('thrown');
+    expect(outcome.result).to.be.instanceOf(errorType);
+    expect(outcome.result).to.match(new RegExp(expectedErrorMessage));
+  };
 
-    if (binaryHelperValidations.includes(test.description)) {
+  if (binaryHelperValidations.includes(test.description)) {
+    describe('when creating a BSON Vector given invalid input values', () => {
       it(`Binary.${dtypeToHelper(test.dtype_hex)}() throws a ${errorName}`, function () {
         check(binaryCreation);
       });
-    } else {
-      expect(errorName).to.equal('BSONError'); // unsupported_error are only when making vectors
+    });
+  } else {
+    expect(errorName).to.equal('BSONError'); // unsupported_error are only when making vectors
 
+    describe('when encoding a BSON Vector given invalid input values', () => {
       it(`Binary.${dtypeToHelper(test.dtype_hex)}() does not throw`, function () {
         expect(binaryCreation).to.have.property('status', 'returned');
       });
@@ -171,8 +171,8 @@ function testVectorInvalidInputValues(test: VectorTest, expectedErrorMessage: st
       it(`EJSON.stringify() throws a BSONError`, function () {
         check(ejsonStringCreation);
       });
-    }
-  });
+    });
+  }
 }
 
 function testVectorInvalidBSONBytes(test: VectorTest, expectedErrorMessage: string) {

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -172,6 +172,21 @@ function testVectorInvalidBSONBytes(test: VectorTest, expectedErrorMessage: stri
       expect(thrownError?.message).to.match(new RegExp(expectedErrorMessage));
     });
 
+    const toHelper = dtypeToHelper(test.dtype_hex).replace('from', 'to');
+    it(`Binary.${toHelper}() throw a BSONError`, function () {
+      let thrownError: Error | undefined;
+      const bin = BSON.deserialize(Buffer.from(test.canonical_bson!, 'hex'));
+
+      try {
+        bin.vector[toHelper]();
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError, thrownError?.stack).to.be.instanceOf(BSONError);
+      expect(thrownError?.message).to.match(new RegExp(expectedErrorMessage));
+    });
+
     it(`EJSON.stringify() throw a BSONError`, function () {
       let thrownError: Error | undefined;
       const bin = BSON.deserialize(Buffer.from(test.canonical_bson!, 'hex'));

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -165,7 +165,7 @@ function testVectorInvalidInputValues(test: VectorTest, expectedErrorMessage: st
     } else {
       expect(errorName).to.equal('BSONError'); // unsupported_error are only when making vectors
 
-      it(`Binary.${dtypeToHelper(test.dtype_hex)}() not throw`, function () {
+      it(`Binary.${dtypeToHelper(test.dtype_hex)}() does not throw`, function () {
         expect(binaryCreation).to.have.property('status', 'returned');
       });
 

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -18,14 +18,10 @@ type VectorTest = {
 type VectorSuite = { description: string; test_key: string; tests: VectorTest[] };
 
 function fixFloats(f: string | number): number {
+  // Should be nothing to "fix" but validates we didn't get
+  // an unexpected type so we don't silently fail on it during the test
   if (typeof f === 'number') {
     return f;
-  }
-  if (f === 'inf') {
-    return Infinity;
-  }
-  if (f === '-inf') {
-    return -Infinity;
   }
   throw new Error(`test format error: unknown float value: ${f}`);
 }
@@ -98,8 +94,6 @@ const invalidTestExpectedError = new Map()
   .set('Overflow Vector INT8', false)
   .set('Underflow Vector INT8', false)
   .set('INT8 with float inputs', false)
-  // duplicate test! but also skipped.
-  .set('Vector with float values PACKED_BIT', false)
   .set('Vector with float values PACKED_BIT', false);
 
 function testVectorBuilding(test: VectorTest, expectedErrorMessage: string) {
@@ -184,7 +178,7 @@ describe('BSON Binary Vector spec tests', () => {
   const tests: Record<string, VectorSuite> = Object.create(null);
 
   for (const file of fs.readdirSync(path.join(__dirname, 'specs/bson-binary-vector'))) {
-    tests[path.basename(file, '.json')] = JSON.parse(
+    tests[path.basename(file, '.json')] = EJSON.parse(
       fs.readFileSync(path.join(__dirname, 'specs/bson-binary-vector', file), 'utf8')
     );
   }

--- a/test/node/bson_binary_vector.spec.test.ts
+++ b/test/node/bson_binary_vector.spec.test.ts
@@ -1,7 +1,6 @@
 import * as util from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as assert from 'node:assert/strict';
 import { BSON, BSONError, Binary, EJSON } from '../register-bson';
 import { expect } from 'chai';
 
@@ -110,10 +109,6 @@ const invalidTestExpectedError = new Map()
   .set('Underflow Vector INT8', 'unsupported_error')
   .set('INT8 with float inputs', 'unsupported_error')
   .set('Vector with float values PACKED_BIT', 'unsupported_error');
-
-const invalidTestsWhereHelpersDoNotThrow = new Set()
-  .add('FLOAT32 with padding')
-  .add('INT8 with padding');
 
 function catchError<T>(
   fn: () => T

--- a/test/node/specs/bson-binary-vector/float32.json
+++ b/test/node/specs/bson-binary-vector/float32.json
@@ -44,8 +44,15 @@
       "vector": [127.0, 7.0],
       "dtype_hex": "0x27",
       "dtype_alias": "FLOAT32",
-      "padding": 3
+      "padding": 3,
+      "canonical_bson": "1C00000005766563746F72000A0000000927030000FE420000E04000"
+    },
+    {
+      "description": "Insufficient vector data FLOAT32",
+      "valid": false,
+      "dtype_hex": "0x27",
+      "dtype_alias": "FLOAT32",
+      "canonical_bson": "1700000005766563746F7200050000000927002A2A2A00"
     }
   ]
 }
-

--- a/test/node/specs/bson-binary-vector/float32.json
+++ b/test/node/specs/bson-binary-vector/float32.json
@@ -32,7 +32,7 @@
     {
       "description": "Infinity Vector FLOAT32",
       "valid": true,
-      "vector": ["-inf", 0.0, "inf"],
+      "vector": [{"$numberDouble": "-Infinity"}, 0.0, {"$numberDouble": "Infinity"} ],
       "dtype_hex": "0x27",
       "dtype_alias": "FLOAT32",
       "padding": 0,
@@ -48,11 +48,18 @@
       "canonical_bson": "1C00000005766563746F72000A0000000927030000FE420000E04000"
     },
     {
-      "description": "Insufficient vector data FLOAT32",
+      "description": "Insufficient vector data with 3 bytes FLOAT32",
       "valid": false,
       "dtype_hex": "0x27",
       "dtype_alias": "FLOAT32",
       "canonical_bson": "1700000005766563746F7200050000000927002A2A2A00"
+    },
+    {
+      "description": "Insufficient vector data with 5 bytes FLOAT32",
+      "valid": false,
+      "dtype_hex": "0x27",
+      "dtype_alias": "FLOAT32",
+      "canonical_bson": "1900000005766563746F7200070000000927002A2A2A2A2A00"
     }
   ]
 }

--- a/test/node/specs/bson-binary-vector/int8.json
+++ b/test/node/specs/bson-binary-vector/int8.json
@@ -42,7 +42,8 @@
       "vector": [127, 7],
       "dtype_hex": "0x03",
       "dtype_alias": "INT8",
-      "padding": 3
+      "padding": 3,
+      "canonical_bson": "1600000005766563746F7200040000000903037F0700"
     },
     {
       "description": "INT8 with float inputs",
@@ -54,4 +55,3 @@
     }
   ]
 }
-

--- a/test/node/specs/bson-binary-vector/packed_bit.json
+++ b/test/node/specs/bson-binary-vector/packed_bit.json
@@ -8,7 +8,8 @@
       "vector": [],
       "dtype_hex": "0x10",
       "dtype_alias": "PACKED_BIT",
-      "padding": 1
+      "padding": 1,
+      "canonical_bson": "1400000005766563746F72000200000009100100"
     },
     {
       "description": "Simple Vector PACKED_BIT",
@@ -62,20 +63,13 @@
       "padding": 0
     },
     {
-      "description": "Padding specified with no vector data PACKED_BIT",
-      "valid": false,
-      "vector": [],
-      "dtype_hex": "0x10",
-      "dtype_alias": "PACKED_BIT",
-      "padding": 1
-    },
-    {
       "description": "Exceeding maximum padding PACKED_BIT",
       "valid": false,
       "vector": [1],
       "dtype_hex": "0x10",
       "dtype_alias": "PACKED_BIT",
-      "padding": 8
+      "padding": 8,
+      "canonical_bson": "1500000005766563746F7200030000000910080100"
     },
     {
       "description": "Negative padding PACKED_BIT",
@@ -84,15 +78,6 @@
       "dtype_hex": "0x10",
       "dtype_alias": "PACKED_BIT",
       "padding": -1
-    },
-    {
-      "description": "Vector with float values PACKED_BIT",
-      "valid": false,
-      "vector": [127.5],
-      "dtype_hex": "0x10",
-      "dtype_alias": "PACKED_BIT",
-      "padding": 0
     }
   ]
 }
-


### PR DESCRIPTION
### Description

#### What is changing?

NODE-6735 and NODE-6711

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Prevent the creation of incorrectly sized float32 vectors

This adds validation to our `BSON.serialize` and `EJSON.stringify` methods that will prevent creating float 32 vectors that are not a multiple of 4. Previously created vectors that do not meet this validation will still be `deserialized` and `parsed` so they can be fixed. 

Additionally, the `toFloat32Array()`, `toInt8Array()`, and `toPackedBits()` methods now perform the same validation that serialize does to prevent use of incorrectly formatted Binary vector values. (For example, a packed bits vector with more than 7 bits of padding)

Vectors of an incorrect length could only be made manually (directly constructing the bytes and calling `new Binary`). We recommend using `toFloat32Array` and `fromFloat32Array` when interacting with Vectors in MongoDB as they handle the proper creation and translation of this data type.  

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
