### PR TITLE
fix(NODE-6074): Removes top-level await in bson with separate node and browser ESM bundles

### DIFF
--- a/etc/rollup/rollup-plugin-require-rewriter/require_rewriter.mjs
+++ b/etc/rollup/rollup-plugin-require-rewriter/require_rewriter.mjs
@@ -1,44 +1,46 @@
 import MagicString from 'magic-string';
 
-const CRYPTO_IMPORT_ESM_SRC = `const nodejsRandomBytes = await (async () => {
+const CRYPTO_IMPORT_ESM_SRC = `import { randomBytes as nodejsRandomBytes } from 'crypto';`;
+const BROWSER_ESM_SRC = `const nodejsRandomBytes = nodejsMathRandomBytes;`;
+const CODE_TO_REPLACE = `const nodejsRandomBytes = (() => {
     try {
-        return (await import('crypto')).randomBytes;`;
-
-export class RequireRewriter {
-  /**
-   * Take the compiled source code input; types are expected to already have been removed
-   * Look for the function that depends on crypto, replace it with a top-level await
-   * and dynamic import for the crypto module.
-   *
-   * @param {string} code - source code of the module being transformed
-   * @param {string} id - module id (usually the source file name)
-   * @returns {{ code: string; map: import('magic-string').SourceMap }}
-   */
-  transform(code, id) {
-    if (!id.includes('node_byte_utils')) {
-      return;
+        return require('crypto').randomBytes;
     }
-    if (!code.includes('const nodejsRandomBytes')) {
-      throw new Error(`Unexpected! 'const nodejsRandomBytes' is missing from ${id}`);
+    catch {
+        return nodejsMathRandomBytes;
     }
+})();`;
 
-    const start = code.indexOf('const nodejsRandomBytes');
-    const endString = `return require('crypto').randomBytes;`;
-    const end = code.indexOf(endString) + endString.length;
+export function requireRewriter({ isBrowser = false } = {}) {
+  return {
+    /**
+     * Take the compiled source code input; types are expected to already have been removed
+     * Look for the function that depends on crypto, replace it with a top-level await
+     * and dynamic import for the crypto module.
+     *
+     * @param {string} code - source code of the module being transformed
+     * @param {string} id - module id (usually the source file name)
+     * @returns {{ code: string; map: import('magic-string').SourceMap }}
+     */
+    transform(code, id) {
+      if (!id.includes('node_byte_utils')) {
+        return;
+      }
+      const start = code.indexOf(CODE_TO_REPLACE);
+      if (start === -1) {
+        throw new Error(`Unexpected! Code meant to be replaced is missing from ${id}`);
+      }
 
-    if (start < 0 || end < 0) {
-      throw new Error(
-        `Unexpected! 'const nodejsRandomBytes' or 'return require('crypto').randomBytes;' not found`
-      );
+      const end = start + CODE_TO_REPLACE.length;
+
+      // MagicString lets us edit the source code and still generate an accurate source map
+      const magicString = new MagicString(code);
+      magicString.overwrite(start, end, isBrowser ? BROWSER_ESM_SRC : CRYPTO_IMPORT_ESM_SRC);
+
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap({ hires: true })
+      };
     }
-
-    // MagicString lets us edit the source code and still generate an accurate source map
-    const magicString = new MagicString(code);
-    magicString.overwrite(start, end, CRYPTO_IMPORT_ESM_SRC);
-
-    return {
-      code: magicString.toString(),
-      map: magicString.generateMap({ hires: true })
-    };
-  }
+  };
 }

--- a/package.json
+++ b/package.json
@@ -75,18 +75,18 @@
     "native": false
   },
   "main": "./lib/bson.cjs",
-  "module": "./lib/bson.mjs",
+  "module": "./lib/bson.node.mjs",
   "exports": {
-    "import": {
+    "browser": {
       "types": "./bson.d.ts",
-      "default": "./lib/bson.mjs"
-    },
-    "require": {
-      "types": "./bson.d.ts",
-      "default": "./lib/bson.cjs"
+      "default": "./lib/bson.browser.mjs"
     },
     "react-native": "./lib/bson.rn.cjs",
-    "browser": "./lib/bson.mjs"
+    "default": {
+      "types": "./bson.d.ts",
+      "import": "./lib/bson.node.mjs",
+      "require": "./lib/bson.cjs"
+    }
   },
   "compass:exports": {
     "import": "./lib/bson.cjs",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,6 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
-import { RequireRewriter } from './etc/rollup/rollup-plugin-require-rewriter/require_rewriter.mjs';
+import { requireRewriter } from './etc/rollup/rollup-plugin-require-rewriter/require_rewriter.mjs';
 import { RequireVendor } from './etc/rollup/rollup-plugin-require-vendor/require_vendor.mjs';
 
 /** @type {typescript.RollupTypescriptOptions} */
@@ -55,9 +55,22 @@ const config = [
   },
   {
     input,
-    plugins: [typescript(tsConfig), new RequireRewriter(), nodeResolve({ resolveOnly: [] })],
+    plugins: [
+      typescript(tsConfig),
+      requireRewriter({ isBrowser: true }),
+      nodeResolve({ resolveOnly: [] })
+    ],
     output: {
-      file: 'lib/bson.mjs',
+      file: 'lib/bson.browser.mjs',
+      format: 'esm',
+      sourcemap: true
+    }
+  },
+  {
+    input,
+    plugins: [typescript(tsConfig), requireRewriter(), nodeResolve({ resolveOnly: [] })],
+    output: {
+      file: 'lib/bson.node.mjs',
       format: 'esm',
       sourcemap: true
     }

--- a/test/bundling/webpack/readme.md
+++ b/test/bundling/webpack/readme.md
@@ -1,7 +1,6 @@
 # Webpack BSON setup example
 
-In order to use BSON with webpack there are two changes beyond the default config file needed:
-- Set `experiments: { topLevelAwait: true }` in the top-level config object
+In order to use BSON with webpack there is one change beyond the default config file needed:
 - Set `resolve: { fallback: { crypto: false } }` in the top-level config object
 
 ## Testing

--- a/test/bundling/webpack/webpack.config.js
+++ b/test/bundling/webpack/webpack.config.js
@@ -14,7 +14,6 @@ const config = {
     // Add your plugins here
     // Learn more about plugins from https://webpack.js.org/configuration/plugins/
   ],
-  experiments: { topLevelAwait: true },
   module: {
     rules: [
       {

--- a/test/node/byte_utils.test.ts
+++ b/test/node/byte_utils.test.ts
@@ -694,11 +694,11 @@ describe('ByteUtils', () => {
       });
     });
 
-    describe('nodejs es module environment dynamically imports crypto', function () {
+    describe('nodejs es module environment imports crypto', function () {
       let bsonImportedFromESMMod;
 
       beforeEach(async function () {
-        const { exports } = await loadESModuleBSON({});
+        const { exports } = await loadESModuleBSON();
         bsonImportedFromESMMod = exports;
       });
 

--- a/test/node/exports.test.ts
+++ b/test/node/exports.test.ts
@@ -69,31 +69,31 @@ describe('bson entrypoint', () => {
 
     it('maintains the order of keys in exports conditions', async () => {
       expect(pkg).property('exports').is.a('object');
-      expect(pkg).nested.property('exports.import').is.a('object');
-      expect(pkg).nested.property('exports.require').is.a('object');
+      expect(pkg).nested.property('exports.browser').is.a('object');
+      expect(pkg).nested.property('exports.default').is.a('object');
 
       expect(
         Object.keys(pkg.exports),
         'Order matters in the exports fields. import/require need to proceed the "bundler" targets (RN/browser) and react-native MUST proceed browser'
-      ).to.deep.equal(['import', 'require', 'react-native', 'browser']);
+      ).to.deep.equal(['browser', 'react-native', 'default']);
 
       // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing
       expect(
-        Object.keys(pkg.exports.import),
+        Object.keys(pkg.exports.browser),
         'TS docs say that `types` should ALWAYS proceed `default`'
       ).to.deep.equal(['types', 'default']);
       expect(
-        Object.keys(pkg.exports.require),
+        Object.keys(pkg.exports.default),
         'TS docs say that `types` should ALWAYS proceed `default`'
-      ).to.deep.equal(['types', 'default']);
+      ).to.deep.equal(['types', 'import', 'require']);
 
       expect(Object.keys(pkg['compass:exports'])).to.deep.equal(['import', 'require']);
     });
 
     it('has the equivalent "bson.d.ts" value for all "types" specifiers', () => {
       expect(pkg).property('types', 'bson.d.ts');
-      expect(pkg).nested.property('exports.import.types', './bson.d.ts');
-      expect(pkg).nested.property('exports.require.types', './bson.d.ts');
+      expect(pkg).nested.property('exports.browser.types', './bson.d.ts');
+      expect(pkg).nested.property('exports.default.types', './bson.d.ts');
     });
   });
 });


### PR DESCRIPTION
### Description

#### What is changing?

The bundling process has been changed to make two separate ESM bundles for browsers and Node.js respectively.

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

The main motivation for this change is that the top level async-await usage breaks hot refresh in Next.js when importing this library on the client, as documented in this issue https://github.com/vercel/next.js/issues/61452 with a reproduction in this repo https://github.com/flo-dao/repro-fast-refresh.

The code does execute fine, it's specifically that the hot refresh behavior is broken. This is very problematic on applications that are very stateful and leverage hot refresh to have a quick iteration cycle. The current state is that when changing any module that imports `"bson"` it causes a full-page refresh, and you lose all of the state driving the UI you were developing

This has been raised before in this repo in https://github.com/mongodb/js-bson/pull/669 with a corresponding ticket that was closed without resolution https://jira.mongodb.org/browse/NODE-6074.

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
