### PR TITLE
fix(NODE-6818): flip byte order depending on system endianness

### DIFF
--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -1,6 +1,11 @@
 const FLOAT = new Float64Array(1);
 const FLOAT_BYTES = new Uint8Array(FLOAT.buffer, 0, 8);
 
+FLOAT[0] = -1;
+// Little endian [0, 0, 0, 0, 0, 0,  240, 191]
+// Big endian    [191, 240, 0, 0, 0, 0, 0, 0]
+const isBigEndian = FLOAT_BYTES[7] === 0;
+
 /**
  * Number parsing and serializing utilities.
  *
@@ -59,17 +64,29 @@ export const NumberUtils = {
   },
 
   /** Reads a little-endian 64-bit float from source */
-  getFloat64LE(source: Uint8Array, offset: number): number {
-    FLOAT_BYTES[0] = source[offset];
-    FLOAT_BYTES[1] = source[offset + 1];
-    FLOAT_BYTES[2] = source[offset + 2];
-    FLOAT_BYTES[3] = source[offset + 3];
-    FLOAT_BYTES[4] = source[offset + 4];
-    FLOAT_BYTES[5] = source[offset + 5];
-    FLOAT_BYTES[6] = source[offset + 6];
-    FLOAT_BYTES[7] = source[offset + 7];
-    return FLOAT[0];
-  },
+  getFloat64LE: isBigEndian
+    ? (source: Uint8Array, offset: number) => {
+        FLOAT_BYTES[7] = source[offset];
+        FLOAT_BYTES[6] = source[offset + 1];
+        FLOAT_BYTES[5] = source[offset + 2];
+        FLOAT_BYTES[4] = source[offset + 3];
+        FLOAT_BYTES[3] = source[offset + 4];
+        FLOAT_BYTES[2] = source[offset + 5];
+        FLOAT_BYTES[1] = source[offset + 6];
+        FLOAT_BYTES[0] = source[offset + 7];
+        return FLOAT[0];
+      }
+    : (source: Uint8Array, offset: number) => {
+        FLOAT_BYTES[0] = source[offset];
+        FLOAT_BYTES[1] = source[offset + 1];
+        FLOAT_BYTES[2] = source[offset + 2];
+        FLOAT_BYTES[3] = source[offset + 3];
+        FLOAT_BYTES[4] = source[offset + 4];
+        FLOAT_BYTES[5] = source[offset + 5];
+        FLOAT_BYTES[6] = source[offset + 6];
+        FLOAT_BYTES[7] = source[offset + 7];
+        return FLOAT[0];
+      },
 
   /** Writes a big-endian 32-bit integer to destination, can be signed or unsigned */
   setInt32BE(destination: Uint8Array, offset: number, value: number): 4 {
@@ -129,16 +146,29 @@ export const NumberUtils = {
   },
 
   /** Writes a little-endian 64-bit float to destination */
-  setFloat64LE(destination: Uint8Array, offset: number, value: number): 8 {
-    FLOAT[0] = value;
-    destination[offset] = FLOAT_BYTES[0];
-    destination[offset + 1] = FLOAT_BYTES[1];
-    destination[offset + 2] = FLOAT_BYTES[2];
-    destination[offset + 3] = FLOAT_BYTES[3];
-    destination[offset + 4] = FLOAT_BYTES[4];
-    destination[offset + 5] = FLOAT_BYTES[5];
-    destination[offset + 6] = FLOAT_BYTES[6];
-    destination[offset + 7] = FLOAT_BYTES[7];
-    return 8;
-  }
+  setFloat64LE: isBigEndian
+    ? (destination: Uint8Array, offset: number, value: number) => {
+        FLOAT[0] = value;
+        destination[offset] = FLOAT_BYTES[7];
+        destination[offset + 1] = FLOAT_BYTES[6];
+        destination[offset + 2] = FLOAT_BYTES[5];
+        destination[offset + 3] = FLOAT_BYTES[4];
+        destination[offset + 4] = FLOAT_BYTES[3];
+        destination[offset + 5] = FLOAT_BYTES[2];
+        destination[offset + 6] = FLOAT_BYTES[1];
+        destination[offset + 7] = FLOAT_BYTES[0];
+        return 8;
+      }
+    : (destination: Uint8Array, offset: number, value: number) => {
+        FLOAT[0] = value;
+        destination[offset] = FLOAT_BYTES[0];
+        destination[offset + 1] = FLOAT_BYTES[1];
+        destination[offset + 2] = FLOAT_BYTES[2];
+        destination[offset + 3] = FLOAT_BYTES[3];
+        destination[offset + 4] = FLOAT_BYTES[4];
+        destination[offset + 5] = FLOAT_BYTES[5];
+        destination[offset + 6] = FLOAT_BYTES[6];
+        destination[offset + 7] = FLOAT_BYTES[7];
+        return 8;
+      }
 };

--- a/test/node/utils/number_utils.test.ts
+++ b/test/node/utils/number_utils.test.ts
@@ -1,7 +1,32 @@
 import { expect } from 'chai';
 import { NumberUtils } from '../../../src/utils/number_utils';
 
+const FLOAT = new Float64Array(1);
+const FLOAT_BYTES = new Uint8Array(FLOAT.buffer, 0, 8);
+
+FLOAT[0] = -1;
+// Little endian [0, 0, 0, 0, 0, 0,  240, 191]
+// Big endian    [191, 240, 0, 0, 0, 0, 0, 0]
+const isBigEndian = FLOAT_BYTES[7] === 0;
+
 describe('NumberUtils', () => {
+  context(`handles ${isBigEndian ? 'big' : 'little'} endianness correctly`, () => {
+    context('getFloat64LE()', () => {
+      it('should return -1', () => {
+        const res = NumberUtils.getFloat64LE(new Uint8Array([0, 0, 0, 0, 0, 0, 240, 191]), 0);
+        expect(res).to.equal(-1);
+      });
+    });
+
+    context('setFloat64LE()', () => {
+      it('should return -1 as little endian bytes', () => {
+        const buf = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]);
+        NumberUtils.setFloat64LE(buf, 0, -1);
+        expect(buf).to.deep.equal(new Uint8Array([0, 0, 0, 0, 0, 0, 240, 191]));
+      });
+    });
+  });
+
   /** Make a Uint8Array in a less verbose way */
   const b = (...values) => new Uint8Array(values);
 


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed float byte-wise handling on big-endian systems

> [!CAUTION]
> Among the platforms BSON and the MongoDB driver support this issue impacts s390x big-endian systems. x86, ARM, and other little-endian systems are not affected. Existing versions of the driver can be upgraded to this release.

A recent change to the BSON library started parsing and serializing floats using a `Float64Array`. When reading the bytes from this array the ordering is dependent on the platform it is running on and we now properly account for that ordering.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
