### PR TITLE
fix(NODE-6764): incorrect negative bigint handling

### DIFF
--- a/src/utils/number_utils.ts
+++ b/src/utils/number_utils.ts
@@ -79,14 +79,23 @@ export const NumberUtils: NumberUtils = {
 
   /** Reads a little-endian 64-bit integer from source */
   getBigInt64LE(source: Uint8Array, offset: number): bigint {
-    const lo = NumberUtils.getUint32LE(source, offset);
-    const hi = NumberUtils.getUint32LE(source, offset + 4);
+    // eslint-disable-next-line no-restricted-globals
+    const hi = BigInt(
+      source[offset + 4] +
+        source[offset + 5] * 256 +
+        source[offset + 6] * 65536 +
+        (source[offset + 7] << 24)
+    ); // Overflow
 
-    /*
-      eslint-disable-next-line no-restricted-globals
-      -- This is allowed since this helper should not be called unless bigint features are enabled
-     */
-    return (BigInt(hi) << BigInt(32)) + BigInt(lo);
+    // eslint-disable-next-line no-restricted-globals
+    const lo = BigInt(
+      source[offset] +
+        source[offset + 1] * 256 +
+        source[offset + 2] * 65536 +
+        source[offset + 3] * 16777216
+    );
+    // eslint-disable-next-line no-restricted-globals
+    return (hi << BigInt(32)) + lo;
   },
 
   /** Reads a little-endian 64-bit float from source */

--- a/test/node/bigint.test.ts
+++ b/test/node/bigint.test.ts
@@ -105,6 +105,46 @@ describe('BSON BigInt support', function () {
 
       it(description, test);
     }
+
+    it('correctly deserializes min 64 bit int (-2n**63n)', function () {
+      expect(
+        BSON.deserialize(Buffer.from('10000000126100000000000000008000', 'hex'), {
+          useBigInt64: true
+        })
+      ).to.deep.equal({ a: -(2n ** 63n) });
+    });
+
+    it('correctly deserializes -1n', function () {
+      expect(
+        BSON.deserialize(Buffer.from('10000000126100FFFFFFFFFFFFFFFF00', 'hex'), {
+          useBigInt64: true
+        })
+      ).to.deep.equal({ a: -1n });
+    });
+
+    it('correctly deserializes 0n', function () {
+      expect(
+        BSON.deserialize(Buffer.from('10000000126100000000000000000000', 'hex'), {
+          useBigInt64: true
+        })
+      ).to.deep.equal({ a: 0n });
+    });
+
+    it('correctly deserializes 1n', function () {
+      expect(
+        BSON.deserialize(Buffer.from('10000000126100010000000000000000', 'hex'), {
+          useBigInt64: true
+        })
+      ).to.deep.equal({ a: 1n });
+    });
+
+    it('correctly deserializes max 64 bit int (2n**63n -1n)', function () {
+      expect(
+        BSON.deserialize(Buffer.from('10000000126100FFFFFFFFFFFFFF7F00', 'hex'), {
+          useBigInt64: true
+        })
+      ).to.deep.equal({ a: 2n ** 63n - 1n });
+    });
   });
 
   describe('BSON.serialize()', function () {


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
