### PR TITLE
chore(NODE-6938): update typescript to 5.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "tar": "^7.4.3",
         "ts-node": "^10.9.2",
         "tsd": "^0.31.1",
-        "typescript": "^5.5.4",
+        "typescript": "^5.8.3",
         "typescript-cached-transpile": "0.0.6",
         "uuid": "^11.1.0"
       },
@@ -6407,9 +6407,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "tar": "^7.4.3",
     "ts-node": "^10.9.2",
     "tsd": "^0.31.1",
-    "typescript": "^5.5.4",
+    "typescript": "^5.8.3",
     "typescript-cached-transpile": "0.0.6",
     "uuid": "^11.1.0"
   },

--- a/src/parser/on_demand/parse_to_elements.ts
+++ b/src/parser/on_demand/parse_to_elements.ts
@@ -33,7 +33,7 @@ const BSONElementType = {
   maxKey: 127
 } as const;
 
-type BSONElementType = typeof BSONElementType[keyof typeof BSONElementType];
+type BSONElementType = (typeof BSONElementType)[keyof typeof BSONElementType];
 
 /**
  * @public

--- a/src/parser/on_demand/parse_to_elements.ts
+++ b/src/parser/on_demand/parse_to_elements.ts
@@ -9,29 +9,31 @@ import { NumberUtils } from '../../utils/number_utils';
  * - `minKey` is set to 255 so unsigned comparisons succeed
  * - Modify with caution, double check the bundle contains literals
  */
-const enum BSONElementType {
-  double = 1,
-  string = 2,
-  object = 3,
-  array = 4,
-  binData = 5,
-  undefined = 6,
-  objectId = 7,
-  bool = 8,
-  date = 9,
-  null = 10,
-  regex = 11,
-  dbPointer = 12,
-  javascript = 13,
-  symbol = 14,
-  javascriptWithScope = 15,
-  int = 16,
-  timestamp = 17,
-  long = 18,
-  decimal = 19,
-  minKey = 255,
-  maxKey = 127
-}
+const BSONElementType = {
+  double: 1,
+  string: 2,
+  object: 3,
+  array: 4,
+  binData: 5,
+  undefined: 6,
+  objectId: 7,
+  bool: 8,
+  date: 9,
+  null: 10,
+  regex: 11,
+  dbPointer: 12,
+  javascript: 13,
+  symbol: 14,
+  javascriptWithScope: 15,
+  int: 16,
+  timestamp: 17,
+  long: 18,
+  decimal: 19,
+  minKey: 255,
+  maxKey: 127
+} as const;
+
+type BSONElementType = typeof BSONElementType[keyof typeof BSONElementType];
 
 /**
  * @public

--- a/test/bench/tsconfig.json
+++ b/test/bench/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "skipLibCheck": true,
+    "erasableSyntaxOnly": true,
     "lib": [
       "es2021"
     ],

--- a/test/bundling/webpack/package.json
+++ b/test/bundling/webpack/package.json
@@ -13,6 +13,7 @@
     "watch": "webpack --watch"
   },
   "devDependencies": {
+    "@webpack-cli/generators": "^3.0.1",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
     "webpack": "^5.99.7",

--- a/test/bundling/webpack/tsconfig.json
+++ b/test/bundling/webpack/tsconfig.json
@@ -4,7 +4,8 @@
     "noImplicitAny": true,
     "module": "es6",
     "target": "es5",
-    "allowJs": true
+    "allowJs": true,
+    "erasableSyntaxOnly": true
   },
   "files": ["src/index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "skipLibCheck": true,
+    "erasableSyntaxOnly": true,
     "lib": [
       "es2021",
       "ES2022.Error"


### PR DESCRIPTION
### Description

Updates typescript to 5.8.3

#### What is changing?
- Update typescript.
- Updates dependencies that were out of date with the TS update.
- Enable `erasableSyntaxOnly` option.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6938

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
