### PR TITLE
feat(NODE-7099): deprecate BSON binary subtype 2 constant

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -45,7 +45,9 @@ export class Binary extends BSONValue {
   static readonly SUBTYPE_DEFAULT = 0;
   /** Function BSON type */
   static readonly SUBTYPE_FUNCTION = 1;
-  /** Byte Array BSON type */
+  /** Legacy default BSON Binary type
+   * @deprecated BSON Binary subtype 2 is deprecated in the BSON specification
+   */
   static readonly SUBTYPE_BYTE_ARRAY = 2;
   /** Deprecated UUID BSON type @deprecated Please use SUBTYPE_UUID */
   static readonly SUBTYPE_UUID_OLD = 3;

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -45,7 +45,8 @@ export class Binary extends BSONValue {
   static readonly SUBTYPE_DEFAULT = 0;
   /** Function BSON type */
   static readonly SUBTYPE_FUNCTION = 1;
-  /** Legacy default BSON Binary type
+  /**
+   * Legacy default BSON Binary type
    * @deprecated BSON Binary subtype 2 is deprecated in the BSON specification
    */
   static readonly SUBTYPE_BYTE_ARRAY = 2;


### PR DESCRIPTION
### Description

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### BSON Binary Subtype 2 Constant Deprecated
BSON Binary subtype 2 was previously deprecated in the BSON specification, but the corresponding subtype constant remained available in the BSON library. This constant has now been deprecated to align with the specification.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
