### PR TITLE
fix(NODE-7436): EJSON.stringify type signature

### DIFF
--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -63,7 +63,7 @@ function isEJSONSerializeOptions(value: unknown): value is EJSONSerializeOptions
   if (value == null || typeof value !== 'object') {
     return false;
   }
-    
+
   // Check that all properties, if present, are of the correct type
   if ('legacy' in value && typeof value.legacy !== 'boolean') {
     return false;
@@ -74,11 +74,11 @@ function isEJSONSerializeOptions(value: unknown): value is EJSONSerializeOptions
   if ('ignoreUndefined' in value && typeof value.ignoreUndefined !== 'boolean') {
     return false;
   }
-  
+
   // Check that there are no invalid properties (only known EJSON serialize options)
   const validKeys = ['legacy', 'relaxed', 'ignoreUndefined'];
   const keys = Object.keys(value);
-  
+
   return keys.every(key => validKeys.includes(key));
 }
 
@@ -467,6 +467,7 @@ function parse(text: string, options?: EJSONParseOptions): any {
   });
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Converts a BSON document to an Extended JSON string, optionally replacing values if a replacer
  * function is specified or optionally including only the specified properties if a replacer array
@@ -488,13 +489,22 @@ function parse(text: string, options?: EJSONParseOptions): any {
  *
  * // prints '{"int32":10}'
  * console.log(EJSON.stringify(doc));
- * 
+ *
  * // prints '{"int32":{"$numberInt":"10"}}' with 2 space indentation
  * console.log(EJSON.stringify(doc, { relaxed: false }, 2));
  * ```
  */
-function stringify(value: any, replacer?: (number | string)[] | ((this: any, key: string, value: any) => any) | null, space?: string | number, options?: EJSONSerializeOptions): string;
-function stringify(value: any, replacer?: (number | string)[] | ((this: any, key: string, value: any) => any) | null, options?: EJSONSerializeOptions): string;
+function stringify(
+  value: any,
+  replacer?: (number | string)[] | ((this: any, key: string, value: any) => any) | null,
+  space?: string | number,
+  options?: EJSONSerializeOptions
+): string;
+function stringify(
+  value: any,
+  replacer?: (number | string)[] | ((this: any, key: string, value: any) => any) | null,
+  options?: EJSONSerializeOptions
+): string;
 function stringify(value: any, options?: EJSONSerializeOptions, space?: string | number): string;
 function stringify(
   value: any,
@@ -506,14 +516,22 @@ function stringify(
   spaceOrOptions?: string | number | EJSONSerializeOptions,
   options?: EJSONSerializeOptions
 ): string {
-  let replacer: ((this: any, key: string, value: any) => any) | (number | string)[] | null | undefined;
+  let replacer:
+    | ((this: any, key: string, value: any) => any)
+    | (number | string)[]
+    | null
+    | undefined;
   let space: string | number | undefined;
-  
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
   // Check if second parameter is options
   if (isEJSONSerializeOptions(replacerOrOptions)) {
     options = replacerOrOptions;
     replacer = undefined;
-    space = typeof spaceOrOptions === 'number' || typeof spaceOrOptions === 'string' ? spaceOrOptions : undefined;
+    space =
+      typeof spaceOrOptions === 'number' || typeof spaceOrOptions === 'string'
+        ? spaceOrOptions
+        : undefined;
   }
   // Check if third parameter is options
   else if (isEJSONSerializeOptions(spaceOrOptions)) {
@@ -524,9 +542,12 @@ function stringify(
   // Standard case: replacer, space, options
   else {
     replacer = replacerOrOptions;
-    space = typeof spaceOrOptions === 'number' || typeof spaceOrOptions === 'string' ? spaceOrOptions : undefined;
+    space =
+      typeof spaceOrOptions === 'number' || typeof spaceOrOptions === 'string'
+        ? spaceOrOptions
+        : undefined;
   }
-  
+
   const serializeOptions = Object.assign({ relaxed: true, legacy: false }, options, {
     seenObjects: [{ propertyName: '(root)', obj: null }]
   });

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -59,14 +59,6 @@ export type EJSONParseOptions = EJSONOptionsBase & {
 export type EJSONOptions = EJSONSerializeOptions & EJSONParseOptions;
 
 /** @internal */
-function isEJSONSerializeOptions(value: unknown): value is EJSONSerializeOptions {
-  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
-  return true;
-}
-
-/** @internal */
 type BSONType =
   | Binary
   | Code
@@ -500,36 +492,15 @@ function stringify(
   spaceOrOptions?: string | number | EJSONSerializeOptions,
   options?: EJSONSerializeOptions
 ): string {
-  let replacer:
-    | ((this: any, key: string, value: any) => any)
-    | (number | string)[]
-    | null
-    | undefined;
-  let space: string | number | undefined;
   /* eslint-enable @typescript-eslint/no-explicit-any */
 
-  // Check if second parameter is options
-  if (isEJSONSerializeOptions(replacerOrOptions)) {
-    options = replacerOrOptions;
-    replacer = undefined;
-    space =
-      typeof spaceOrOptions === 'number' || typeof spaceOrOptions === 'string'
-        ? spaceOrOptions
-        : undefined;
-  }
-  // Check if third parameter is options
-  else if (isEJSONSerializeOptions(spaceOrOptions)) {
+  if (spaceOrOptions != null && typeof spaceOrOptions === 'object') {
     options = spaceOrOptions;
-    replacer = replacerOrOptions;
-    space = undefined;
+    spaceOrOptions = undefined;
   }
-  // Standard case: replacer, space, options
-  else {
-    replacer = replacerOrOptions;
-    space =
-      typeof spaceOrOptions === 'number' || typeof spaceOrOptions === 'string'
-        ? spaceOrOptions
-        : undefined;
+  if (replacerOrOptions != null && typeof replacerOrOptions === 'object' && !Array.isArray(replacerOrOptions)) {
+    options = replacerOrOptions;
+    replacerOrOptions = undefined;
   }
 
   const serializeOptions = Object.assign({ relaxed: true, legacy: false }, options, {
@@ -537,7 +508,7 @@ function stringify(
   });
 
   const doc = serializeValue(value, serializeOptions);
-  return JSON.stringify(doc, replacer as Parameters<JSON['stringify']>[1], space);
+  return JSON.stringify(doc, replacerOrOptions as Parameters<JSON['stringify']>[1], spaceOrOptions);
 }
 
 /**

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -498,7 +498,11 @@ function stringify(
     options = spaceOrOptions;
     spaceOrOptions = undefined;
   }
-  if (replacerOrOptions != null && typeof replacerOrOptions === 'object' && !Array.isArray(replacerOrOptions)) {
+  if (
+    replacerOrOptions != null &&
+    typeof replacerOrOptions === 'object' &&
+    !Array.isArray(replacerOrOptions)
+  ) {
     options = replacerOrOptions;
     replacerOrOptions = undefined;
   }

--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -60,26 +60,10 @@ export type EJSONOptions = EJSONSerializeOptions & EJSONParseOptions;
 
 /** @internal */
 function isEJSONSerializeOptions(value: unknown): value is EJSONSerializeOptions {
-  if (value == null || typeof value !== 'object') {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
     return false;
   }
-
-  // Check that all properties, if present, are of the correct type
-  if ('legacy' in value && typeof value.legacy !== 'boolean') {
-    return false;
-  }
-  if ('relaxed' in value && typeof value.relaxed !== 'boolean') {
-    return false;
-  }
-  if ('ignoreUndefined' in value && typeof value.ignoreUndefined !== 'boolean') {
-    return false;
-  }
-
-  // Check that there are no invalid properties (only known EJSON serialize options)
-  const validKeys = ['legacy', 'relaxed', 'ignoreUndefined'];
-  const keys = Object.keys(value);
-
-  return keys.every(key => validKeys.includes(key));
+  return true;
 }
 
 /** @internal */

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -734,65 +734,141 @@ describe('Extended JSON', function () {
     });
   });
 
-  context('Formatting', function () {
-
-    const docToFormat = {
+  context('stringify: Parameter signature combinations', function () {
+    const testDoc = {
       objectId: ObjectId.createFromHexString('111111111111111111111111'),
-      int32Number: 300
+      int32Number: 300,
+      name: 'test'
     };
-    
-    it('should format with default spacing', function () {
-      const formatted = EJSON.stringify(docToFormat, undefined, undefined, { relaxed: false });
-      expect(formatted).to.equal(
-        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"}}'
-      );
+
+    it('should work with (value) - only value parameter', function () {
+      const result = EJSON.stringify(testDoc);
+      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"int32Number":300,"name":"test"}');
     });
 
-    it('should format with custom spacing', function () {
-      const formatted = EJSON.stringify(docToFormat, undefined, 2, { relaxed: false });
-      expect(formatted).to.equal(
-        `{
+    it('should work with (value, null, space) - replacer null, space number', function () {
+      const result = EJSON.stringify(testDoc, null, 2);
+      expect(result).to.equal(`{
+  "objectId": {
+    "$oid": "111111111111111111111111"
+  },
+  "int32Number": 300,
+  "name": "test"
+}`);
+    });
+
+    it('should work with (value, null, space, options) - replacer null, space, options', function () {
+      const result = EJSON.stringify(testDoc, null, 2, { relaxed: false });
+      expect(result).to.equal(`{
+  "objectId": {
+    "$oid": "111111111111111111111111"
+  },
+  "int32Number": {
+    "$numberInt": "300"
+  },
+  "name": "test"
+}`);
+    });
+
+    it('should work with (value, array, space) - replacer array, space', function () {
+      const result = EJSON.stringify(testDoc, ['objectId', '$oid', 'name'], 2);
+      expect(result).to.equal(`{
+  "objectId": {
+    "$oid": "111111111111111111111111"
+  },
+  "name": "test"
+}`);
+    });
+
+    it('should work with (value, array, space, options) - replacer array, space, options', function () {
+      const result = EJSON.stringify(testDoc, ['objectId', '$oid'], 2, { relaxed: false });
+      expect(result).to.equal(`{
+  "objectId": {
+    "$oid": "111111111111111111111111"
+  }
+}`);
+    });
+
+    it('should work with (value, function, space) - replacer function, space', function () {
+      const replacer = function(key: string, value: any) {
+        return key === 'name' ? undefined : value;
+      };
+      const result = EJSON.stringify(testDoc, replacer, 2);
+      expect(result).to.equal(`{
+  "objectId": {
+    "$oid": "111111111111111111111111"
+  },
+  "int32Number": 300
+}`);
+    });
+
+    it('should work with (value, function, space, options) - replacer function, space, options', function () {
+      const replacer = function(key: string, value: any) {
+        return key === 'name' ? undefined : value;
+      };
+      const result = EJSON.stringify(testDoc, replacer, 2, { relaxed: false });
+      expect(result).to.equal(`{
   "objectId": {
     "$oid": "111111111111111111111111"
   },
   "int32Number": {
     "$numberInt": "300"
   }
-}`
-      );
+}`);
     });
 
-    it('should format with default spacing when options are not provided', function () {
-      const formatted = EJSON.stringify(docToFormat);
-      expect(formatted).to.equal(
-        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":300}'
-      );
+    it('should work with (value, null, options) - replacer null, options', function () {
+      const result = EJSON.stringify(testDoc, null, { relaxed: false });
+      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}');
     });
 
-    it('should format with custom spacing when options are provided', function () {
-      const formatted = EJSON.stringify(docToFormat, undefined, 4);
-      expect(formatted).to.equal(
-        `{
-    "objectId": {
-        "$oid": "111111111111111111111111"
-    },
-    "int32Number": 300
-}`
-      );
+    it('should work with (value, array, options) - replacer array, options', function () {
+      const result = EJSON.stringify(testDoc, ['objectId', '$oid'], { relaxed: false });
+      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"}}');
     });
 
-    it('should format with custom spacing and options', function () {
-      const formatted = EJSON.stringify(docToFormat, { relaxed: false }, 2);
-      expect(formatted).to.equal(
-        `{
+    it('should work with (value, function, options) - replacer function, options', function () {
+      const replacer = function(key: string, value: any) {
+        return key === 'int32Number' ? undefined : value;
+      };
+      const result = EJSON.stringify(testDoc, replacer, { relaxed: false });
+      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"name":"test"}');
+    });
+
+    it('should work with (value, options) - value and options only', function () {
+      const result = EJSON.stringify(testDoc, { relaxed: false });
+      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}');
+    });
+
+    it('should work with (value, options, space) - value, options, space (second overload)', function () {
+      const result = EJSON.stringify(testDoc, { relaxed: false }, 2);
+      expect(result).to.equal(`{
   "objectId": {
     "$oid": "111111111111111111111111"
   },
   "int32Number": {
     "$numberInt": "300"
-  }
-}`
-      );
+  },
+  "name": "test"
+}`);
+    });
+
+    it('should work with string space parameter', function () {
+      const result = EJSON.stringify(testDoc, null, '\t', { relaxed: false });
+      expect(result).to.equal(`{
+\t"objectId": {
+\t\t"$oid": "111111111111111111111111"
+\t},
+\t"int32Number": {
+\t\t"$numberInt": "300"
+\t},
+\t"name": "test"
+}`);
+    });
+
+    it('should work with space 0 (no formatting)', function () {
+      const result = EJSON.stringify(testDoc, null, 0, { relaxed: false });
+      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}');
     });
   });
 });

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -743,7 +743,9 @@ describe('Extended JSON', function () {
 
     it('should work with (value) - only value parameter', function () {
       const result = EJSON.stringify(testDoc);
-      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"int32Number":300,"name":"test"}');
+      expect(result).to.equal(
+        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":300,"name":"test"}'
+      );
     });
 
     it('should work with (value, null, space) - replacer null, space number', function () {
@@ -790,7 +792,8 @@ describe('Extended JSON', function () {
     });
 
     it('should work with (value, function, space) - replacer function, space', function () {
-      const replacer = function(key: string, value: any) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const replacer = function (key: string, value: any) {
         return key === 'name' ? undefined : value;
       };
       const result = EJSON.stringify(testDoc, replacer, 2);
@@ -803,7 +806,8 @@ describe('Extended JSON', function () {
     });
 
     it('should work with (value, function, space, options) - replacer function, space, options', function () {
-      const replacer = function(key: string, value: any) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const replacer = function (key: string, value: any) {
         return key === 'name' ? undefined : value;
       };
       const result = EJSON.stringify(testDoc, replacer, 2, { relaxed: false });
@@ -819,7 +823,9 @@ describe('Extended JSON', function () {
 
     it('should work with (value, null, options) - replacer null, options', function () {
       const result = EJSON.stringify(testDoc, null, { relaxed: false });
-      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}');
+      expect(result).to.equal(
+        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}'
+      );
     });
 
     it('should work with (value, array, options) - replacer array, options', function () {
@@ -828,7 +834,8 @@ describe('Extended JSON', function () {
     });
 
     it('should work with (value, function, options) - replacer function, options', function () {
-      const replacer = function(key: string, value: any) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const replacer = function (key: string, value: any) {
         return key === 'int32Number' ? undefined : value;
       };
       const result = EJSON.stringify(testDoc, replacer, { relaxed: false });
@@ -837,7 +844,9 @@ describe('Extended JSON', function () {
 
     it('should work with (value, options) - value and options only', function () {
       const result = EJSON.stringify(testDoc, { relaxed: false });
-      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}');
+      expect(result).to.equal(
+        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}'
+      );
     });
 
     it('should work with (value, options, space) - value, options, space (second overload)', function () {
@@ -868,7 +877,9 @@ describe('Extended JSON', function () {
 
     it('should work with space 0 (no formatting)', function () {
       const result = EJSON.stringify(testDoc, null, 0, { relaxed: false });
-      expect(result).to.equal('{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}');
+      expect(result).to.equal(
+        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}'
+      );
     });
   });
 });

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -733,4 +733,66 @@ describe('Extended JSON', function () {
       expect(() => EJSON.stringify(input)).to.throw(BSONError);
     });
   });
+
+  context('Formatting', function () {
+
+    const docToFormat = {
+      objectId: ObjectId.createFromHexString('111111111111111111111111'),
+      int32Number: 300
+    };
+    
+    it('should format with default spacing', function () {
+      const formatted = EJSON.stringify(docToFormat, undefined, undefined, { relaxed: false });
+      expect(formatted).to.equal(
+        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"}}'
+      );
+    });
+
+    it('should format with custom spacing', function () {
+      const formatted = EJSON.stringify(docToFormat, undefined, 2, { relaxed: false });
+      expect(formatted).to.equal(
+        `{
+  "objectId": {
+    "$oid": "111111111111111111111111"
+  },
+  "int32Number": {
+    "$numberInt": "300"
+  }
+}`
+      );
+    });
+
+    it('should format with default spacing when options are not provided', function () {
+      const formatted = EJSON.stringify(docToFormat);
+      expect(formatted).to.equal(
+        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":300}'
+      );
+    });
+
+    it('should format with custom spacing when options are provided', function () {
+      const formatted = EJSON.stringify(docToFormat, undefined, 4);
+      expect(formatted).to.equal(
+        `{
+    "objectId": {
+        "$oid": "111111111111111111111111"
+    },
+    "int32Number": 300
+}`
+      );
+    });
+
+    it('should format with custom spacing and options', function () {
+      const formatted = EJSON.stringify(docToFormat, { relaxed: false }, 2);
+      expect(formatted).to.equal(
+        `{
+  "objectId": {
+    "$oid": "111111111111111111111111"
+  },
+  "int32Number": {
+    "$numberInt": "300"
+  }
+}`
+      );
+    });
+  });
 });

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -21,7 +21,6 @@ const BSONRegExp = BSON.BSONRegExp;
 const BSONSymbol = BSON.BSONSymbol;
 const Timestamp = BSON.Timestamp;
 
-
 describe('Extended JSON', function () {
   let doc = {};
 

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -3,7 +3,7 @@ const EJSON = BSON.EJSON;
 import * as vm from 'node:vm';
 import { expect } from 'chai';
 import { BSONVersionError, BSONRuntimeError } from '../../src';
-import { BSONError } from '../register-bson';
+import { BSONError, EJSONSerializeOptions } from '../register-bson';
 
 // BSON types
 const Binary = BSON.Binary;
@@ -844,6 +844,16 @@ describe('Extended JSON', function () {
 
     it('should work with (value, options) - value and options only', function () {
       const result = EJSON.stringify(testDoc, { relaxed: false });
+      expect(result).to.equal(
+        '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}'
+      );
+    });
+
+    it('should work with (value, options) - value and options only (options with typo)', function () {
+      const result = EJSON.stringify(testDoc, {
+        relaxed: false,
+        igroneUndefined: true
+      } as unknown as EJSONSerializeOptions);
       expect(result).to.equal(
         '{"objectId":{"$oid":"111111111111111111111111"},"int32Number":{"$numberInt":"300"},"name":"test"}'
       );

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -21,6 +21,7 @@ const BSONRegExp = BSON.BSONRegExp;
 const BSONSymbol = BSON.BSONSymbol;
 const Timestamp = BSON.Timestamp;
 
+
 describe('Extended JSON', function () {
   let doc = {};
 


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->
This pull request enhances the flexibility and robustness of the `EJSON.stringify` function by supporting multiple parameter signature combinations, similar to `JSON.stringify`.
It introduces a new internal type guard to accurately distinguish between options and replacer parameters, and adds comprehensive tests to ensure correct behavior across all supported overloads.
It supports a previously advertised function signature which was not implemented. `EJSON.stringify(object, { relaxed: false }, 2)`

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->
The tests should contain every previously possible and also previously advertised but not working combination of inputs.
The changes within the function have to do with the previous typescript signature which has been used but did not work. See https://github.com/mongodb/js-bson/blob/0712bb15653093766a80bbd4ba104353cd4581e3/test/bench/etc/generate_documents.ts#L27

Off Topic: Documented within [NODE-7437](https://jira.mongodb.org/browse/NODE-7437)
> I noticed that the array replacement signature for JSON.stringify replaces the serialized keys.
> ```typescript
> const testDoc = {
>   objectId: ObjectId.createFromHexString('111111111111111111111111')
> };
> 
> const result = EJSON.stringify(testDoc, ['objectId', '$oid']) // {"objectId":{"$oid":"111111111111111111111111"}}
> const result2 = EJSON.stringify(testDoc, ['objectId']) // {"objectId":{}}
> ```
> Maybe if the replacer is an Array it should add the data types to the array.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### `EJSON.stringify` now correctly handles all parameter combinations

Previously, calling `EJSON.stringify(value, options, space)` silently discarded the `space` parameter, producing unformatted output. This has been fixed so all documented call signatures work as expected:

```typescript
// This now correctly produces indented canonical EJSON
EJSON.stringify(doc, { relaxed: false }, 2);
```

Thanks to @chdanielmueller for working on this problem!

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
