### PR TITLE
feat(NODE-4793): add Symbol.toStringTag to all BSON types

### DIFF
--- a/src/bson_value.ts
+++ b/src/bson_value.ts
@@ -29,6 +29,9 @@ export abstract class BSONValue {
   public get [bsonType](): this['_bsontype'] {
     return this._bsontype;
   }
+  public get [Symbol.toStringTag](): string {
+    return this._bsontype;
+  }
 
   /** @internal */
   get [BSON_VERSION_SYMBOL](): typeof BSON_MAJOR_VERSION {

--- a/test/node/bson_type_classes.test.ts
+++ b/test/node/bson_type_classes.test.ts
@@ -98,6 +98,17 @@ describe('BSON Type classes common interfaces', () => {
           ));
       }
 
+      if (TypeClass.name !== 'UUID') {
+        it(`defines Symbol.toStringTag equal to its name`, () =>
+          expect(TypeClass.prototype).to.have.property(Symbol.toStringTag, TypeClass.name));
+      } else {
+        it(`UUID inherits Symbol.toStringTag from Binary`, () =>
+          expect(Object.getPrototypeOf(TypeClass.prototype)).to.have.property(
+            Symbol.toStringTag,
+            'Binary'
+          ));
+      }
+
       it(`defines a Symbol.for('@@mdb.bson.version') property equal to 7`, () =>
         expect(TypeClass.prototype).to.have.property(Symbol.for('@@mdb.bson.version'), 7));
 


### PR DESCRIPTION
### Description
#### Summary of Changes
Adds `Symbol.toStringTag` to all BSON types by implementing the getter in the `BSONValue` base class, delegating to `this._bsontype`. Since `_bsontype` is abstract on `BSONValue` and implemented by every subclass, all 13 BSON types inherit the correct tag automatically.

Before:
Object.prototype.toString.call(new ObjectId()) // '[object Object]'

After:
Object.prototype.toString.call(new ObjectId()) // '[object ObjectId]'

#### Notes for Reviewers
Follows the same pattern as the existing `bsonType` symbol getter added in NODE-7255. The implementation is a single getter on `BSONValue` — no changes needed in individual subclasses.

### Double check the following
- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed
- [x] PR title follows the correct format: `feat(NODE-4793): add Symbol.toStringTag to all BSON types`
- [x] Changes are covered by tests (14 new tests added in `bson_type_classes.test.ts`)
- [x] No new TODOs