### PR TITLE
fix(NODE-5116): validate null bytes in EJSON keys during serialization

### DIFF
--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -351,6 +351,11 @@ function serializeDocument(doc: any, options: EJSONSerializeInternalOptions) {
     // It's a regular object. Recursively serialize its property values.
     const _doc: Document = {};
     for (const name of Object.keys(doc)) {
+      if (name.indexOf('\x00') !== -1) {
+        throw new BSONError(
+          `BSON Document field names cannot contain null bytes, found: ${JSON.stringify(name)}`
+        );
+      }
       options.seenObjects.push({ propertyName: name, obj: null });
       try {
         const value = serializeValue(doc[name], options);

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -733,4 +733,18 @@ describe('Extended JSON', function () {
       expect(() => EJSON.stringify(input)).to.throw(BSONError);
     });
   });
+
+  context('when document keys contain null bytes', function () {
+    it('EJSON.stringify throws a BSONError', function () {
+      expect(() => EJSON.stringify({ 'a\x00b': 1 })).to.throw(BSONError, /null bytes/);
+    });
+
+    it('EJSON.serialize throws a BSONError', function () {
+      expect(() => EJSON.serialize({ 'a\x00b': 1 })).to.throw(BSONError, /null bytes/);
+    });
+
+    it('EJSON.parse throws a BSONError', function () {
+      expect(() => EJSON.parse('{"a\\u0000b": 1}')).to.throw(BSONError, /null bytes/);
+    });
+  });
 });


### PR DESCRIPTION
### Description
#### Summary of Changes
Adds null byte validation to `EJSON.stringify` and `EJSON.serialize` when processing document keys. Previously, BSON serialization would throw a `BSONError` for keys containing null bytes, but EJSON serialization would silently produce output that could never be round-tripped back through BSON.

Before:
EJSON.stringify({ 'a\x00b': 1 }) // '{"a\u0000":1}' — silent, invalid output
BSON.serialize({ 'a\x00b': 1 })  // throws BSONError ✅

After:
EJSON.stringify({ 'a\x00b': 1 }) // throws BSONError ✅
EJSON.serialize({ 'a\x00b': 1 }) // throws BSONError ✅

#### Notes for Reviewers
The check is added in `serializeDocument` in `extended_json.ts`, mirroring the existing null byte check already present in `EJSON.parse`. The error message is identical to the one used in `parse` for consistency.

### Double check the following
- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed
- [x] PR title follows the correct format: `fix(NODE-5116): validate null bytes in EJSON keys during serialization`
- [x] Changes are covered by tests (3 new tests added in `extended_json.test.ts`)
- [x] No new TODOs