### PR TITLE
tests(NODE-7533): pin NPM version & provide new configuration option to TS6 compiler

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -80,6 +80,7 @@ functions:
           PROJECT_DIRECTORY: ${PROJECT_DIRECTORY}
           TS_VERSION: "${TS_VERSION}"
           TRY_COMPILING_LIBRARY: "${TRY_COMPILING_LIBRARY}"
+          TSC_EXTRA_FLAGS: "${TSC_EXTRA_FLAGS}"
         binary: bash
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-typescript.sh
@@ -148,6 +149,7 @@ tasks:
       - func: fetch source
         vars:
           NODE_LTS_VERSION: 22
+          NPM_VERSION: 11.11.1
       - func: install dependencies
       - func: run tests
   - name: node-tests-v24
@@ -222,9 +224,12 @@ tasks:
       - func: install dependencies
       - func: "run typescript"
         vars:
-          # TODO(NODE-7233): switch to `next` again once compatible with TS 6.0
-          TS_VERSION: "latest"
+          TS_VERSION: "next"
+          # TODO(NODE-7542): flip to "true" once the library builds under TS 6.0.
           TRY_COMPILING_LIBRARY: "false"
+          # Keeps the consumer-perspective checks in run-typescript.sh from inheriting
+          # this repo's tsconfig. Available in TS 6.0+, so only set on this task.
+          TSC_EXTRA_FLAGS: "--ignoreConfig"
   - name: run-granular-benchmarks
     commands:
       - func: fetch source

--- a/.evergreen/run-typescript.sh
+++ b/.evergreen/run-typescript.sh
@@ -19,11 +19,11 @@ npm install --no-save --force typescript@"$TS_VERSION"
 echo "Typescript $($TSC -v)"
 
 # check resolution uses the default latest types
-echo "import * as BSON from '.'" > file.ts && node $TSC --noEmit --traceResolution file.ts | grep 'bson.d.ts' && rm file.ts
+echo "import * as BSON from '.'" > file.ts && node $TSC $TSC_EXTRA_FLAGS --noEmit --traceResolution file.ts | grep 'bson.d.ts' && rm file.ts
 
 # check compilation
 rm -rf node_modules/@types/eslint # not a dependency we use, but breaks the build :(
-node $TSC bson.d.ts
+node $TSC $TSC_EXTRA_FLAGS bson.d.ts
 
 if [[ $TRY_COMPILING_LIBRARY != "false" ]]; then
     npm run build:ts


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

Apply 2 small patches: pin NPM version on node22 to the version which it can upgrade itself into. Add new flag for running check on TS6 (which is both next and latest at the moment).

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

Broken CI on Node22 & with TS6

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
