### PR TITLE
fix(NODE-7575): reset ObjectId state when building startup snapshot

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -4,9 +4,6 @@ import { type InspectFn, defaultInspect } from './parser/utils';
 import { ByteUtils } from './utils/byte_utils';
 import { NumberUtils } from './utils/number_utils';
 
-// Unique sequence for the current process (initialized on first use)
-let PROCESS_UNIQUE: Uint8Array | null = null;
-
 /** ObjectId hexString cache @internal */
 const __idCache = new WeakMap(); // TODO(NODE-6549): convert this to #__id private field when target updated to ES2022
 
@@ -33,7 +30,28 @@ export class ObjectId extends BSONValue {
   }
 
   /** @internal */
-  private static index = Math.floor(Math.random() * 0xffffff);
+  private static index = 0;
+
+  /** Unique sequence for the current process (initialized on first use)
+   * @internal
+   */
+  private static PROCESS_UNIQUE: Uint8Array | null = null;
+
+  /** @internal */
+  private static resetState = (): void => {
+    this.index = Math.floor(Math.random() * 0x1000000);
+    this.PROCESS_UNIQUE = null;
+  };
+
+  static {
+    this.resetState();
+    // https://nodejs.org/api/v8.html#startup-snapshot-api
+    // @ts-expect-error Node.js types not present since this is an optional API
+    const { startupSnapshot } = globalThis?.process?.getBuiltinModule('v8') ?? {};
+    if (startupSnapshot?.isBuildingSnapshot()) {
+      startupSnapshot?.addDeserializeCallback(this.resetState);
+    }
+  }
 
   static cacheHexString: boolean;
 
@@ -178,7 +196,7 @@ export class ObjectId extends BSONValue {
    * @internal
    */
   private static getInc(): number {
-    return (ObjectId.index = (ObjectId.index + 1) % 0xffffff);
+    return (ObjectId.index = (ObjectId.index + 1) % 0x1000000);
   }
 
   /**
@@ -198,9 +216,7 @@ export class ObjectId extends BSONValue {
     NumberUtils.setInt32BE(buffer, 0, time);
 
     // set PROCESS_UNIQUE if yet not initialized
-    if (PROCESS_UNIQUE === null) {
-      PROCESS_UNIQUE = ByteUtils.randomBytes(5);
-    }
+    const PROCESS_UNIQUE = (this.PROCESS_UNIQUE ??= ByteUtils.randomBytes(5));
 
     // 5-byte process unique
     buffer[4] = PROCESS_UNIQUE[0];

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -40,7 +40,7 @@ export class ObjectId extends BSONValue {
   /** @internal */
   private static resetState = (): void => {
     this.index = Math.floor(Math.random() * 0x1000000);
-    this.PROCESS_UNIQUE = null;
+    this.PROCESS_UNIQUE = ByteUtils.randomBytes(5);
   };
 
   static {
@@ -215,10 +215,8 @@ export class ObjectId extends BSONValue {
     // 4-byte timestamp
     NumberUtils.setInt32BE(buffer, 0, time);
 
-    // set PROCESS_UNIQUE if yet not initialized
-    const PROCESS_UNIQUE = (this.PROCESS_UNIQUE ??= ByteUtils.randomBytes(5));
-
     // 5-byte process unique
+    const PROCESS_UNIQUE = this.PROCESS_UNIQUE!;
     buffer[4] = PROCESS_UNIQUE[0];
     buffer[5] = PROCESS_UNIQUE[1];
     buffer[6] = PROCESS_UNIQUE[2];

--- a/test/node/startup_snapshot.test.ts
+++ b/test/node/startup_snapshot.test.ts
@@ -1,0 +1,90 @@
+import * as child_process from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { expect } from 'chai';
+
+describe('snapshot support', () => {
+  let tmpdir: string;
+
+  beforeEach(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'js-bson-snapshot-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpdir, { recursive: true, force: true });
+  });
+
+  // Regression test for https://jira.mongodb.org/browse/MONGOSH-3277
+  it('should reset relevant state when using startup snapshot', async () => {
+    // Build a startup snapshot including the BSON library and an example ObjectId
+    const bsonBundleSource = path.join(__dirname, '..', '..', 'lib', 'bson.bundle.js');
+    await fs.writeFile(
+      path.join(tmpdir, 'snapshot_main.cjs'),
+      `
+    ${await fs.readFile(bsonBundleSource, 'utf8')}
+    const { startupSnapshot } = require('v8');
+    globalThis.pid = new BSON.ObjectId();
+    startupSnapshot.setDeserializeMainFunction(() => {
+      console.log(globalThis.pid.toHexString());
+      console.log(new BSON.ObjectId().toHexString());
+    });
+    `
+    );
+    await promisify(child_process.execFile)(
+      process.execPath,
+      ['--snapshot-blob', 'snapshot.blob', '--build-snapshot', 'snapshot_main.cjs'],
+      {
+        cwd: tmpdir,
+        encoding: 'utf8'
+      }
+    );
+
+    // Run the resulting snapshot twice to compare
+    const stdout1 = (
+      await promisify(child_process.execFile)(
+        process.execPath,
+        ['--snapshot-blob', 'snapshot.blob'],
+        {
+          cwd: tmpdir,
+          encoding: 'utf8'
+        }
+      )
+    ).stdout
+      .trim()
+      .split('\n');
+    const stdout2 = (
+      await promisify(child_process.execFile)(
+        process.execPath,
+        ['--snapshot-blob', 'snapshot.blob'],
+        {
+          cwd: tmpdir,
+          encoding: 'utf8'
+        }
+      )
+    ).stdout
+      .trim()
+      .split('\n');
+
+    // Each process should print two values
+    expect(stdout1).to.have.lengthOf(2);
+    expect(stdout2).to.have.lengthOf(2);
+
+    // The in-snapshot ObjectId is persisted
+    expect(stdout1[0]).to.equal(stdout2[0]);
+
+    // We get different per-process values (counter and process unique)
+    // created after deserialization
+    const [oid1, oid2] = [stdout1[1], stdout2[1]].map(
+      oid => oid.match(/^(?<ts>\w{8})(?<uniq>\w{10})(?<counter>\w{6})$/)!.groups!
+    );
+
+    // Less than 20 seconds between timestamps should be plenty of leeway
+    expect(Math.abs(parseInt(oid2.ts, 16) - parseInt(oid1.ts, 16))).to.be.lessThan(20);
+    // Distinct process unique values
+    expect(oid1.uniq).to.not.equal(oid2.uniq);
+    // Distinct counter values
+    expect(oid1.counter).to.not.equal(oid2.counter);
+  });
+});


### PR DESCRIPTION

### Description

#### Summary of Changes

Use the relevant Node.js API to ensure that different processes indeed have different counter and process-unique values in their ObjectId classes, as intended, even when using Node.js's startup snapshot feature.

<!-- Please describe the changes in this PR in a high-level overview. -->

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### ObjectId generates unique values across Node.js startup snapshot processes

`ObjectId` now resets its random state (process-unique bytes and counter seed) when a process restores from a Node.js [startup snapshot](https://nodejs.org/api/v8.html#startup-snapshot-api). Previously these values were frozen into the snapshot blob, causing processes restored from the same snapshot to generate colliding ObjectIds.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
