### PR TITLE
chore(NODE-7564): Migrate js-bson into trusted publisher workflow.

### DIFF
--- a/.github/scripts/dispatch-and-wait.mjs
+++ b/.github/scripts/dispatch-and-wait.mjs
@@ -1,0 +1,73 @@
+// @ts-check
+// TODO(NODE-7570): replace with workflow_call once GitHub/npm resolve the OIDC
+// workflow_ref mismatch (https://github.com/npm/documentation/issues/1755).
+//
+// Dispatch a workflow_dispatch-triggered GitHub Actions workflow and wait for
+// the resulting run to complete (propagating its exit status).
+//
+// `gh workflow run` prints the created workflow run URL on stdout when the
+// server returns it (current github.com API version does); we parse the run
+// id out of the URL and pass it to `gh run watch`.
+//
+// Usage:
+//   node dispatch-and-wait.mjs <workflow.yml> [key=value ...]
+//
+//   For npm-publish.yml specifically:
+//   node dispatch-and-wait.mjs npm-publish.yml tag=<tag> version=<v> ref=<sha>
+//
+// Arguments:
+//   <workflow.yml>    Filename of the target workflow under .github/workflows/
+//                     in the same repo. Must declare `on: workflow_dispatch:`.
+//   key=value ...     Inputs forwarded to the dispatched workflow. Valid keys
+//                     and which of them are required are determined by the
+//                     target workflow's `on.workflow_dispatch.inputs`; the
+//                     dispatch fails if any required input is missing or any
+//                     unknown input is passed. For `npm-publish.yml`, all of
+//                     `tag`, `version`, and `ref` are required.
+//                     Example: tag=alpha version=1.2.3-alpha.0 ref=abc1234
+//
+// Environment:
+//   GH_TOKEN              (required) used by the gh CLI; in a workflow set
+//                         this to ${{ github.token }}.
+//   DISPATCH_WORKFLOW_REF (optional, default `main`) git ref the target
+//                         workflow file is loaded from. Hardcoded to main by
+//                         default so callers on backport branches don't have
+//                         to keep a copy of the target workflow on their
+//                         branch.
+import * as child_process from 'node:child_process';
+import * as process from 'node:process';
+
+const [, , workflow, ...inputArgs] = process.argv;
+if (!workflow) {
+  console.error('usage: dispatch-and-wait.mjs <workflow.yml> [key=value ...]');
+  process.exit(2);
+}
+
+const dispatchRef = process.env.DISPATCH_WORKFLOW_REF || 'main';
+
+const ghArgs = [
+  'workflow', 'run', workflow,
+  '--ref', dispatchRef,
+  ...inputArgs.flatMap(kv => ['-f', kv])
+];
+console.log(`Dispatching ${workflow} from ref ${dispatchRef}`);
+
+const dispatch = child_process.spawnSync('gh', ghArgs, {
+  encoding: 'utf8',
+  stdio: ['inherit', 'pipe', 'inherit']
+});
+if (dispatch.status !== 0) process.exit(dispatch.status ?? 1);
+
+// gh prints e.g. "https://github.com/owner/repo/actions/runs/<id>"
+const match = dispatch.stdout.match(/\/actions\/runs\/(\d+)/);
+if (!match) {
+  console.error('Could not extract run id from gh workflow run output:', dispatch.stdout);
+  process.exit(1);
+}
+const runId = match[1];
+console.log(`Dispatched run ${runId}`);
+
+const watch = child_process.spawnSync('gh', ['run', 'watch', runId, '--exit-status'], {
+  stdio: 'inherit'
+});
+process.exit(watch.status ?? 1);

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,9 +33,15 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@v5
+        env:
+          REF: ${{ inputs.ref }}
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ env.REF }}
       - name: Install Node and dependencies
         uses: mongodb-labs/drivers-github-tools/node/setup@v3
-      - run: npm version "${{ inputs.version }}" --git-tag-version=false --allow-same-version
-      - run: npm publish --provenance --tag="${{ inputs.tag }}"
+      - run: npm version "$VERSION" --git-tag-version=false --allow-same-version
+        env:
+          VERSION: ${{ inputs.version }}
+      - run: npm publish --provenance --tag="$TAG"
+        env:
+          TAG: ${{ inputs.tag }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,40 @@
+# This workflow is invoked by callers via `workflow_dispatch` (the GitHub
+# Actions API), NOT as a reusable workflow (`on: workflow_call:`). With
+# workflow_call, the OIDC token's workflow_ref claim points to the caller's
+# filename rather than this file, which breaks npm Trusted Publishing's
+# workflow-filename matching. See npm/documentation#1755.
+name: npm-publish
+
+run-name: 'npm-publish ${{ inputs.tag }}@${{ inputs.version }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'npm dist-tag (e.g. alpha, latest, 5x, legacy)'
+        required: true
+        type: string
+      version:
+        description: 'Package version to publish'
+        required: true
+        type: string
+      ref:
+        description: 'Git ref (commit SHA preferred) to publish from'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Install Node and dependencies
+        uses: mongodb-labs/drivers-github-tools/node/setup@v3
+      - run: npm version "${{ inputs.version }}" --git-tag-version=false --allow-same-version
+      - run: npm publish --provenance --tag="${{ inputs.tag }}"

--- a/.github/workflows/release-5.x.yml
+++ b/.github/workflows/release-5.x.yml
@@ -6,7 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
+  actions: write
 
 name: release-5x
 
@@ -95,11 +95,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install Node and dependencies
-        uses: mongodb-labs/drivers-github-tools/node/setup@v3
-
-      - run: npm publish --provenance --tag=5x
+      - name: Dispatch npm-publish workflow
         if: ${{ needs.release_please.outputs.release_created }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+            tag=5x \
+            version="$(node -p "require('./package.json').version")" \
+            ref="${{ github.sha }}"

--- a/.github/workflows/release-6.4.yml
+++ b/.github/workflows/release-6.4.yml
@@ -6,7 +6,7 @@ on:
 permissions:
     contents: write
     pull-requests: write
-    id-token: write
+    actions: write
 
 name: release-6.4
   
@@ -95,12 +95,13 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v5
-  
-        - name: Install Node and dependencies
-          uses: mongodb-labs/drivers-github-tools/node/setup@v3
-  
-        - run: npm publish --provenance --tag legacy
+        - name: Dispatch npm-publish workflow
           if: ${{ needs.release_please.outputs.release_created }}
           env:
-            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            GH_TOKEN: ${{ github.token }}
+          run: |
+            node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+              tag=legacy \
+              version="$(node -p "require('./package.json').version")" \
+              ref="${{ github.sha }}"
   

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -19,10 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - shell: bash
+        env:
+          ALPHA_VERSION: ${{ inputs.alphaVersion }}
         run: |
           ALPHA_SEMVER_REGEXP="-alpha(\.([0-9]|[1-9][0-9]+))?$"
 
-          if ! [[ "${{ inputs.alphaVersion }}" =~ $ALPHA_SEMVER_REGEXP ]]; then
+          if ! [[ "$ALPHA_VERSION" =~ $ALPHA_SEMVER_REGEXP ]]; then
             echo "Invalid alphaVersion string"
             exit 1
           fi
@@ -30,8 +32,9 @@ jobs:
       - name: Dispatch npm-publish workflow
         env:
           GH_TOKEN: ${{ github.token }}
+          ALPHA_VERSION: ${{ inputs.alphaVersion }}
         run: |
           node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
             tag=alpha \
-            version="${{ inputs.alphaVersion }}" \
+            version="$ALPHA_VERSION" \
             ref="${{ github.sha }}"

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -26,10 +26,10 @@ jobs:
             echo "Invalid alphaVersion string"
             exit 1
           fi
+      - uses: actions/checkout@v5
       - name: Dispatch npm-publish workflow
         env:
           GH_TOKEN: ${{ github.token }}
-          DISPATCH_WORKFLOW_REF: ${{ github.sha }}
         run: |
           node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
             tag=alpha \

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -9,7 +9,8 @@ on:
         type: string
 
 permissions:
-  id-token: write
+  contents: read
+  actions: write
 
 name: release-alpha
 
@@ -25,12 +26,12 @@ jobs:
             echo "Invalid alphaVersion string"
             exit 1
           fi
-      - uses: actions/checkout@v5
-      
-      - name: Install Node and dependencies
-        uses: mongodb-labs/drivers-github-tools/node/setup@v3
-
-      - run: npm version "${{ inputs.alphaVersion }}" --git-tag-version=false
-      - run: npm publish --provenance --tag=alpha
+      - name: Dispatch npm-publish workflow
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          DISPATCH_WORKFLOW_REF: ${{ github.sha }}
+        run: |
+          node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+            tag=alpha \
+            version="${{ inputs.alphaVersion }}" \
+            ref="${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
+  actions: write
 
 name: release-latest
 
@@ -95,11 +95,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install Node and dependencies
-        uses: mongodb-labs/drivers-github-tools/node/setup@v3
-
-      - run: npm publish --provenance --tag=latest
+      - name: Dispatch npm-publish workflow
         if: ${{ needs.release_please.outputs.release_created }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node ./.github/scripts/dispatch-and-wait.mjs npm-publish.yml \
+            tag=latest \
+            version="$(node -p "require('./package.json').version")" \
+            ref="${{ github.sha }}"


### PR DESCRIPTION
### Description

#### Summary of Changes

Copy of the npm trusted publisher migration we did in Driver: https://github.com/mongodb/node-mongodb-native/pull/4930

This PR updates all jobs at once.

> Migrates ~~the nightly~~ all release flow off `NPM_TOKEN` and onto npm Trusted Publishing (OIDC). The pattern routes publishing through a dedicated, single-purpose workflow that we can register once on npmjs.com as the trusted publisher for the `mongodb` package.
> 
> npm Trusted Publishing currently allows **one trusted publisher entry per package**, and the OIDC validation matches against the top-level caller workflow's filename - so [`workflow_call` does not work around this](https://github.com/npm/documentation/issues/1755) (that's because with `workflow_call` the caller name appears, so it won't be npm_publish.yml but release.yml, release-nightly.yml, -alpha.yml, etc.). Dispatching the publish workflow via the `workflow_dispatch` API lets us register a single publisher entry and eventually route every release flow (nightly, latest, alpha, backports) through it.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
