### PR TITLE
fix(NODE-5937): rewrite deserializeObject as iterative, not recursive

### DIFF
--- a/src/bson.ts
+++ b/src/bson.ts
@@ -117,7 +117,6 @@ export function serialize(object: Document, options: SerializeOptions = {}): Uin
     object,
     checkKeys,
     0,
-    0,
     serializeFunctions,
     ignoreUndefined,
     null
@@ -160,7 +159,6 @@ export function serializeWithBufferAndIndex(
     buffer,
     object,
     checkKeys,
-    0,
     0,
     serializeFunctions,
     ignoreUndefined,

--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -10,43 +10,51 @@ export function internalCalculateObjectSize(
   serializeFunctions?: boolean,
   ignoreUndefined?: boolean
 ): number {
-  let totalLength = 4 + 1;
+  const objectStack: Document[] = [object];
+  let total = 0;
 
-  if (Array.isArray(object)) {
-    for (let i = 0; i < object.length; i++) {
-      totalLength += calculateElement(
-        i.toString(),
-        object[i],
-        serializeFunctions,
-        true,
-        ignoreUndefined
-      );
-    }
-  } else {
-    // If we have toBSON defined, override the current object
+  while (objectStack.length > 0) {
+    const obj = objectStack.pop()!;
+    total += 5; // 4-byte size field + null terminator
 
-    if (typeof object?.toBSON === 'function') {
-      object = object.toBSON();
+    const isObjArray = Array.isArray(obj);
+    let target = obj;
+    if (!isObjArray && typeof (obj as any)?.toBSON === 'function') {
+      target = (obj as any).toBSON();
     }
 
-    // Calculate size
-    for (const key of Object.keys(object)) {
-      totalLength += calculateElement(key, object[key], serializeFunctions, false, ignoreUndefined);
+    if (isObjArray) {
+      const array = target as unknown[];
+      for (let i = 0; i < array.length; i++) {
+        total += calculateElementSize(
+          i.toString(),
+          array[i],
+          serializeFunctions,
+          true,
+          ignoreUndefined,
+          objectStack
+        );
+      }
+    } else {
+      for (const key of Object.keys(target)) {
+        total += calculateElementSize(key, target[key], serializeFunctions, false, ignoreUndefined, objectStack);
+      }
     }
   }
 
-  return totalLength;
+  return total;
 }
 
 /** @internal */
-function calculateElement(
+function calculateElementSize(
   name: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
   serializeFunctions = false,
   isArray = false,
-  ignoreUndefined = false
-) {
+  ignoreUndefined = false,
+  objectStack: Document[]
+): number {
   // If we have toBSON defined, override the current object
   if (typeof value?.toBSON === 'function') {
     value = value.toBSON();
@@ -107,16 +115,16 @@ function calculateElement(
       } else if (value._bsontype === 'Decimal128') {
         return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (16 + 1);
       } else if (value._bsontype === 'Code') {
-        // Calculate size depending on the availability of a scope
+        // Calculate size deobjectStack on the availability of a scope
         if (value.scope != null && Object.keys(value.scope).length > 0) {
+          objectStack.push(value.scope);
           return (
             (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
             1 +
             4 +
             4 +
             ByteUtils.utf8ByteLength(value.code.toString()) +
-            1 +
-            internalCalculateObjectSize(value.scope, serializeFunctions, ignoreUndefined)
+            1
           );
         } else {
           return (
@@ -163,11 +171,8 @@ function calculateElement(
           ordered_values['$db'] = value.db;
         }
 
-        return (
-          (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
-          1 +
-          internalCalculateObjectSize(ordered_values, serializeFunctions, ignoreUndefined)
-        );
+        objectStack.push(ordered_values);
+        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + 1;
       } else if (value instanceof RegExp || isRegExp(value)) {
         return (
           (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
@@ -189,11 +194,8 @@ function calculateElement(
           1
         );
       } else {
-        return (
-          (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
-          internalCalculateObjectSize(value, serializeFunctions, ignoreUndefined) +
-          1
-        );
+        objectStack.push(value);
+        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + 1;
       }
     case 'function':
       if (serializeFunctions) {

--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -37,7 +37,14 @@ export function internalCalculateObjectSize(
       }
     } else {
       for (const key of Object.keys(target)) {
-        total += calculateElementSize(key, target[key], serializeFunctions, false, ignoreUndefined, objectStack);
+        total += calculateElementSize(
+          key,
+          target[key],
+          serializeFunctions,
+          false,
+          ignoreUndefined,
+          objectStack
+        );
       }
     }
   }
@@ -71,20 +78,19 @@ function calculateElementSize(
       ) {
         if (value >= constants.BSON_INT32_MIN && value <= constants.BSON_INT32_MAX) {
           // 32 bit
-          return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (4 + 1);
+          return ByteUtils.utf8ByteLength(name) + 1 + (4 + 1);
         } else {
-          return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (8 + 1);
+          return ByteUtils.utf8ByteLength(name) + 1 + (8 + 1);
         }
       } else {
         // 64 bit
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (8 + 1);
+        return ByteUtils.utf8ByteLength(name) + 1 + (8 + 1);
       }
     case 'undefined':
-      if (isArray || !ignoreUndefined)
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + 1;
+      if (isArray || !ignoreUndefined) return ByteUtils.utf8ByteLength(name) + 1 + 1;
       return 0;
     case 'boolean':
-      return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (1 + 1);
+      return ByteUtils.utf8ByteLength(name) + 1 + (1 + 1);
     case 'object':
       if (
         value != null &&
@@ -93,33 +99,32 @@ function calculateElementSize(
       ) {
         throw new BSONVersionError();
       } else if (value == null || value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + 1;
+        return ByteUtils.utf8ByteLength(name) + 1 + 1;
       } else if (value._bsontype === 'ObjectId') {
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (12 + 1);
+        return ByteUtils.utf8ByteLength(name) + 1 + (12 + 1);
       } else if (value instanceof Date || isDate(value)) {
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (8 + 1);
+        return ByteUtils.utf8ByteLength(name) + 1 + (8 + 1);
       } else if (
         ArrayBuffer.isView(value) ||
         value instanceof ArrayBuffer ||
         isAnyArrayBuffer(value)
       ) {
-        return (
-          (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (1 + 4 + 1) + value.byteLength
-        );
+        return ByteUtils.utf8ByteLength(name) + 1 + (1 + 4 + 1) + value.byteLength;
       } else if (
         value._bsontype === 'Long' ||
         value._bsontype === 'Double' ||
         value._bsontype === 'Timestamp'
       ) {
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (8 + 1);
+        return ByteUtils.utf8ByteLength(name) + 1 + (8 + 1);
       } else if (value._bsontype === 'Decimal128') {
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (16 + 1);
+        return ByteUtils.utf8ByteLength(name) + 1 + (16 + 1);
       } else if (value._bsontype === 'Code') {
-        // Calculate size deobjectStack on the availability of a scope
+        // Calculate size depending on the availability of a scope
         if (value.scope != null && Object.keys(value.scope).length > 0) {
           objectStack.push(value.scope);
           return (
-            (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
+            ByteUtils.utf8ByteLength(name) +
+            1 +
             1 +
             4 +
             4 +
@@ -128,7 +133,8 @@ function calculateElementSize(
           );
         } else {
           return (
-            (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
+            ByteUtils.utf8ByteLength(name) +
+            1 +
             1 +
             4 +
             ByteUtils.utf8ByteLength(value.code.toString()) +
@@ -139,22 +145,13 @@ function calculateElementSize(
         const binary: Binary = value;
         // Check what kind of subtype we have
         if (binary.sub_type === Binary.SUBTYPE_BYTE_ARRAY) {
-          return (
-            (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
-            (binary.position + 1 + 4 + 1 + 4)
-          );
+          return ByteUtils.utf8ByteLength(name) + 1 + (binary.position + 1 + 4 + 1 + 4);
         } else {
-          return (
-            (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (binary.position + 1 + 4 + 1)
-          );
+          return ByteUtils.utf8ByteLength(name) + 1 + (binary.position + 1 + 4 + 1);
         }
       } else if (value._bsontype === 'Symbol') {
         return (
-          (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
-          ByteUtils.utf8ByteLength(value.value) +
-          4 +
-          1 +
-          1
+          ByteUtils.utf8ByteLength(name) + 1 + ByteUtils.utf8ByteLength(value.value) + 4 + 1 + 1
         );
       } else if (value._bsontype === 'DBRef') {
         // Set up correct object for serialization
@@ -172,10 +169,11 @@ function calculateElementSize(
         }
 
         objectStack.push(ordered_values);
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + 1;
+        return ByteUtils.utf8ByteLength(name) + 1 + 1;
       } else if (value instanceof RegExp || isRegExp(value)) {
         return (
-          (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
+          ByteUtils.utf8ByteLength(name) +
+          1 +
           1 +
           ByteUtils.utf8ByteLength(value.source) +
           1 +
@@ -186,7 +184,8 @@ function calculateElementSize(
         );
       } else if (value._bsontype === 'BSONRegExp') {
         return (
-          (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
+          ByteUtils.utf8ByteLength(name) +
+          1 +
           1 +
           ByteUtils.utf8ByteLength(value.pattern) +
           1 +
@@ -195,12 +194,13 @@ function calculateElementSize(
         );
       } else {
         objectStack.push(value);
-        return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + 1;
+        return ByteUtils.utf8ByteLength(name) + 1 + 1;
       }
     case 'function':
       if (serializeFunctions) {
         return (
-          (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) +
+          ByteUtils.utf8ByteLength(name) +
+          1 +
           1 +
           4 +
           ByteUtils.utf8ByteLength(value.toString()) +
@@ -209,12 +209,10 @@ function calculateElementSize(
       }
       return 0;
     case 'bigint':
-      return (name != null ? ByteUtils.utf8ByteLength(name) + 1 : 0) + (8 + 1);
+      return ByteUtils.utf8ByteLength(name) + 1 + (8 + 1);
     case 'symbol':
       return 0;
     default:
       throw new BSONError(`Unrecognized JS type: ${typeof value}`);
   }
-
-  return 0;
 }

--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -19,7 +19,9 @@ export function internalCalculateObjectSize(
 
     const isObjArray = Array.isArray(obj);
     let target = obj;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (!isObjArray && typeof (obj as any)?.toBSON === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       target = (obj as any).toBSON();
     }
 

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -125,12 +125,14 @@ export function internalDeserialize(
 interface NestedParsingFrame {
   // Document that we will fill out as we parse the nested object
   holdingDocument: Document;
+  // The name of the key we will set the parsed object on once we finish parsing the nested object, this is used in the onComplete callback to know where to set the parsed nested object in the parent document
+  propertyName: string | number;
   // The index in the buffer where the current object ends, used to know when we are done parsing the current object and can pop the stack
   lastIndex: number;
   // Whether the current frame is parsing an array, used to know whether to interpret keys as strings or array indices
   isArray: boolean;
   // The next array index to use if this frame is parsing an array, used to assign numeric keys to array elements without having to utf-8 decode the key from the buffer
-  arrayIndex?: number;
+  arrayIndex: number;
   // When true, all objects in this frame will be returned as raw bson buffers without parsing.
   // This is used when the fieldsAsRaw option is used on a parent object, and is inherited by nested frames.
   // It can also be set to true if the global raw option is set, but it cannot be set to true for a frame if the global raw option is false.
@@ -141,8 +143,15 @@ interface NestedParsingFrame {
   globalUTFValidation: boolean;
   // The utf-8 validation setting for this frame, used to determine whether to utf-8 validate keys in this frame. This is determined based on the global utf-8 validation setting and the specific keys specified in the validation option.
   validationSetting: boolean;
-  // A callback function that will be called when the frame is completed, used to set the value in the parent object once we have finished parsing the current object.
-  onComplete: () => void;
+  functionString: string | null; // only used for Code with Scope
+  // One of 3 supported types:
+  // - constants.BSON_DATA_OBJECT
+  // - constants.BSON_DATA_ARRAY
+  // - constants.BSON_DATA_CODE_W_SCOPE
+  elementType:
+    | typeof constants.BSON_DATA_OBJECT
+    | typeof constants.BSON_DATA_ARRAY
+    | typeof constants.BSON_DATA_CODE_W_SCOPE;
 }
 
 const allowedDBRefKeys = /^\$ref$|^\$id$|^\$db$/;
@@ -250,13 +259,41 @@ function deserializeObject(
 
   let isPossibleDBRef = isArray ? false : null;
 
+  // How we set the value in the destination object, with special handling for __proto__ to avoid prototype pollution vulnerabilities
+  const setValue = (name: string | number, value: unknown) => {
+    const dest =
+      nestedParsingStack.length === 0
+        ? rootObject
+        : nestedParsingStack[nestedParsingStack.length - 1].holdingDocument;
+    if (name === '__proto__') {
+      Object.defineProperty(dest, name, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true
+      });
+    } else {
+      dest[name] = value;
+    }
+  };
+
+  const toPotentialDbRef = (doc: Document): DBRef | Document => {
+    if (isDBRefLike(doc)) {
+      const copy = Object.assign({}, doc) as Partial<DBRefLike>;
+      delete copy.$ref;
+      delete copy.$id;
+      delete copy.$db;
+      const dbref = new DBRef(doc.$ref, doc.$id, doc.$db, copy);
+      return dbref;
+    }
+    return doc;
+  };
+
   // While we have more left data left keep parsing
   while (!done) {
     // Current frame, if one is present
     const currentFrame =
       nestedParsingStack.length === 0 ? null : nestedParsingStack[nestedParsingStack.length - 1];
-    // The object that we will be setting the current key value on, this is either the root object if we are at the top level, or the holdingDocument of the current frame if we are nested
-    const destObject = currentFrame === null ? rootObject : currentFrame.holdingDocument;
 
     // Read the type
     const elementType = buffer[index++];
@@ -269,7 +306,28 @@ function deserializeObject(
         if (index === currentFrame.lastIndex) {
           // Current index matches the last index of the frame, so we pop the frame and set the value in the parent document
           nestedParsingStack.pop();
-          currentFrame.onComplete();
+          // finish the frame
+          let result: Document = currentFrame.holdingDocument;
+          switch (currentFrame.elementType) {
+            case constants.BSON_DATA_OBJECT:
+              // if this is a DBRef, we need to construct a DBRef object instead of a plain object
+              if (currentFrame.isPossibleDBRef) {
+                result = toPotentialDbRef(result);
+              }
+              break;
+            case constants.BSON_DATA_ARRAY:
+              // nothing to do, the holding document is already an array and the keys were set as numeric indices
+              break;
+            case constants.BSON_DATA_CODE_W_SCOPE:
+              // the holding document is the scope, we need to construct a Code object with the function string and scope
+              result = new Code(currentFrame.functionString!, currentFrame.holdingDocument);
+              break;
+            default:
+              throw new BSONError('Unexpected element type in frame stack');
+          }
+          const propName = currentFrame.propertyName;
+          // set the value in the parent document
+          setValue(propName, result);
           continue;
         } else {
           // Current index does not match the last index of the frame, the document is malformed
@@ -302,23 +360,9 @@ function deserializeObject(
     // Represents the key
     const name = isArray
       ? currentFrame && currentFrame.isArray
-        ? currentFrame.arrayIndex!++
+        ? currentFrame.arrayIndex++
         : arrayIndex++
       : ByteUtils.toUTF8(buffer, index, i, false);
-
-    // How we set the value in the destination object, with special handling for __proto__ to avoid prototype pollution vulnerabilities
-    const setValue = (value: unknown) => {
-      if (name === '__proto__') {
-        Object.defineProperty(destObject, name, {
-          value,
-          writable: true,
-          enumerable: true,
-          configurable: true
-        });
-      } else {
-        destObject[name] = value;
-      }
-    };
 
     // shouldValidateKey is true if the key should be validated, false otherwise.
     // Within a nested frame the original code passed a collapsed boolean validation option,
@@ -396,23 +440,16 @@ function deserializeObject(
         isDeferredValue = true;
         nestedParsingStack.push({
           holdingDocument: {},
+          elementType: constants.BSON_DATA_OBJECT,
+          propertyName: name,
+          functionString: null,
           lastIndex: index + objectSize,
           isArray: false,
+          arrayIndex: 0,
           raw: false,
           isPossibleDBRef: null, // we don't know if this is a DBRef until we parse the keys, so we start with null and set to false if we encounter a key that is not valid for a DBRef
           globalUTFValidation: true,
-          validationSetting: shouldValidateKey,
-          onComplete: function () {
-            let result = this.holdingDocument;
-            if (this.isPossibleDBRef && isDBRefLike(result)) {
-              const copy = Object.assign({}, result) as Partial<DBRefLike>;
-              delete copy.$ref;
-              delete copy.$id;
-              delete copy.$db;
-              result = new DBRef(result.$ref, result.$id, result.$db, copy);
-            }
-            setValue(result);
-          }
+          validationSetting: shouldValidateKey
         });
         index = index + 4;
       }
@@ -428,16 +465,16 @@ function deserializeObject(
       isDeferredValue = true;
       nestedParsingStack.push({
         holdingDocument: [],
+        elementType: constants.BSON_DATA_ARRAY,
+        propertyName: name,
+        functionString: null,
         lastIndex: stopIndex,
         isArray: true,
         arrayIndex: 0,
         raw: arrayRaw,
         isPossibleDBRef: false,
         globalUTFValidation: true,
-        validationSetting: shouldValidateKey,
-        onComplete: function () {
-          setValue(this.holdingDocument);
-        }
+        validationSetting: shouldValidateKey
       });
       index = index + 4;
     } else if (elementType === constants.BSON_DATA_UNDEFINED) {
@@ -674,16 +711,16 @@ function deserializeObject(
       isDeferredValue = true;
       nestedParsingStack.push({
         holdingDocument: {},
+        elementType: constants.BSON_DATA_CODE_W_SCOPE,
+        propertyName: name,
+        functionString: functionString,
         lastIndex: _index + objectSize,
         isArray: false,
+        arrayIndex: 0,
         raw: false,
         isPossibleDBRef: null,
         globalUTFValidation: true,
-        validationSetting: shouldValidateKey,
-        onComplete: function () {
-          const result = new Code(functionString, this.holdingDocument);
-          setValue(result);
-        }
+        validationSetting: shouldValidateKey
       });
       index = index + 4; // move index past the size of the object, the rest of the object will be parsed in subsequent iterations of this loop
     } else if (elementType === constants.BSON_DATA_DBPOINTER) {
@@ -720,7 +757,7 @@ function deserializeObject(
 
     // If we have the value, set it on the target object
     if (!isDeferredValue) {
-      setValue(value);
+      setValue(name, value);
     }
   }
 
@@ -740,13 +777,5 @@ function deserializeObject(
   if (!isPossibleDBRef) return object;
 
   // If the object is DBRef-like, create a new DBRef instance
-  if (isDBRefLike(object)) {
-    const copy = Object.assign({}, object) as Partial<DBRefLike>;
-    delete copy.$ref;
-    delete copy.$id;
-    delete copy.$db;
-    return new DBRef(object.$ref, object.$id, object.$db, copy);
-  }
-
-  return object;
+  return toPotentialDbRef(object);
 }

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -331,6 +331,9 @@ function deserializeObject(
           continue;
         } else {
           // Current index does not match the last index of the frame, the document is malformed
+          if (currentFrame.elementType === constants.BSON_DATA_ARRAY) {
+            throw new BSONError('corrupted array bson');
+          }
           throw new BSONError('Bad BSON Document: object not properly terminated');
         }
       } else {

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -456,6 +456,9 @@ function deserializeObject(
     } else if (elementType === constants.BSON_DATA_ARRAY) {
       const objectSize = NumberUtils.getInt32LE(buffer, index);
 
+      if (objectSize <= 0 || objectSize > buffer.length - index)
+        throw new BSONError('bad embedded array length in bson');
+
       // Stop index
       const stopIndex = index + objectSize;
 

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -263,7 +263,7 @@ function deserializeObject(
 
   // How we set the value in the destination object, with special handling for __proto__ to avoid prototype pollution vulnerabilities
   const setValue = (name: string | number, value: unknown) => {
-    const frame = currentFrame as NestedParsingFrame | null;
+    const frame = currentFrame;
     const dest = frame !== null ? frame.holdingDocument : rootObject;
     if (name === '__proto__') {
       Object.defineProperty(dest, name, {
@@ -304,7 +304,9 @@ function deserializeObject(
           const completedFrame = currentFrame;
           nestedParsingStack.pop();
           currentFrame =
-            nestedParsingStack.length === 0 ? null : nestedParsingStack[nestedParsingStack.length - 1];
+            nestedParsingStack.length === 0
+              ? null
+              : nestedParsingStack[nestedParsingStack.length - 1];
           // finish the frame
           let result: Document = completedFrame.holdingDocument;
           switch (completedFrame.elementType) {

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -255,16 +255,16 @@ function deserializeObject(
   const nestedParsingStack: NestedParsingFrame[] = [];
   // Used for arrays to skip having to perform utf8 decoding
   let arrayIndex = 0;
-  const done = false;
 
   let isPossibleDBRef = isArray ? false : null;
 
+  // Tracks the top of nestedParsingStack, or null if there is no nested document currently being parsed.
+  let currentFrame: NestedParsingFrame | null = null;
+
   // How we set the value in the destination object, with special handling for __proto__ to avoid prototype pollution vulnerabilities
   const setValue = (name: string | number, value: unknown) => {
-    const dest =
-      nestedParsingStack.length === 0
-        ? rootObject
-        : nestedParsingStack[nestedParsingStack.length - 1].holdingDocument;
+    const frame = currentFrame as NestedParsingFrame | null;
+    const dest = frame !== null ? frame.holdingDocument : rootObject;
     if (name === '__proto__') {
       Object.defineProperty(dest, name, {
         value,
@@ -290,11 +290,7 @@ function deserializeObject(
   };
 
   // While we have more left data left keep parsing
-  while (!done) {
-    // Current frame, if one is present
-    const currentFrame =
-      nestedParsingStack.length === 0 ? null : nestedParsingStack[nestedParsingStack.length - 1];
-
+  while (true) {
     // Read the type
     const elementType = buffer[index++];
 
@@ -304,14 +300,17 @@ function deserializeObject(
       if (currentFrame) {
         // If we're in a frame, that means the end of the current nested document
         if (index === currentFrame.lastIndex) {
-          // Current index matches the last index of the frame, so we pop the frame and set the value in the parent document
+          // Snapshot the completed frame before updating currentFrame to the parent.
+          const completedFrame = currentFrame;
           nestedParsingStack.pop();
+          currentFrame =
+            nestedParsingStack.length === 0 ? null : nestedParsingStack[nestedParsingStack.length - 1];
           // finish the frame
-          let result: Document = currentFrame.holdingDocument;
-          switch (currentFrame.elementType) {
+          let result: Document = completedFrame.holdingDocument;
+          switch (completedFrame.elementType) {
             case constants.BSON_DATA_OBJECT:
               // if this is a DBRef, we need to construct a DBRef object instead of a plain object
-              if (currentFrame.isPossibleDBRef) {
+              if (completedFrame.isPossibleDBRef) {
                 result = toPotentialDbRef(result);
               }
               break;
@@ -320,14 +319,13 @@ function deserializeObject(
               break;
             case constants.BSON_DATA_CODE_W_SCOPE:
               // the holding document is the scope, we need to construct a Code object with the function string and scope
-              result = new Code(currentFrame.functionString!, currentFrame.holdingDocument);
+              result = new Code(completedFrame.functionString!, completedFrame.holdingDocument);
               break;
             default:
               throw new BSONError('Unexpected element type in frame stack');
           }
-          const propName = currentFrame.propertyName;
-          // set the value in the parent document
-          setValue(propName, result);
+          // set the value in the parent document (setValue reads currentFrame, now pointing to parent)
+          setValue(completedFrame.propertyName, result);
           continue;
         } else {
           // Current index does not match the last index of the frame, the document is malformed
@@ -451,6 +449,7 @@ function deserializeObject(
           globalUTFValidation: true,
           validationSetting: shouldValidateKey
         });
+        currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
         index = index + 4;
       }
     } else if (elementType === constants.BSON_DATA_ARRAY) {
@@ -476,6 +475,7 @@ function deserializeObject(
         globalUTFValidation: true,
         validationSetting: shouldValidateKey
       });
+      currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
       index = index + 4;
     } else if (elementType === constants.BSON_DATA_UNDEFINED) {
       value = undefined;
@@ -722,6 +722,7 @@ function deserializeObject(
         globalUTFValidation: true,
         validationSetting: shouldValidateKey
       });
+      currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
       index = index + 4; // move index past the size of the object, the rest of the object will be parsed in subsequent iterations of this loop
     } else if (elementType === constants.BSON_DATA_DBPOINTER) {
       // Get the code string size

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -439,17 +439,17 @@ function deserializeObject(
       } else {
         isDeferredValue = true;
         nestedParsingStack.push({
-          elementType: constants.BSON_DATA_OBJECT,
           holdingDocument: {},
+          elementType: constants.BSON_DATA_OBJECT,
           propertyName: name,
+          functionString: null,
           lastIndex: index + objectSize,
           isArray: false,
           arrayIndex: 0,
           raw: false,
           isPossibleDBRef: null, // we don't know if this is a DBRef until we parse the keys, so we start with null and set to false if we encounter a key that is not valid for a DBRef
           globalUTFValidation: true,
-          validationSetting: shouldValidateKey,
-          functionString: null
+          validationSetting: shouldValidateKey
         });
         currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
         index = index + 4;
@@ -465,17 +465,17 @@ function deserializeObject(
       const arrayRaw = !!(fieldsAsRaw && fieldsAsRaw[name]) || (currentFrame?.raw ?? false);
       isDeferredValue = true;
       nestedParsingStack.push({
-        elementType: constants.BSON_DATA_ARRAY,
         holdingDocument: [],
+        elementType: constants.BSON_DATA_ARRAY,
         propertyName: name,
+        functionString: null,
         lastIndex: stopIndex,
         isArray: true,
         arrayIndex: 0,
         raw: arrayRaw,
         isPossibleDBRef: false,
         globalUTFValidation: true,
-        validationSetting: shouldValidateKey,
-        functionString: null
+        validationSetting: shouldValidateKey
       });
       currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
       index = index + 4;
@@ -712,17 +712,17 @@ function deserializeObject(
 
       isDeferredValue = true;
       nestedParsingStack.push({
-        elementType: constants.BSON_DATA_CODE_W_SCOPE,
         holdingDocument: {},
+        elementType: constants.BSON_DATA_CODE_W_SCOPE,
         propertyName: name,
+        functionString: functionString,
         lastIndex: _index + objectSize,
         isArray: false,
         arrayIndex: 0,
         raw: false,
         isPossibleDBRef: null,
         globalUTFValidation: true,
-        validationSetting: shouldValidateKey,
-        functionString: functionString
+        validationSetting: shouldValidateKey
       });
       currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
       index = index + 4; // move index past the size of the object, the rest of the object will be parsed in subsequent iterations of this loop

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -123,6 +123,14 @@ export function internalDeserialize(
 }
 
 interface NestedParsingFrame {
+  // One of 3 supported types:
+  // - constants.BSON_DATA_OBJECT
+  // - constants.BSON_DATA_ARRAY
+  // - constants.BSON_DATA_CODE_W_SCOPE
+  elementType:
+    | typeof constants.BSON_DATA_OBJECT
+    | typeof constants.BSON_DATA_ARRAY
+    | typeof constants.BSON_DATA_CODE_W_SCOPE;
   // Document that we will fill out as we parse the nested object
   holdingDocument: Document;
   // The name of the key we will set the parsed object on once we finish parsing the nested object, this is used in the onComplete callback to know where to set the parsed nested object in the parent document
@@ -144,14 +152,6 @@ interface NestedParsingFrame {
   // The utf-8 validation setting for this frame, used to determine whether to utf-8 validate keys in this frame. This is determined based on the global utf-8 validation setting and the specific keys specified in the validation option.
   validationSetting: boolean;
   functionString: string | null; // only used for Code with Scope
-  // One of 3 supported types:
-  // - constants.BSON_DATA_OBJECT
-  // - constants.BSON_DATA_ARRAY
-  // - constants.BSON_DATA_CODE_W_SCOPE
-  elementType:
-    | typeof constants.BSON_DATA_OBJECT
-    | typeof constants.BSON_DATA_ARRAY
-    | typeof constants.BSON_DATA_CODE_W_SCOPE;
 }
 
 const allowedDBRefKeys = /^\$ref$|^\$id$|^\$db$/;
@@ -437,17 +437,17 @@ function deserializeObject(
       } else {
         isDeferredValue = true;
         nestedParsingStack.push({
-          holdingDocument: {},
           elementType: constants.BSON_DATA_OBJECT,
+          holdingDocument: {},
           propertyName: name,
-          functionString: null,
           lastIndex: index + objectSize,
           isArray: false,
           arrayIndex: 0,
           raw: false,
           isPossibleDBRef: null, // we don't know if this is a DBRef until we parse the keys, so we start with null and set to false if we encounter a key that is not valid for a DBRef
           globalUTFValidation: true,
-          validationSetting: shouldValidateKey
+          validationSetting: shouldValidateKey,
+          functionString: null
         });
         currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
         index = index + 4;
@@ -463,17 +463,17 @@ function deserializeObject(
       const arrayRaw = !!(fieldsAsRaw && fieldsAsRaw[name]) || (currentFrame?.raw ?? false);
       isDeferredValue = true;
       nestedParsingStack.push({
-        holdingDocument: [],
         elementType: constants.BSON_DATA_ARRAY,
+        holdingDocument: [],
         propertyName: name,
-        functionString: null,
         lastIndex: stopIndex,
         isArray: true,
         arrayIndex: 0,
         raw: arrayRaw,
         isPossibleDBRef: false,
         globalUTFValidation: true,
-        validationSetting: shouldValidateKey
+        validationSetting: shouldValidateKey,
+        functionString: null
       });
       currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
       index = index + 4;
@@ -710,17 +710,17 @@ function deserializeObject(
 
       isDeferredValue = true;
       nestedParsingStack.push({
-        holdingDocument: {},
         elementType: constants.BSON_DATA_CODE_W_SCOPE,
+        holdingDocument: {},
         propertyName: name,
-        functionString: functionString,
         lastIndex: _index + objectSize,
         isArray: false,
         arrayIndex: 0,
         raw: false,
         isPossibleDBRef: null,
         globalUTFValidation: true,
-        validationSetting: shouldValidateKey
+        validationSetting: shouldValidateKey,
+        functionString: functionString
       });
       currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
       index = index + 4; // move index past the size of the object, the rest of the object will be parsed in subsequent iterations of this loop

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -122,6 +122,29 @@ export function internalDeserialize(
   return deserializeObject(buffer, index, options, isArray);
 }
 
+interface NestedParsingFrame {
+  // Document that we will fill out as we parse the nested object
+  holdingDocument: Document;
+  // The index in the buffer where the current object ends, used to know when we are done parsing the current object and can pop the stack
+  lastIndex: number;
+  // Whether the current frame is parsing an array, used to know whether to interpret keys as strings or array indices
+  isArray: boolean;
+  // The next array index to use if this frame is parsing an array, used to assign numeric keys to array elements without having to utf-8 decode the key from the buffer
+  arrayIndex?: number;
+  // When true, all objects in this frame will be returned as raw bson buffers without parsing.
+  // This is used when the fieldsAsRaw option is used on a parent object, and is inherited by nested frames.
+  // It can also be set to true if the global raw option is set, but it cannot be set to true for a frame if the global raw option is false.
+  raw: boolean;
+  // When true, this frame may be a DBRef. This is set to false if we encounter a key that is not valid for a DBRef, and is left as null for arrays since they cannot be DBRefs.
+  isPossibleDBRef: boolean | null;
+  // The global utf-8 validation setting for this frame, used to determine the default utf-8 validation behavior for keys in this frame if the validation option is not an object specifying specific keys.
+  globalUTFValidation: boolean;
+  // The utf-8 validation setting for this frame, used to determine whether to utf-8 validate keys in this frame. This is determined based on the global utf-8 validation setting and the specific keys specified in the validation option.
+  validationSetting: boolean;
+  // A callback function that will be called when the frame is completed, used to set the value in the parent object once we have finished parsing the current object.
+  onComplete: () => void;
+}
+
 const allowedDBRefKeys = /^\$ref$|^\$id$|^\$db$/;
 
 function deserializeObject(
@@ -130,6 +153,15 @@ function deserializeObject(
   options: DeserializeOptions,
   isArray = false
 ) {
+  // Settings configured from options parameter
+
+  // Strip the prototype chain so inherited properties don't affect option reads.
+  options = Object.assign({}, options);
+
+  // Used to track whether we are parsing an array or object, affects how keys are interpreted and when we hit the end of the document
+  const originalIsArray = isArray;
+
+  // Used to track fields that should be returned as raw bson buffers without parsing, this is set based on the fieldsAsRaw option and is inherited by nested frames when parsing nested objects
   const fieldsAsRaw = options['fieldsAsRaw'] == null ? null : options['fieldsAsRaw'];
 
   // Return raw bson buffer instead of parsing it
@@ -144,10 +176,10 @@ function deserializeObject(
   const promoteValues = options.promoteValues ?? true;
   const useBigInt64 = options.useBigInt64 ?? false;
 
+  // Validate bigint and long promotion settings
   if (useBigInt64 && !promoteValues) {
     throw new BSONError('Must either request bigint or Long for int64 deserialization');
   }
-
   if (useBigInt64 && !promoteLongs) {
     throw new BSONError('Must either request bigint or Long for int64 deserialization');
   }
@@ -193,6 +225,8 @@ function deserializeObject(
     }
   }
 
+  // Begin parsing the document
+
   // Set the start index
   const startIndex = index;
 
@@ -201,13 +235,15 @@ function deserializeObject(
 
   // Read the document size
   const size = NumberUtils.getInt32LE(buffer, index);
+  // Skip past the size field
   index += 4;
 
   // Ensure buffer is valid size
   if (size < 5 || size > buffer.length) throw new BSONError('corrupt bson message');
 
   // Create holding object
-  const object: Document = isArray ? [] : {};
+  const rootObject: Document = isArray ? [] : {};
+  const nestedParsingStack: NestedParsingFrame[] = [];
   // Used for arrays to skip having to perform utf8 decoding
   let arrayIndex = 0;
   const done = false;
@@ -216,11 +252,42 @@ function deserializeObject(
 
   // While we have more left data left keep parsing
   while (!done) {
+    // Current frame, if one is present
+    const currentFrame =
+      nestedParsingStack.length === 0 ? null : nestedParsingStack[nestedParsingStack.length - 1];
+    // The object that we will be setting the current key value on, this is either the root object if we are at the top level, or the holdingDocument of the current frame if we are nested
+    const destObject = currentFrame === null ? rootObject : currentFrame.holdingDocument;
+
     // Read the type
     const elementType = buffer[index++];
 
     // If we get a zero it's the last byte, exit
-    if (elementType === 0) break;
+    if (elementType === 0) {
+      // 0 byte marks end of document.
+      if (currentFrame) {
+        // If we're in a frame, that means the end of the current nested document
+        if (index === currentFrame.lastIndex) {
+          // Current index matches the last index of the frame, so we pop the frame and set the value in the parent document
+          nestedParsingStack.pop();
+          currentFrame.onComplete();
+          continue;
+        } else {
+          // Current index does not match the last index of the frame, the document is malformed
+          throw new BSONError('Bad BSON Document: object not properly terminated');
+        }
+      } else {
+        // If we're not in a frame, that means the end of the root document, so we break out of the loop and return the object
+        break;
+      }
+    }
+
+    if (currentFrame) {
+      // If we're in a frame, use the frame's array setting
+      isArray = currentFrame.isArray;
+    } else {
+      // If we're not in a frame, use the original isArray value that was passed in for the root document
+      isArray = originalIsArray;
+    }
 
     // Get the start search index
     let i = index;
@@ -233,20 +300,48 @@ function deserializeObject(
     if (i >= buffer.byteLength) throw new BSONError('Bad BSON Document: illegal CString');
 
     // Represents the key
-    const name = isArray ? arrayIndex++ : ByteUtils.toUTF8(buffer, index, i, false);
+    const name = isArray
+      ? currentFrame && currentFrame.isArray
+        ? currentFrame.arrayIndex!++
+        : arrayIndex++
+      : ByteUtils.toUTF8(buffer, index, i, false);
 
-    // shouldValidateKey is true if the key should be validated, false otherwise
-    let shouldValidateKey = true;
-    if (globalUTFValidation || utf8KeysSet?.has(name)) {
+    // How we set the value in the destination object, with special handling for __proto__ to avoid prototype pollution vulnerabilities
+    const setValue = (value: unknown) => {
+      if (name === '__proto__') {
+        Object.defineProperty(destObject, name, {
+          value,
+          writable: true,
+          enumerable: true,
+          configurable: true
+        });
+      } else {
+        destObject[name] = value;
+      }
+    };
+
+    // shouldValidateKey is true if the key should be validated, false otherwise.
+    // Within a nested frame the original code passed a collapsed boolean validation option,
+    // so all keys in the frame are validated uniformly using the frame's setting.
+    let shouldValidateKey: boolean;
+    if (currentFrame !== null) {
+      shouldValidateKey = currentFrame.validationSetting;
+    } else if (globalUTFValidation || utf8KeysSet?.has(name)) {
       shouldValidateKey = validationSetting;
     } else {
       shouldValidateKey = !validationSetting;
     }
 
-    if (isPossibleDBRef !== false && (name as string)[0] === '$') {
+    // Route DBRef key tracking to the current frame; the root variable handles the root doc.
+    if (currentFrame !== null) {
+      if (currentFrame.isPossibleDBRef !== false && typeof name === 'string' && name[0] === '$') {
+        currentFrame.isPossibleDBRef = allowedDBRefKeys.test(name);
+      }
+    } else if (isPossibleDBRef !== false && (name as string)[0] === '$') {
       isPossibleDBRef = allowedDBRefKeys.test(name as string);
     }
     let value;
+    let isDeferredValue = false;
 
     index = i + 1;
 
@@ -288,45 +383,63 @@ function deserializeObject(
         throw new BSONError('illegal boolean type value');
       value = buffer[index++] === 1;
     } else if (elementType === constants.BSON_DATA_OBJECT) {
-      const _index = index;
       const objectSize = NumberUtils.getInt32LE(buffer, index);
 
       if (objectSize <= 0 || objectSize > buffer.length - index)
         throw new BSONError('bad embedded document length in bson');
 
-      // We have a raw value
-      if (raw) {
+      // We have a raw value: either the global raw option, or the parent frame requested raw elements.
+      if (raw || (currentFrame?.raw ?? false)) {
         value = buffer.subarray(index, index + objectSize);
+        index = index + objectSize;
       } else {
-        let objectOptions = options;
-        if (!globalUTFValidation) {
-          objectOptions = { ...options, validation: { utf8: shouldValidateKey } };
-        }
-        value = deserializeObject(buffer, _index, objectOptions, false);
+        isDeferredValue = true;
+        nestedParsingStack.push({
+          holdingDocument: {},
+          lastIndex: index + objectSize,
+          isArray: false,
+          raw: false,
+          isPossibleDBRef: null, // we don't know if this is a DBRef until we parse the keys, so we start with null and set to false if we encounter a key that is not valid for a DBRef
+          globalUTFValidation: true,
+          validationSetting: shouldValidateKey,
+          onComplete: function () {
+            let result = this.holdingDocument;
+            if (this.isPossibleDBRef && isDBRefLike(result)) {
+              const copy = Object.assign({}, result) as Partial<DBRefLike>;
+              delete copy.$ref;
+              delete copy.$id;
+              delete copy.$db;
+              result = new DBRef(result.$ref, result.$id, result.$db, copy);
+            }
+            setValue(result);
+          }
+        });
+        index = index + 4;
       }
-
-      index = index + objectSize;
     } else if (elementType === constants.BSON_DATA_ARRAY) {
-      const _index = index;
       const objectSize = NumberUtils.getInt32LE(buffer, index);
-      let arrayOptions: DeserializeOptions = options;
 
       // Stop index
       const stopIndex = index + objectSize;
 
-      // All elements of array to be returned as raw bson
-      if (fieldsAsRaw && fieldsAsRaw[name]) {
-        arrayOptions = { ...options, raw: true };
-      }
-
-      if (!globalUTFValidation) {
-        arrayOptions = { ...arrayOptions, validation: { utf8: shouldValidateKey } };
-      }
-      value = deserializeObject(buffer, _index, arrayOptions, true);
-      index = index + objectSize;
-
-      if (buffer[index - 1] !== 0) throw new BSONError('invalid array terminator byte');
-      if (index !== stopIndex) throw new BSONError('corrupted array bson');
+      // fieldsAsRaw match: push with raw=true so embedded objects inside come back as raw bytes.
+      // Also propagate raw from the parent frame (nested arrays inside a raw array stay raw).
+      const arrayRaw = !!(fieldsAsRaw && fieldsAsRaw[name]) || (currentFrame?.raw ?? false);
+      isDeferredValue = true;
+      nestedParsingStack.push({
+        holdingDocument: [],
+        lastIndex: stopIndex,
+        isArray: true,
+        arrayIndex: 0,
+        raw: arrayRaw,
+        isPossibleDBRef: false,
+        globalUTFValidation: true,
+        validationSetting: shouldValidateKey,
+        onComplete: function () {
+          setValue(this.holdingDocument);
+        }
+      });
+      index = index + 4;
     } else if (elementType === constants.BSON_DATA_UNDEFINED) {
       value = undefined;
     } else if (elementType === constants.BSON_DATA_NULL) {
@@ -547,10 +660,6 @@ function deserializeObject(
       const _index = index;
       // Decode the size of the object document
       const objectSize = NumberUtils.getInt32LE(buffer, index);
-      // Decode the scope object
-      const scopeObject = deserializeObject(buffer, _index, options, false);
-      // Adjust the index
-      index = index + objectSize;
 
       // Check if field length is too short
       if (totalSize < 4 + 4 + objectSize + stringSize) {
@@ -562,7 +671,21 @@ function deserializeObject(
         throw new BSONError('code_w_scope total size is too long, clips outer document');
       }
 
-      value = new Code(functionString, scopeObject);
+      isDeferredValue = true;
+      nestedParsingStack.push({
+        holdingDocument: {},
+        lastIndex: _index + objectSize,
+        isArray: false,
+        raw: false,
+        isPossibleDBRef: null,
+        globalUTFValidation: true,
+        validationSetting: shouldValidateKey,
+        onComplete: function () {
+          const result = new Code(functionString, this.holdingDocument);
+          setValue(result);
+        }
+      });
+      index = index + 4; // move index past the size of the object, the rest of the object will be parsed in subsequent iterations of this loop
     } else if (elementType === constants.BSON_DATA_DBPOINTER) {
       // Get the code string size
       const stringSize = NumberUtils.getInt32LE(buffer, index);
@@ -594,17 +717,19 @@ function deserializeObject(
         `Detected unknown BSON type ${elementType.toString(16)} for fieldname "${name}"`
       );
     }
-    if (name === '__proto__') {
-      Object.defineProperty(object, name, {
-        value,
-        writable: true,
-        enumerable: true,
-        configurable: true
-      });
+
+    if (isDeferredValue) {
+      // console.log(`Deferring setting value for key "${name}" until end of object parsing`);
     } else {
-      object[name] = value;
+      setValue(value);
     }
   }
+
+  // Check if we have any frames left on the stack, if we do then we had a malformed document
+  if (nestedParsingStack.length !== 0) {
+    throw new BSONError('corrupted bson, more objects expected based on the current document size');
+  }
+  const object = rootObject;
 
   // Check if the deserialization was against a valid array/object
   if (size !== index - startIndex) {

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -2,7 +2,7 @@ import { Binary, UUID } from '../binary';
 import type { Document } from '../bson';
 import { Code } from '../code';
 import * as constants from '../constants';
-import { DBRef, type DBRefLike, isDBRefLike } from '../db_ref';
+import { DBRef, isDBRefLike } from '../db_ref';
 import { Decimal128 } from '../decimal128';
 import { Double } from '../double';
 import { BSONError } from '../error';
@@ -164,8 +164,8 @@ function deserializeObject(
 ) {
   // Settings configured from options parameter
 
-  // Strip the prototype chain so inherited properties don't affect option reads.
-  options = Object.assign({}, options);
+  // Strips prototype chain so inherited properties don't affect option reads.
+  options = { ...options };
 
   // Used to track whether we are parsing an array or object, affects how keys are interpreted and when we hit the end of the document
   const originalIsArray = isArray;
@@ -279,12 +279,8 @@ function deserializeObject(
 
   const toPotentialDbRef = (doc: Document): DBRef | Document => {
     if (isDBRefLike(doc)) {
-      const copy = Object.assign({}, doc) as Partial<DBRefLike>;
-      delete copy.$ref;
-      delete copy.$id;
-      delete copy.$db;
-      const dbref = new DBRef(doc.$ref, doc.$id, doc.$db, copy);
-      return dbref;
+      const { $ref, $id, $db, ...fields } = doc;
+      return new DBRef($ref, $id, $db, fields);
     }
     return doc;
   };

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -718,9 +718,8 @@ function deserializeObject(
       );
     }
 
-    if (isDeferredValue) {
-      // console.log(`Deferring setting value for key "${name}" until end of object parsing`);
-    } else {
+    // If we have the value, set it on the target object
+    if (!isDeferredValue) {
       setValue(value);
     }
   }
@@ -740,6 +739,7 @@ function deserializeObject(
   // if we did not find "$ref", "$id", "$db", or found an extraneous $key, don't make a DBRef
   if (!isPossibleDBRef) return object;
 
+  // If the object is DBRef-like, create a new DBRef instance
   if (isDBRefLike(object)) {
     const copy = Object.assign({}, object) as Partial<DBRefLike>;
     delete copy.$ref;

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -647,9 +647,8 @@ export function serializeInto(
       } else if (value._bsontype === 'DBRef') {
         const dbref = value as DBRef;
         const orderedValues: Document = Object.assign(
-          { $ref: dbref.collection },
-          dbref.oid ? { $id: dbref.oid } : null,
-          dbref.db ? { $db: dbref.db } : null,
+          { $ref: dbref.collection, $id: dbref.oid },
+          dbref.db != null ? { $db: dbref.db } : null,
           dbref.fields
         );
         buffer[index++] = constants.BSON_DATA_OBJECT;

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -2,7 +2,6 @@ import { Binary, validateBinaryVector } from '../binary';
 import type { BSONSymbol, DBRef, Document, MaxKey } from '../bson';
 import type { Code } from '../code';
 import * as constants from '../constants';
-import type { DBRefLike } from '../db_ref';
 import type { Decimal128 } from '../decimal128';
 import type { Double } from '../double';
 import { BSONError, BSONVersionError } from '../error';
@@ -268,46 +267,6 @@ function serializeBuffer(buffer: Uint8Array, key: string, value: Uint8Array, ind
   return index;
 }
 
-function serializeObject(
-  buffer: Uint8Array,
-  key: string,
-  value: Document,
-  index: number,
-  checkKeys: boolean,
-  depth: number,
-  serializeFunctions: boolean,
-  ignoreUndefined: boolean,
-  path: Set<Document>
-) {
-  if (path.has(value)) {
-    throw new BSONError('Cannot convert circular structure to BSON');
-  }
-
-  path.add(value);
-
-  // Write the type
-  buffer[index++] = Array.isArray(value) ? constants.BSON_DATA_ARRAY : constants.BSON_DATA_OBJECT;
-  // Number of written bytes
-  const numberOfWrittenBytes = ByteUtils.encodeUTF8Into(buffer, key, index);
-  // Encode the name
-  index = index + numberOfWrittenBytes;
-  buffer[index++] = 0;
-  const endIndex = serializeInto(
-    buffer,
-    value,
-    checkKeys,
-    index,
-    depth + 1,
-    serializeFunctions,
-    ignoreUndefined,
-    path
-  );
-
-  path.delete(value);
-
-  return endIndex;
-}
-
 function serializeDecimal128(buffer: Uint8Array, key: string, value: Decimal128, index: number) {
   buffer[index++] = constants.BSON_DATA_DECIMAL128;
   // Number of written bytes
@@ -391,85 +350,6 @@ function serializeFunction(buffer: Uint8Array, key: string, value: Function, ind
   return index;
 }
 
-function serializeCode(
-  buffer: Uint8Array,
-  key: string,
-  value: Code,
-  index: number,
-  checkKeys = false,
-  depth = 0,
-  serializeFunctions = false,
-  ignoreUndefined = true,
-  path: Set<Document>
-) {
-  if (value.scope && typeof value.scope === 'object') {
-    // Write the type
-    buffer[index++] = constants.BSON_DATA_CODE_W_SCOPE;
-    // Number of written bytes
-    const numberOfWrittenBytes = ByteUtils.encodeUTF8Into(buffer, key, index);
-    // Encode the name
-    index = index + numberOfWrittenBytes;
-    buffer[index++] = 0;
-
-    // Starting index
-    let startIndex = index;
-
-    // Serialize the function
-    // Get the function string
-    const functionString = value.code;
-    // Index adjustment
-    index = index + 4;
-    // Write string into buffer
-    const codeSize = ByteUtils.encodeUTF8Into(buffer, functionString, index + 4) + 1;
-    // Write the size of the string to buffer
-    NumberUtils.setInt32LE(buffer, index, codeSize);
-    // Write end 0
-    buffer[index + 4 + codeSize - 1] = 0;
-    // Write the
-    index = index + codeSize + 4;
-
-    // Serialize the scope value
-    const endIndex = serializeInto(
-      buffer,
-      value.scope,
-      checkKeys,
-      index,
-      depth + 1,
-      serializeFunctions,
-      ignoreUndefined,
-      path
-    );
-    index = endIndex - 1;
-
-    // Writ the total
-    const totalSize = endIndex - startIndex;
-
-    // Write the total size of the object
-    startIndex += NumberUtils.setInt32LE(buffer, startIndex, totalSize);
-    // Write trailing zero
-    buffer[index++] = 0;
-  } else {
-    buffer[index++] = constants.BSON_DATA_CODE;
-    // Number of written bytes
-    const numberOfWrittenBytes = ByteUtils.encodeUTF8Into(buffer, key, index);
-    // Encode the name
-    index = index + numberOfWrittenBytes;
-    buffer[index++] = 0;
-    // Function string
-    const functionString = value.code.toString();
-    // Write the string
-    const size = ByteUtils.encodeUTF8Into(buffer, functionString, index + 4) + 1;
-    // Write the size of the string to buffer
-    NumberUtils.setInt32LE(buffer, index, size);
-    // Update index
-    index = index + 4 + size - 1;
-    // Write zero
-    buffer[index++] = 0;
-  }
-
-  return index;
-}
-
 function serializeBinary(buffer: Uint8Array, key: string, value: Binary, index: number) {
   // Write the type
   buffer[index++] = constants.BSON_DATA_BINARY;
@@ -528,52 +408,46 @@ function serializeSymbol(buffer: Uint8Array, key: string, value: BSONSymbol, ind
   return index;
 }
 
-function serializeDBRef(
-  buffer: Uint8Array,
-  key: string,
-  value: DBRef,
-  index: number,
-  depth: number,
-  serializeFunctions: boolean,
-  path: Set<Document>
-) {
-  // Write the type
-  buffer[index++] = constants.BSON_DATA_OBJECT;
-  // Number of written bytes
-  const numberOfWrittenBytes = ByteUtils.encodeUTF8Into(buffer, key, index);
+interface SerializationFrame {
+  // The object we are serializing at this level of the stack. Used for circular reference detection and to avoid having to call toBSON multiple times on the same object in case of circular references.
+  sourceObject: Document;
+  // Whether the object we are serializing is an array, which forces the keys to be serialized as ascii strings of their index in the array
+  isArray: boolean;
+  // The key-value pairs of the object we are serializing.
+  // We compute this once per object to avoid having to compute it multiple times in case of circular references
+  kvPairs: [string, unknown][];
+  // The number of serialized kvPairs, used to keep track of where we are in the serialization process
+  serializedPairCount: number;
+  // The index in the buffer where the size of the current object being serialized is stored. We will only know the size of the object once we have finished serializing it, so we keep track of where to write the size once we know it.
+  objectSizeIndex: number;
+  // The index in the buffer where the size of the code with scope object is stored, used for Code with Scope serialization. We will only know the size of the code with scope object once we have finished serializing it, so we keep track of where to write the size once we know it.
+  codeSizeIndex: number | null;
+}
 
-  // Encode the name
-  index = index + numberOfWrittenBytes;
-  buffer[index++] = 0;
-
-  let startIndex = index;
-  let output: DBRefLike = {
-    $ref: value.collection || value.namespace, // "namespace" was what library 1.x called "collection"
-    $id: value.oid
-  };
-
-  if (value.db != null) {
-    output.$db = value.db;
+function toKvPairs(object: Document): [string, unknown][] {
+  if (Array.isArray(object)) {
+    const kvPairs = new Array<[string, unknown]>(object.length);
+    for (let i = 0; i < object.length; i++) {
+      kvPairs[i] = [`${i}`, object[i]];
+    }
+    return kvPairs;
+  } else if (object instanceof Map || isMap(object)) {
+    return Array.from((object as Map<unknown, unknown>).entries()) as [string, unknown][];
+  } else {
+    let target: Document = object;
+    if (typeof (target as any)?.toBSON === 'function') {
+      target = (target as any).toBSON() as Document;
+      if (target != null && typeof target !== 'object') {
+        throw new BSONError('toBSON function did not return an object');
+      }
+    }
+    const keys = Object.keys(target);
+    const kvPairs = new Array<[string, unknown]>(keys.length);
+    for (let i = 0; i < keys.length; i++) {
+      kvPairs[i] = [keys[i], target[keys[i]]];
+    }
+    return kvPairs;
   }
-
-  output = Object.assign(output, value.fields);
-  const endIndex = serializeInto(
-    buffer,
-    output,
-    false,
-    index,
-    depth + 1,
-    serializeFunctions,
-    true,
-    path
-  );
-
-  // Calculate object size
-  const size = endIndex - startIndex;
-  // Write the size
-  startIndex += NumberUtils.setInt32LE(buffer, index, size);
-  // Set index
-  return endIndex;
 }
 
 export function serializeInto(
@@ -581,7 +455,6 @@ export function serializeInto(
   object: Document,
   checkKeys: boolean,
   startingIndex: number,
-  depth: number,
   serializeFunctions: boolean,
   ignoreUndefined: boolean,
   path: Set<Document> | null
@@ -619,336 +492,184 @@ export function serializeInto(
     path = new Set();
   }
 
-  // Push the object to the path
   path.add(object);
 
-  // Start place to serialize into
+  const stack: SerializationFrame[] = [
+    {
+      kvPairs: toKvPairs(object),
+      serializedPairCount: 0,
+      objectSizeIndex: startingIndex,
+      codeSizeIndex: null,
+      sourceObject: object,
+      isArray: Array.isArray(object)
+    }
+  ];
   let index = startingIndex + 4;
 
-  // Special case isArray
-  if (Array.isArray(object)) {
-    // Get object keys
-    for (let i = 0; i < object.length; i++) {
-      const key = `${i}`;
-      let value = object[i];
+  while (stack.length > 0) {
+    const frame = stack[stack.length - 1];
 
-      // Is there an override value
-      if (typeof value?.toBSON === 'function') {
-        value = value.toBSON();
+    if (frame.serializedPairCount >= frame.kvPairs.length) {
+      buffer[index++] = 0x00;
+      NumberUtils.setInt32LE(buffer, frame.objectSizeIndex, index - frame.objectSizeIndex);
+      if (frame.codeSizeIndex !== null) {
+        NumberUtils.setInt32LE(buffer, frame.codeSizeIndex, index - frame.codeSizeIndex);
       }
+      path.delete(frame.sourceObject);
+      stack.pop();
+      continue;
+    }
 
-      // Check the type of the value
-      const type = typeof value;
+    const pair = frame.kvPairs[frame.serializedPairCount++];
+    const key = pair[0];
+    let value: any = pair[1];
 
-      if (value === undefined) {
-        index = serializeNull(buffer, key, value, index);
-      } else if (value === null) {
-        index = serializeNull(buffer, key, value, index);
-      } else if (type === 'string') {
-        index = serializeString(buffer, key, value, index);
-      } else if (type === 'number') {
-        index = serializeNumber(buffer, key, value, index);
-      } else if (type === 'bigint') {
-        index = serializeBigInt(buffer, key, value, index);
-      } else if (type === 'boolean') {
-        index = serializeBoolean(buffer, key, value, index);
-      } else if (type === 'object' && value._bsontype == null) {
-        if (value instanceof Date || isDate(value)) {
-          index = serializeDate(buffer, key, value, index);
-        } else if (value instanceof Uint8Array || isUint8Array(value)) {
-          index = serializeBuffer(buffer, key, value, index);
-        } else if (value instanceof RegExp || isRegExp(value)) {
-          index = serializeRegExp(buffer, key, value, index);
-        } else {
-          index = serializeObject(
-            buffer,
-            key,
-            value,
-            index,
-            checkKeys,
-            depth,
-            serializeFunctions,
-            ignoreUndefined,
-            path
-          );
+    if (typeof value?.toBSON === 'function') {
+      value = value.toBSON();
+    }
+
+    if (!frame.isArray && typeof key === 'string' && !ignoreKeys.has(key)) {
+      if (key.match(regexp) != null) {
+        throw new BSONError('key ' + key + ' must not contain null bytes');
+      }
+      if (checkKeys) {
+        if ('$' === key[0]) {
+          throw new BSONError('key ' + key + " must not start with '$'");
+        } else if (key.includes('.')) {
+          throw new BSONError('key ' + key + " must not contain '.'");
         }
-      } else if (type === 'object') {
-        if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
-          throw new BSONVersionError();
-        } else if (value._bsontype === 'ObjectId') {
-          index = serializeObjectId(buffer, key, value, index);
-        } else if (value._bsontype === 'Decimal128') {
-          index = serializeDecimal128(buffer, key, value, index);
-        } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
-          index = serializeLong(buffer, key, value, index);
-        } else if (value._bsontype === 'Double') {
-          index = serializeDouble(buffer, key, value, index);
-        } else if (value._bsontype === 'Code') {
-          index = serializeCode(
-            buffer,
-            key,
-            value,
-            index,
-            checkKeys,
-            depth,
-            serializeFunctions,
-            ignoreUndefined,
-            path
-          );
-        } else if (value._bsontype === 'Binary') {
-          index = serializeBinary(buffer, key, value, index);
-        } else if (value._bsontype === 'BSONSymbol') {
-          index = serializeSymbol(buffer, key, value, index);
-        } else if (value._bsontype === 'DBRef') {
-          index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
-        } else if (value._bsontype === 'BSONRegExp') {
-          index = serializeBSONRegExp(buffer, key, value, index);
-        } else if (value._bsontype === 'Int32') {
-          index = serializeInt32(buffer, key, value, index);
-        } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
-          index = serializeMinMax(buffer, key, value, index);
-        } else if (typeof value._bsontype !== 'undefined') {
-          throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
-        }
-      } else if (type === 'function' && serializeFunctions) {
-        index = serializeFunction(buffer, key, value, index);
       }
     }
-  } else if (object instanceof Map || isMap(object)) {
-    const iterator = object.entries();
-    let done = false;
 
-    while (!done) {
-      // Unpack the next entry
-      const entry = iterator.next();
-      done = !!entry.done;
-      // Are we done, then skip and terminate
-      if (done) continue;
+    const type = typeof value;
 
-      // Get the entry values
-      const key = entry.value ? entry.value[0] : undefined;
-      let value = entry.value ? entry.value[1] : undefined;
-
-      if (typeof value?.toBSON === 'function') {
-        value = value.toBSON();
+    if (value === undefined) {
+      if (frame.isArray || ignoreUndefined === false) {
+        index = serializeNull(buffer, key, value, index);
       }
-
-      // Check the type of the value
-      const type = typeof value;
-
-      // Check the key and throw error if it's illegal
-      if (typeof key === 'string' && !ignoreKeys.has(key)) {
-        if (key.match(regexp) != null) {
-          // The BSON spec doesn't allow keys with null bytes because keys are
-          // null-terminated.
-          throw new BSONError('key ' + key + ' must not contain null bytes');
+    } else if (value === null) {
+      index = serializeNull(buffer, key, value, index);
+    } else if (type === 'string') {
+      index = serializeString(buffer, key, value, index);
+    } else if (type === 'number') {
+      index = serializeNumber(buffer, key, value, index);
+    } else if (type === 'bigint') {
+      index = serializeBigInt(buffer, key, value, index);
+    } else if (type === 'boolean') {
+      index = serializeBoolean(buffer, key, value, index);
+    } else if (type === 'object' && value._bsontype == null) {
+      if (value instanceof Date || isDate(value)) {
+        index = serializeDate(buffer, key, value, index);
+      } else if (value instanceof Uint8Array || isUint8Array(value)) {
+        index = serializeBuffer(buffer, key, value, index);
+      } else if (value instanceof RegExp || isRegExp(value)) {
+        index = serializeRegExp(buffer, key, value, index);
+      } else {
+        if (path.has(value)) {
+          throw new BSONError('Cannot convert circular structure to BSON');
         }
-
-        if (checkKeys) {
-          if ('$' === key[0]) {
-            throw new BSONError('key ' + key + " must not start with '$'");
-          } else if (key.includes('.')) {
-            throw new BSONError('key ' + key + " must not contain '.'");
+        const nestedIsArray = Array.isArray(value);
+        buffer[index++] = nestedIsArray ? constants.BSON_DATA_ARRAY : constants.BSON_DATA_OBJECT;
+        index += ByteUtils.encodeUTF8Into(buffer, key, index);
+        buffer[index++] = 0x00;
+        const nestedStartIndex = index;
+        path.add(value);
+        stack.push({
+          kvPairs: toKvPairs(value),
+          serializedPairCount: 0,
+          objectSizeIndex: nestedStartIndex,
+          codeSizeIndex: null,
+          sourceObject:value,
+          isArray: nestedIsArray
+        });
+        index += 4;
+      }
+    } else if (type === 'object') {
+      if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
+        throw new BSONVersionError();
+      } else if (value._bsontype === 'ObjectId') {
+        index = serializeObjectId(buffer, key, value, index);
+      } else if (value._bsontype === 'Decimal128') {
+        index = serializeDecimal128(buffer, key, value, index);
+      } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
+        index = serializeLong(buffer, key, value, index);
+      } else if (value._bsontype === 'Double') {
+        index = serializeDouble(buffer, key, value, index);
+      } else if (value._bsontype === 'Code') {
+        const codeValue = value as Code;
+        if (codeValue.scope && typeof codeValue.scope === 'object') {
+          buffer[index++] = constants.BSON_DATA_CODE_W_SCOPE;
+          index += ByteUtils.encodeUTF8Into(buffer, key, index);
+          buffer[index++] = 0x00;
+          const codeTotalSizeIndex = index;
+          index += 4;
+          const functionString = codeValue.code;
+          const codeSize = ByteUtils.encodeUTF8Into(buffer, functionString, index + 4) + 1;
+          NumberUtils.setInt32LE(buffer, index, codeSize);
+          buffer[index + 4 + codeSize - 1] = 0;
+          index = index + codeSize + 4;
+          const scope = codeValue.scope as Document;
+          if (path.has(scope)) {
+            throw new BSONError('Cannot convert circular structure to BSON');
           }
-        }
-      }
-
-      if (value === undefined) {
-        if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
-      } else if (value === null) {
-        index = serializeNull(buffer, key, value, index);
-      } else if (type === 'string') {
-        index = serializeString(buffer, key, value, index);
-      } else if (type === 'number') {
-        index = serializeNumber(buffer, key, value, index);
-      } else if (type === 'bigint') {
-        index = serializeBigInt(buffer, key, value, index);
-      } else if (type === 'boolean') {
-        index = serializeBoolean(buffer, key, value, index);
-      } else if (type === 'object' && value._bsontype == null) {
-        if (value instanceof Date || isDate(value)) {
-          index = serializeDate(buffer, key, value, index);
-        } else if (value instanceof Uint8Array || isUint8Array(value)) {
-          index = serializeBuffer(buffer, key, value, index);
-        } else if (value instanceof RegExp || isRegExp(value)) {
-          index = serializeRegExp(buffer, key, value, index);
+          path.add(scope);
+          stack.push({
+            kvPairs: toKvPairs(scope),
+            serializedPairCount: 0,
+            objectSizeIndex: index,
+            codeSizeIndex: codeTotalSizeIndex,
+            sourceObject:scope,
+            isArray: false
+          });
+          index += 4;
         } else {
-          index = serializeObject(
-            buffer,
-            key,
-            value,
-            index,
-            checkKeys,
-            depth,
-            serializeFunctions,
-            ignoreUndefined,
-            path
-          );
+          buffer[index++] = constants.BSON_DATA_CODE;
+          index += ByteUtils.encodeUTF8Into(buffer, key, index);
+          buffer[index++] = 0x00;
+          const functionString = codeValue.code.toString();
+          const size = ByteUtils.encodeUTF8Into(buffer, functionString, index + 4) + 1;
+          NumberUtils.setInt32LE(buffer, index, size);
+          index = index + 4 + size - 1;
+          buffer[index++] = 0;
         }
-      } else if (type === 'object') {
-        if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
-          throw new BSONVersionError();
-        } else if (value._bsontype === 'ObjectId') {
-          index = serializeObjectId(buffer, key, value, index);
-        } else if (value._bsontype === 'Decimal128') {
-          index = serializeDecimal128(buffer, key, value, index);
-        } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
-          index = serializeLong(buffer, key, value, index);
-        } else if (value._bsontype === 'Double') {
-          index = serializeDouble(buffer, key, value, index);
-        } else if (value._bsontype === 'Code') {
-          index = serializeCode(
-            buffer,
-            key,
-            value,
-            index,
-            checkKeys,
-            depth,
-            serializeFunctions,
-            ignoreUndefined,
-            path
-          );
-        } else if (value._bsontype === 'Binary') {
-          index = serializeBinary(buffer, key, value, index);
-        } else if (value._bsontype === 'BSONSymbol') {
-          index = serializeSymbol(buffer, key, value, index);
-        } else if (value._bsontype === 'DBRef') {
-          index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
-        } else if (value._bsontype === 'BSONRegExp') {
-          index = serializeBSONRegExp(buffer, key, value, index);
-        } else if (value._bsontype === 'Int32') {
-          index = serializeInt32(buffer, key, value, index);
-        } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
-          index = serializeMinMax(buffer, key, value, index);
-        } else if (typeof value._bsontype !== 'undefined') {
-          throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
-        }
-      } else if (type === 'function' && serializeFunctions) {
-        index = serializeFunction(buffer, key, value, index);
+      } else if (value._bsontype === 'Binary') {
+        index = serializeBinary(buffer, key, value, index);
+      } else if (value._bsontype === 'BSONSymbol') {
+        index = serializeSymbol(buffer, key, value, index);
+      } else if (value._bsontype === 'DBRef') {
+        const dbref = value as DBRef;
+        const orderedValues: Document = Object.assign(
+          { $ref: dbref.collection },
+          dbref.oid ? { $id: dbref.oid } : null,
+          dbref.db ? { $db: dbref.db } : null,
+          dbref.fields
+        );
+        buffer[index++] = constants.BSON_DATA_OBJECT;
+        index += ByteUtils.encodeUTF8Into(buffer, key, index);
+        buffer[index++] = 0x00;
+        path.add(orderedValues);
+        stack.push({
+          kvPairs: toKvPairs(orderedValues),
+          serializedPairCount: 0,
+          objectSizeIndex: index,
+          codeSizeIndex: null,
+          sourceObject:orderedValues,
+          isArray: false
+        });
+        index += 4;
+      } else if (value._bsontype === 'BSONRegExp') {
+        index = serializeBSONRegExp(buffer, key, value, index);
+      } else if (value._bsontype === 'Int32') {
+        index = serializeInt32(buffer, key, value, index);
+      } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
+        index = serializeMinMax(buffer, key, value, index);
+      } else if (typeof value._bsontype !== 'undefined') {
+        throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
       }
-    }
-  } else {
-    if (typeof object?.toBSON === 'function') {
-      // Provided a custom serialization method
-      object = object.toBSON();
-      if (object != null && typeof object !== 'object') {
-        throw new BSONError('toBSON function did not return an object');
-      }
-    }
-
-    // Iterate over all the keys
-    for (const key of Object.keys(object)) {
-      let value = object[key];
-      // Is there an override value
-      if (typeof value?.toBSON === 'function') {
-        value = value.toBSON();
-      }
-
-      // Check the type of the value
-      const type = typeof value;
-
-      // Check the key and throw error if it's illegal
-      if (typeof key === 'string' && !ignoreKeys.has(key)) {
-        if (key.match(regexp) != null) {
-          // The BSON spec doesn't allow keys with null bytes because keys are
-          // null-terminated.
-          throw new BSONError('key ' + key + ' must not contain null bytes');
-        }
-
-        if (checkKeys) {
-          if ('$' === key[0]) {
-            throw new BSONError('key ' + key + " must not start with '$'");
-          } else if (key.includes('.')) {
-            throw new BSONError('key ' + key + " must not contain '.'");
-          }
-        }
-      }
-
-      if (value === undefined) {
-        if (ignoreUndefined === false) index = serializeNull(buffer, key, value, index);
-      } else if (value === null) {
-        index = serializeNull(buffer, key, value, index);
-      } else if (type === 'string') {
-        index = serializeString(buffer, key, value, index);
-      } else if (type === 'number') {
-        index = serializeNumber(buffer, key, value, index);
-      } else if (type === 'bigint') {
-        index = serializeBigInt(buffer, key, value, index);
-      } else if (type === 'boolean') {
-        index = serializeBoolean(buffer, key, value, index);
-      } else if (type === 'object' && value._bsontype == null) {
-        if (value instanceof Date || isDate(value)) {
-          index = serializeDate(buffer, key, value, index);
-        } else if (value instanceof Uint8Array || isUint8Array(value)) {
-          index = serializeBuffer(buffer, key, value, index);
-        } else if (value instanceof RegExp || isRegExp(value)) {
-          index = serializeRegExp(buffer, key, value, index);
-        } else {
-          index = serializeObject(
-            buffer,
-            key,
-            value,
-            index,
-            checkKeys,
-            depth,
-            serializeFunctions,
-            ignoreUndefined,
-            path
-          );
-        }
-      } else if (type === 'object') {
-        if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
-          throw new BSONVersionError();
-        } else if (value._bsontype === 'ObjectId') {
-          index = serializeObjectId(buffer, key, value, index);
-        } else if (value._bsontype === 'Decimal128') {
-          index = serializeDecimal128(buffer, key, value, index);
-        } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
-          index = serializeLong(buffer, key, value, index);
-        } else if (value._bsontype === 'Double') {
-          index = serializeDouble(buffer, key, value, index);
-        } else if (value._bsontype === 'Code') {
-          index = serializeCode(
-            buffer,
-            key,
-            value,
-            index,
-            checkKeys,
-            depth,
-            serializeFunctions,
-            ignoreUndefined,
-            path
-          );
-        } else if (value._bsontype === 'Binary') {
-          index = serializeBinary(buffer, key, value, index);
-        } else if (value._bsontype === 'BSONSymbol') {
-          index = serializeSymbol(buffer, key, value, index);
-        } else if (value._bsontype === 'DBRef') {
-          index = serializeDBRef(buffer, key, value, index, depth, serializeFunctions, path);
-        } else if (value._bsontype === 'BSONRegExp') {
-          index = serializeBSONRegExp(buffer, key, value, index);
-        } else if (value._bsontype === 'Int32') {
-          index = serializeInt32(buffer, key, value, index);
-        } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
-          index = serializeMinMax(buffer, key, value, index);
-        } else if (typeof value._bsontype !== 'undefined') {
-          throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
-        }
-      } else if (type === 'function' && serializeFunctions) {
-        index = serializeFunction(buffer, key, value, index);
-      }
+    } else if (type === 'function' && serializeFunctions) {
+      index = serializeFunction(buffer, key, value, index);
     }
   }
 
-  // Remove the path
-  path.delete(object);
-
-  // Final padding byte for object
-  buffer[index++] = 0x00;
-
-  // Final size
-  const size = index - startingIndex;
-  // Write the size of the object
-  startingIndex += NumberUtils.setInt32LE(buffer, startingIndex, size);
   return index;
 }

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -409,18 +409,23 @@ function serializeSymbol(buffer: Uint8Array, key: string, value: BSONSymbol, ind
 }
 
 interface SerializationFrame {
-  // The object we are serializing at this level of the stack. Used for circular reference detection and to avoid having to call toBSON multiple times on the same object in case of circular references.
+  // The object being serialized at this frame.
+  // Held so it can be removed from the cycle-detection path when this frame completes.
   sourceObject: Document;
-  // Whether the object we are serializing is an array, which forces the keys to be serialized as ascii strings of their index in the array
+  // Whether the object we are serializing is an array.
+  // This forces the keys to be serialized as ASCII strings of their index in the array.
   isArray: boolean;
-  // The key-value pairs of the object we are serializing.
-  // We compute this once per object to avoid having to compute it multiple times in case of circular references
+  // The key-value pairs of the object we are serializing, snapshotted at frame creation.
   kvPairs: [string, unknown][];
-  // The number of serialized kvPairs, used to keep track of where we are in the serialization process
+  // The number of serialized kvPairs.
+  // Used to keep track of where we are in the serialization process
   serializedPairCount: number;
-  // The index in the buffer where the size of the current object being serialized is stored. We will only know the size of the object once we have finished serializing it, so we keep track of where to write the size once we know it.
+  // The index in the buffer where the size of the current serialized object is stored.
+  // We will only know the size of the object once we have finished serializing it, so we keep track of where to write the size once we know it.
   objectSizeIndex: number;
-  // The index in the buffer where the size of the code with scope object is stored, used for Code with Scope serialization. We will only know the size of the code with scope object once we have finished serializing it, so we keep track of where to write the size once we know it.
+  // The index in the buffer where the size of the code with scope object is stored.
+  // Used for Code with Scope serialization.
+  // We will only know the size of the code with scope object once we have finished serializing it, so we keep track of where to write the size once we know it.
   codeSizeIndex: number | null;
 }
 
@@ -579,7 +584,7 @@ export function serializeInto(
           serializedPairCount: 0,
           objectSizeIndex: nestedStartIndex,
           codeSizeIndex: null,
-          sourceObject:value,
+          sourceObject: value,
           isArray: nestedIsArray
         });
         index += 4;
@@ -608,7 +613,7 @@ export function serializeInto(
           NumberUtils.setInt32LE(buffer, index, codeSize);
           buffer[index + 4 + codeSize - 1] = 0;
           index = index + codeSize + 4;
-          const scope = codeValue.scope as Document;
+          const scope = codeValue.scope;
           if (path.has(scope)) {
             throw new BSONError('Cannot convert circular structure to BSON');
           }
@@ -618,7 +623,7 @@ export function serializeInto(
             serializedPairCount: 0,
             objectSizeIndex: index,
             codeSizeIndex: codeTotalSizeIndex,
-            sourceObject:scope,
+            sourceObject: scope,
             isArray: false
           });
           index += 4;
@@ -653,7 +658,7 @@ export function serializeInto(
           serializedPairCount: 0,
           objectSizeIndex: index,
           codeSizeIndex: null,
-          sourceObject:orderedValues,
+          sourceObject: orderedValues,
           isArray: false
         });
         index += 4;

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -415,11 +415,9 @@ interface SerializationFrame {
   // Whether the object we are serializing is an array.
   // This forces the keys to be serialized as ASCII strings of their index in the array.
   isArray: boolean;
-  // The key-value pairs of the object we are serializing, snapshotted at frame creation.
-  kvPairs: [string, unknown][];
-  // The number of serialized kvPairs.
-  // Used to keep track of where we are in the serialization process
-  serializedPairCount: number;
+  // Lazy iterator over the key-value pairs of the object being serialized.
+  // Avoids materializing intermediate arrays for Maps and Arrays.
+  pairs: Iterator<[string, unknown]>;
   // The index in the buffer where the size of the current serialized object is stored.
   // We will only know the size of the object once we have finished serializing it, so we keep track of where to write the size once we know it.
   objectSizeIndex: number;
@@ -429,15 +427,13 @@ interface SerializationFrame {
   codeSizeIndex: number | null;
 }
 
-function toKvPairs(object: Document): [string, unknown][] {
+function* toKvPairs(object: Document): Iterator<[string, unknown]> {
   if (Array.isArray(object)) {
-    const kvPairs = new Array<[string, unknown]>(object.length);
     for (let i = 0; i < object.length; i++) {
-      kvPairs[i] = [`${i}`, object[i]];
+      yield [`${i}`, object[i]];
     }
-    return kvPairs;
   } else if (object instanceof Map || isMap(object)) {
-    return Array.from((object as Map<unknown, unknown>).entries()) as [string, unknown][];
+    yield* (object as Map<unknown, unknown>) as Iterable<[string, unknown]>;
   } else {
     let target: Document = object;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -449,11 +445,9 @@ function toKvPairs(object: Document): [string, unknown][] {
       }
     }
     const keys = Object.keys(target);
-    const kvPairs = new Array<[string, unknown]>(keys.length);
     for (let i = 0; i < keys.length; i++) {
-      kvPairs[i] = [keys[i], target[keys[i]]];
+      yield [keys[i], target[keys[i]]];
     }
-    return kvPairs;
   }
 }
 
@@ -503,8 +497,7 @@ export function serializeInto(
 
   const stack: SerializationFrame[] = [
     {
-      kvPairs: toKvPairs(object),
-      serializedPairCount: 0,
+      pairs: toKvPairs(object),
       objectSizeIndex: startingIndex,
       codeSizeIndex: null,
       sourceObject: object,
@@ -515,8 +508,9 @@ export function serializeInto(
 
   while (stack.length > 0) {
     const frame = stack[stack.length - 1];
+    const next = frame.pairs.next();
 
-    if (frame.serializedPairCount >= frame.kvPairs.length) {
+    if (next.done) {
       buffer[index++] = 0x00;
       NumberUtils.setInt32LE(buffer, frame.objectSizeIndex, index - frame.objectSizeIndex);
       if (frame.codeSizeIndex !== null) {
@@ -527,7 +521,7 @@ export function serializeInto(
       continue;
     }
 
-    const pair = frame.kvPairs[frame.serializedPairCount++];
+    const pair = next.value;
     const key = pair[0];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let value: any = pair[1];
@@ -583,8 +577,7 @@ export function serializeInto(
         const nestedStartIndex = index;
         path.add(value);
         stack.push({
-          kvPairs: toKvPairs(value),
-          serializedPairCount: 0,
+          pairs: toKvPairs(value),
           objectSizeIndex: nestedStartIndex,
           codeSizeIndex: null,
           sourceObject: value,
@@ -622,8 +615,7 @@ export function serializeInto(
           }
           path.add(scope);
           stack.push({
-            kvPairs: toKvPairs(scope),
-            serializedPairCount: 0,
+            pairs: toKvPairs(scope),
             objectSizeIndex: index,
             codeSizeIndex: codeTotalSizeIndex,
             sourceObject: scope,
@@ -656,8 +648,7 @@ export function serializeInto(
         buffer[index++] = 0x00;
         path.add(orderedValues);
         stack.push({
-          kvPairs: toKvPairs(orderedValues),
-          serializedPairCount: 0,
+          pairs: toKvPairs(orderedValues),
           objectSizeIndex: index,
           codeSizeIndex: null,
           sourceObject: orderedValues,

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -429,9 +429,7 @@ interface SerializationFrame {
 
 function* toKvPairs(object: Document): Iterator<[string, unknown]> {
   if (Array.isArray(object)) {
-    for (let i = 0; i < object.length; i++) {
-      yield [`${i}`, object[i]];
-    }
+    yield* Object.entries(object);
   } else if (object instanceof Map || isMap(object)) {
     yield* object as Map<unknown, unknown> as Iterable<[string, unknown]>;
   } else {
@@ -444,10 +442,7 @@ function* toKvPairs(object: Document): Iterator<[string, unknown]> {
         throw new BSONError('toBSON function did not return an object');
       }
     }
-    const keys = Object.keys(target);
-    for (let i = 0; i < keys.length; i++) {
-      yield [keys[i], target[keys[i]]];
-    }
+    yield* Object.entries(target);
   }
 }
 

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -440,7 +440,9 @@ function toKvPairs(object: Document): [string, unknown][] {
     return Array.from((object as Map<unknown, unknown>).entries()) as [string, unknown][];
   } else {
     let target: Document = object;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (typeof (target as any)?.toBSON === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       target = (target as any).toBSON() as Document;
       if (target != null && typeof target !== 'object') {
         throw new BSONError('toBSON function did not return an object');
@@ -527,6 +529,7 @@ export function serializeInto(
 
     const pair = frame.kvPairs[frame.serializedPairCount++];
     const key = pair[0];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let value: any = pair[1];
 
     if (typeof value?.toBSON === 'function') {

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -433,7 +433,7 @@ function* toKvPairs(object: Document): Iterator<[string, unknown]> {
       yield [`${i}`, object[i]];
     }
   } else if (object instanceof Map || isMap(object)) {
-    yield* (object as Map<unknown, unknown>) as Iterable<[string, unknown]>;
+    yield* object as Map<unknown, unknown> as Iterable<[string, unknown]>;
   } else {
     let target: Document = object;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/node/parser/calculate_size.test.ts
+++ b/test/node/parser/calculate_size.test.ts
@@ -1,14 +1,7 @@
 import * as BSON from '../../register-bson';
 import { expect } from 'chai';
 import { BSONVersionError } from '../../register-bson';
-
-function buildDeeplyNestedObject(depth: number): Record<string, unknown> {
-  let inner: Record<string, unknown> = {};
-  for (let i = 0; i < depth; i++) {
-    inner = { a: inner };
-  }
-  return inner;
-}
+import { buildDeeplyNestedObject } from '../tools/utils';
 
 describe('calculateSize()', () => {
   it('should only enumerate own property keys from input objects', () => {

--- a/test/node/parser/calculate_size.test.ts
+++ b/test/node/parser/calculate_size.test.ts
@@ -2,6 +2,14 @@ import * as BSON from '../../register-bson';
 import { expect } from 'chai';
 import { BSONVersionError } from '../../register-bson';
 
+function buildDeeplyNestedObject(depth: number): Record<string, unknown> {
+  let inner: Record<string, unknown> = {};
+  for (let i = 0; i < depth; i++) {
+    inner = { a: inner };
+  }
+  return inner;
+}
+
 describe('calculateSize()', () => {
   it('should only enumerate own property keys from input objects', () => {
     const input = { a: 1 };
@@ -23,6 +31,13 @@ describe('calculateSize()', () => {
         a: { _bsontype: 'Int32', value: 2 }
       })
     ).to.throw(BSONVersionError, /Unsupported BSON version/i);
+  });
+
+  describe('when calculating size of deeply nested documents', () => {
+    it('can calculate the size of a document with 20,000 nesting levels without a stack overflow', () => {
+      const size = BSON.calculateObjectSize(buildDeeplyNestedObject(20_000));
+      expect(size).to.be.greaterThan(0);
+    });
   });
 
   describe('when given a bigint value with a single character key', function () {

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -270,21 +270,30 @@ describe('deserializer()', () => {
       // byte 7: [outer size(4)] [type(1)] [key 'a\0'(2)] → array size field
       const arraySizeOffset = 7;
       valid.writeInt32LE(0, arraySizeOffset);
-      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'bad embedded array length in bson');
+      expect(() => BSON.deserialize(valid)).to.throw(
+        BSON.BSONError,
+        'bad embedded array length in bson'
+      );
     });
 
     it('throws "bad embedded array length in bson" for a nested array with a negative size', () => {
       const valid = Buffer.from(BSON.serialize({ a: [new BSON.Int32(1)] }));
       const arraySizeOffset = 7;
       valid.writeInt32LE(-1, arraySizeOffset);
-      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'bad embedded array length in bson');
+      expect(() => BSON.deserialize(valid)).to.throw(
+        BSON.BSONError,
+        'bad embedded array length in bson'
+      );
     });
 
     it('throws "bad embedded array length in bson" for a nested array whose size exceeds the buffer', () => {
       const valid = Buffer.from(BSON.serialize({ a: [new BSON.Int32(1)] }));
       const arraySizeOffset = 7;
       valid.writeInt32LE(valid.length + 1, arraySizeOffset);
-      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'bad embedded array length in bson');
+      expect(() => BSON.deserialize(valid)).to.throw(
+        BSON.BSONError,
+        'bad embedded array length in bson'
+      );
     });
   });
 

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -4,6 +4,55 @@ import { bufferFromHexArray, int32LEToHex } from '../tools/utils';
 import { utf8WebPlatformSpecTests } from '../data/utf8_wpt_error_cases';
 
 describe('deserializer()', () => {
+  describe('basic deserialization', () => {
+    it('deserializes a simple document', () => {
+      const bytes = BSON.serialize({ hello: 'world' });
+      const result = BSON.deserialize(bytes);
+      expect(result).to.deep.equal({ hello: 'world' });
+    });
+
+    it('can deserialize a document with an array of objects', () => {
+      const bytes = BSON.serialize({ a: [{ b: 1 }, { c: 2 }] });
+      const result = BSON.deserialize(bytes);
+      expect(result).to.deep.equal({ a: [{ b: 1 }, { c: 2 }] });
+    });
+
+    it('converts a root-level DBRef-shaped document to a DBRef instance', () => {
+      const oid = new BSON.ObjectId();
+      const bytes = BSON.serialize({ $ref: 'ns', $id: oid, $db: 'db' });
+      const result = BSON.deserialize(bytes);
+      expect(result).to.have.property('_bsontype', 'DBRef');
+      expect(result).to.have.property('collection', 'ns');
+      expect(result).to.have.property('db', 'db');
+      expect((result as BSON.DBRef).oid.toHexString()).to.equal(oid.toHexString());
+    });
+
+    it('can deserialize a nested document', () => {
+      // Build a valid BSON buffer iteratively to avoid hitting the serializer's own recursion limit.
+      // Each level wraps the previous in { a: <nested> }.
+      let inner = Buffer.from([0x05, 0x00, 0x00, 0x00, 0x00]); // innermost: empty doc {}
+
+      for (let i = 0; i < 1; i++) {
+        // doc layout: [int32 size][0x03 type]['a\0' key][nested doc][0x00 terminator]
+        const docSize = 4 + 1 + 2 + inner.length + 1;
+        const doc = Buffer.allocUnsafe(docSize);
+        let offset = 0;
+        doc.writeInt32LE(docSize, 0);
+        offset += 4;
+        doc[offset++] = 0x03; // BSON_DATA_OBJECT
+        doc[offset++] = 0x61; // 'a'
+        doc[offset++] = 0x00; // key null terminator
+        inner.copy(doc, offset);
+        offset += inner.length;
+        doc[offset] = 0x00; // document null terminator
+        inner = doc;
+      }
+
+      const result = BSON.deserialize(inner);
+      expect(result).to.deep.equal({ a: {} });
+    });
+  });
+
   describe('when the fieldsAsRaw options is present and has a value that corresponds to a key in the object', () => {
     it('ignores non-own properties set on the options object', () => {
       const bytes = BSON.serialize({ someKey: [1] });
@@ -57,6 +106,32 @@ describe('deserializer()', () => {
         'function iLoveJavascript() {}'
       );
       expect(resultCodeWithScope).to.have.deep.nested.property('a.scope', { b: true });
+    });
+  });
+
+  describe('when deserializing deeply nested documents', () => {
+    it('can deserialize a document with 20,000 nesting levels', () => {
+      // Build a valid BSON buffer iteratively to avoid hitting the serializer's own recursion limit.
+      // Each level wraps the previous in { a: <nested> }.
+      let inner = Buffer.from([0x05, 0x00, 0x00, 0x00, 0x00]); // innermost: empty doc {}
+
+      for (let i = 0; i < 20_000; i++) {
+        // doc layout: [int32 size][0x03 type]['a\0' key][nested doc][0x00 terminator]
+        const docSize = 4 + 1 + 2 + inner.length + 1;
+        const doc = Buffer.allocUnsafe(docSize);
+        let offset = 0;
+        doc.writeInt32LE(docSize, 0);
+        offset += 4;
+        doc[offset++] = 0x03; // BSON_DATA_OBJECT
+        doc[offset++] = 0x61; // 'a'
+        doc[offset++] = 0x00; // key null terminator
+        inner.copy(doc, offset);
+        offset += inner.length;
+        doc[offset] = 0x00; // document null terminator
+        inner = doc;
+      }
+
+      expect(() => BSON.deserialize(inner)).to.not.throw();
     });
   });
 

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -26,6 +26,25 @@ describe('deserializer()', () => {
       expect(result).to.have.property('db', 'db');
       expect((result as BSON.DBRef).oid.toHexString()).to.equal(oid.toHexString());
     });
+
+    it('preserves extra fields in DBRef.fields and excludes $ref/$id/$db from them', () => {
+      const oid = new BSON.ObjectId();
+      const bytes = BSON.serialize({ $ref: 'ns', $id: oid, $db: 'db', extra: 'value', num: 42 });
+      const result = BSON.deserialize(bytes) as BSON.DBRef;
+      expect(result).to.have.property('_bsontype', 'DBRef');
+      expect(result.fields).to.deep.equal({ extra: 'value', num: 42 });
+      expect(result.fields).to.not.have.property('$ref');
+      expect(result.fields).to.not.have.property('$id');
+      expect(result.fields).to.not.have.property('$db');
+    });
+
+    it('produces an empty fields object when a DBRef-shaped document has no extra fields', () => {
+      const oid = new BSON.ObjectId();
+      const bytes = BSON.serialize({ $ref: 'ns', $id: oid, $db: 'db' });
+      const result = BSON.deserialize(bytes) as BSON.DBRef;
+      expect(result).to.have.property('_bsontype', 'DBRef');
+      expect(result.fields).to.deep.equal({});
+    });
   });
 
   describe('when the fieldsAsRaw options is present and has a value that corresponds to a key in the object', () => {
@@ -107,6 +126,81 @@ describe('deserializer()', () => {
       }
 
       expect(() => BSON.deserialize(inner)).to.not.throw();
+    });
+
+    it('can deserialize a document with 20,000 levels of nested arrays', () => {
+      // Same technique as the object nesting test but with 0x04 (array) type and '0' index keys.
+      let inner = Buffer.from([0x05, 0x00, 0x00, 0x00, 0x00]); // innermost: empty array []
+
+      for (let i = 0; i < 20_000; i++) {
+        // array doc layout: [int32 size][0x04 type]['0\0' key][nested array][0x00 terminator]
+        const docSize = 4 + 1 + 2 + inner.length + 1;
+        const doc = Buffer.allocUnsafe(docSize);
+        let offset = 0;
+        doc.writeInt32LE(docSize, 0);
+        offset += 4;
+        doc[offset++] = 0x04; // BSON_DATA_ARRAY
+        doc[offset++] = 0x30; // '0'
+        doc[offset++] = 0x00; // key null terminator
+        inner.copy(doc, offset);
+        offset += inner.length;
+        doc[offset] = 0x00; // document null terminator
+        inner = doc;
+      }
+
+      expect(() => BSON.deserialize(inner)).to.not.throw();
+    });
+
+    it('can deserialize a code-with-scope whose scope is 20,000 levels deep', () => {
+      // Build a deeply nested scope document (same technique as the object nesting test).
+      let scope = Buffer.from([0x05, 0x00, 0x00, 0x00, 0x00]); // innermost: empty doc {}
+      for (let i = 0; i < 20_000; i++) {
+        const docSize = 4 + 1 + 2 + scope.length + 1;
+        const doc = Buffer.allocUnsafe(docSize);
+        let offset = 0;
+        doc.writeInt32LE(docSize, 0);
+        offset += 4;
+        doc[offset++] = 0x03; // BSON_DATA_OBJECT
+        doc[offset++] = 0x61; // 'a'
+        doc[offset++] = 0x00;
+        scope.copy(doc, offset);
+        offset += scope.length;
+        doc[offset] = 0x00;
+        scope = doc;
+      }
+
+      // Wrap the scope in a code-with-scope element at the root.
+      // code-with-scope value layout (BSON spec):
+      //   [int32 total_size][int32 string_size][string_bytes][0x00][scope_document]
+      //   total_size = 4 (total_size field) + 4 (string_size field) + string_size + scope.length
+      const stringSize = 1; // empty string: just the null terminator
+      const cwsTotalSize = 4 + 4 + stringSize + scope.length;
+      // outer doc: [int32 size][0x0F]['a\0'][cws bytes][0x00 terminator]
+      const docSize = 4 + 1 + 2 + cwsTotalSize + 1;
+      const doc = Buffer.allocUnsafe(docSize);
+      let offset = 0;
+      doc.writeInt32LE(docSize, offset); offset += 4;
+      doc[offset++] = 0x0f; // BSON_DATA_CODE_W_SCOPE
+      doc[offset++] = 0x61; // 'a'
+      doc[offset++] = 0x00;
+      doc.writeInt32LE(cwsTotalSize, offset); offset += 4;
+      doc.writeInt32LE(stringSize, offset); offset += 4;
+      doc[offset++] = 0x00; // empty function string null terminator
+      scope.copy(doc, offset); offset += scope.length;
+      doc[offset] = 0x00; // document null terminator
+
+      expect(() => BSON.deserialize(doc)).to.not.throw();
+    });
+
+    it('round-trips a deeply nested document without data loss', () => {
+      // Use moderate depth so BSON.serialize can handle it, while verifying the iterative
+      // deserializer reconstructs the structure correctly (not just "doesn't throw").
+      let obj: Record<string, unknown> = { leaf: 'value' };
+      for (let i = 0; i < 100; i++) {
+        obj = { a: obj };
+      }
+      const result = BSON.deserialize(BSON.serialize(obj));
+      expect(result).to.deep.equal(obj);
     });
   });
 

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -61,6 +61,28 @@ describe('deserializer()', () => {
     });
   });
 
+  describe('Code with Scope', () => {
+    it('round-trips a simple scope', () => {
+      const original = new BSON.Code('function() {}', { x: 1, y: 'hello' });
+      const { code } = BSON.deserialize(BSON.serialize({ code: original }));
+      expect(code).to.have.property('_bsontype', 'Code');
+      expect(code.scope).to.deep.equal({ x: 1, y: 'hello' });
+    });
+
+    it('keeps a DBRef-shaped scope as a plain object', () => {
+      const oid = new BSON.ObjectId();
+      const scope = { $ref: 'col', $id: oid, $db: 'db' };
+      const original = new BSON.Code('function () {}', scope);
+      const { code } = BSON.deserialize(BSON.serialize({ code: original }));
+      expect(code).to.have.property('_bsontype', 'Code');
+      expect(code.scope).to.not.have.property('_bsontype');
+      expect(code.scope).to.have.property('$ref', 'col');
+      expect(code.scope).to.have.property('$db', 'db');
+      expect(code.scope.$id).to.be.instanceOf(BSON.ObjectId);
+      expect(code.scope.$id.toHexString()).to.equal(oid.toHexString());
+    });
+  });
+
   describe('when passing an evalFunctions option', () => {
     const codeTypeBSON = bufferFromHexArray([
       '0D', // javascript type
@@ -217,6 +239,52 @@ describe('deserializer()', () => {
       const arraySizeOffset = 7;
       valid.writeInt32LE(valid.readInt32LE(arraySizeOffset) + 1, arraySizeOffset);
       expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'corrupted array bson');
+    });
+
+    it('throws "corrupted array bson" for an array nested inside a nested object', () => {
+      // Regression: before the fix, deeply nested arrays threw 'Bad BSON Document: object not properly terminated'
+      // because the frame-level mismatch check did not distinguish array frames from object frames.
+      // { a: { b: [1] } } — the array is two levels deep, so two frames are on the stack when the
+      // mismatch is detected.
+      // Layout: [root size(4)][0x03 type(1)]['a\0'(2)][obj size(4)][0x04 type(1)]['b\0'(2)][arr size(4)...]
+      //          ^0                                                                           ^14
+      const valid = Buffer.from(BSON.serialize({ a: { b: [new BSON.Int32(1)] } }));
+      const innerArraySizeOffset = 14;
+      valid.writeInt32LE(valid.readInt32LE(innerArraySizeOffset) + 1, innerArraySizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'corrupted array bson');
+    });
+
+    it('throws "corrupted array bson" for an array nested inside another array', () => {
+      // Regression: same fix as above — when the inner array of { a: [[1]] } has a wrong size,
+      // the parser must still throw 'corrupted array bson', not the generic object-terminator error.
+      // Layout: [root size(4)][0x04 type(1)]['a\0'(2)][outer arr size(4)][0x04 type(1)]['0\0'(2)][inner arr size(4)...]
+      //          ^0                                                                                 ^14
+      const valid = Buffer.from(BSON.serialize({ a: [[new BSON.Int32(1)]] }));
+      const innerArraySizeOffset = 14;
+      valid.writeInt32LE(valid.readInt32LE(innerArraySizeOffset) + 1, innerArraySizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'corrupted array bson');
+    });
+
+    it('throws "bad embedded array length in bson" for a nested array with size zero', () => {
+      const valid = Buffer.from(BSON.serialize({ a: [new BSON.Int32(1)] }));
+      // byte 7: [outer size(4)] [type(1)] [key 'a\0'(2)] → array size field
+      const arraySizeOffset = 7;
+      valid.writeInt32LE(0, arraySizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'bad embedded array length in bson');
+    });
+
+    it('throws "bad embedded array length in bson" for a nested array with a negative size', () => {
+      const valid = Buffer.from(BSON.serialize({ a: [new BSON.Int32(1)] }));
+      const arraySizeOffset = 7;
+      valid.writeInt32LE(-1, arraySizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'bad embedded array length in bson');
+    });
+
+    it('throws "bad embedded array length in bson" for a nested array whose size exceeds the buffer', () => {
+      const valid = Buffer.from(BSON.serialize({ a: [new BSON.Int32(1)] }));
+      const arraySizeOffset = 7;
+      valid.writeInt32LE(valid.length + 1, arraySizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'bad embedded array length in bson');
     });
   });
 

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -26,31 +26,6 @@ describe('deserializer()', () => {
       expect(result).to.have.property('db', 'db');
       expect((result as BSON.DBRef).oid.toHexString()).to.equal(oid.toHexString());
     });
-
-    it('can deserialize a nested document', () => {
-      // Build a valid BSON buffer iteratively to avoid hitting the serializer's own recursion limit.
-      // Each level wraps the previous in { a: <nested> }.
-      let inner = Buffer.from([0x05, 0x00, 0x00, 0x00, 0x00]); // innermost: empty doc {}
-
-      for (let i = 0; i < 1; i++) {
-        // doc layout: [int32 size][0x03 type]['a\0' key][nested doc][0x00 terminator]
-        const docSize = 4 + 1 + 2 + inner.length + 1;
-        const doc = Buffer.allocUnsafe(docSize);
-        let offset = 0;
-        doc.writeInt32LE(docSize, 0);
-        offset += 4;
-        doc[offset++] = 0x03; // BSON_DATA_OBJECT
-        doc[offset++] = 0x61; // 'a'
-        doc[offset++] = 0x00; // key null terminator
-        inner.copy(doc, offset);
-        offset += inner.length;
-        doc[offset] = 0x00; // document null terminator
-        inner = doc;
-      }
-
-      const result = BSON.deserialize(inner);
-      expect(result).to.deep.equal({ a: {} });
-    });
   });
 
   describe('when the fieldsAsRaw options is present and has a value that corresponds to a key in the object', () => {

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -110,6 +110,18 @@ describe('deserializer()', () => {
     });
   });
 
+  describe('corrupted BSON error messages', () => {
+    it('throws "corrupted array bson" for a nested array with a wrong size field', () => {
+      // Serialize a valid { a: [1] } document, then corrupt the nested array's size field
+      // so the terminator is reached before the declared end of the array.
+      const valid = Buffer.from(BSON.serialize({ a: [new BSON.Int32(1)] }));
+      // The array size field is at byte 7: [outer size(4)] [type(1)] [key 'a\0'(2)] [array size(4)...]
+      const arraySizeOffset = 7;
+      valid.writeInt32LE(valid.readInt32LE(arraySizeOffset) + 1, arraySizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(BSON.BSONError, 'corrupted array bson');
+    });
+  });
+
   describe('utf8 validation', () => {
     for (const test of utf8WebPlatformSpecTests) {
       const inputStringSize = int32LEToHex(test.input.length + 1); // int32 size of string

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -179,14 +179,18 @@ describe('deserializer()', () => {
       const docSize = 4 + 1 + 2 + cwsTotalSize + 1;
       const doc = Buffer.allocUnsafe(docSize);
       let offset = 0;
-      doc.writeInt32LE(docSize, offset); offset += 4;
+      doc.writeInt32LE(docSize, offset);
+      offset += 4;
       doc[offset++] = 0x0f; // BSON_DATA_CODE_W_SCOPE
       doc[offset++] = 0x61; // 'a'
       doc[offset++] = 0x00;
-      doc.writeInt32LE(cwsTotalSize, offset); offset += 4;
-      doc.writeInt32LE(stringSize, offset); offset += 4;
+      doc.writeInt32LE(cwsTotalSize, offset);
+      offset += 4;
+      doc.writeInt32LE(stringSize, offset);
+      offset += 4;
       doc[offset++] = 0x00; // empty function string null terminator
-      scope.copy(doc, offset); offset += scope.length;
+      scope.copy(doc, offset);
+      offset += scope.length;
       doc[offset] = 0x00; // document null terminator
 
       expect(() => BSON.deserialize(doc)).to.not.throw();

--- a/test/node/parser/serializer.test.ts
+++ b/test/node/parser/serializer.test.ts
@@ -1,23 +1,11 @@
 import * as BSON from '../../register-bson';
-import { bufferFromHexArray } from '../tools/utils';
+import {
+  bufferFromHexArray,
+  buildDeeplyNestedObject,
+  buildDeeplyNestedArray
+} from '../tools/utils';
 import { expect } from 'chai';
 import { BSONVersionError } from '../../register-bson';
-
-function buildDeeplyNestedObject(depth: number): Record<string, unknown> {
-  let inner: Record<string, unknown> = {};
-  for (let i = 0; i < depth; i++) {
-    inner = { a: inner };
-  }
-  return inner;
-}
-
-function buildDeeplyNestedArray(depth: number): unknown[] {
-  let inner: unknown[] = [];
-  for (let i = 0; i < depth; i++) {
-    inner = [inner];
-  }
-  return inner;
-}
 
 describe('serialize()', () => {
   it('should only enumerate own property keys from input objects', () => {

--- a/test/node/parser/serializer.test.ts
+++ b/test/node/parser/serializer.test.ts
@@ -3,6 +3,22 @@ import { bufferFromHexArray } from '../tools/utils';
 import { expect } from 'chai';
 import { BSONVersionError } from '../../register-bson';
 
+function buildDeeplyNestedObject(depth: number): Record<string, unknown> {
+  let inner: Record<string, unknown> = {};
+  for (let i = 0; i < depth; i++) {
+    inner = { a: inner };
+  }
+  return inner;
+}
+
+function buildDeeplyNestedArray(depth: number): unknown[] {
+  let inner: unknown[] = [];
+  for (let i = 0; i < depth; i++) {
+    inner = [inner];
+  }
+  return inner;
+}
+
 describe('serialize()', () => {
   it('should only enumerate own property keys from input objects', () => {
     const input = { a: 1 };
@@ -36,6 +52,42 @@ describe('serialize()', () => {
     expect(emptyDocumentUndef).to.deep.equal(nestedNull);
     const emptyDocumentNull = BSON.serialize({ a: null });
     expect(emptyDocumentNull).to.deep.equal(nestedNull);
+  });
+
+  describe('when serializing deeply nested documents', () => {
+    it('can serialize a document with 20,000 nesting levels without a stack overflow', () => {
+      // Calling serialize directly: if it throws, mocha fails the test.
+      // Avoids expect().to.not.throw() which is silently swallowed by the register-bson chai plugin.
+      // Use byteLength (not instanceof) — instanceof fails across vm.createContext in WEB mode.
+      const result = BSON.serialize(buildDeeplyNestedObject(20_000));
+      expect(result.byteLength).to.be.greaterThan(0);
+    });
+
+    it('produces valid BSON after deserializing and re-serializing a deeply nested document', () => {
+      // Build the BSON buffer the same iterative way the deserializer test does,
+      // bypassing the serializer's own recursion limit to get a deeply nested BSON buffer.
+      let inner = Buffer.from([0x05, 0x00, 0x00, 0x00, 0x00]); // empty doc {}
+      for (let i = 0; i < 20_000; i++) {
+        const docSize = 4 + 1 + 2 + inner.length + 1;
+        const doc = Buffer.allocUnsafe(docSize);
+        let offset = 0;
+        doc.writeInt32LE(docSize, 0); offset += 4;
+        doc[offset++] = 0x03; // BSON_DATA_OBJECT
+        doc[offset++] = 0x61; // 'a'
+        doc[offset++] = 0x00;
+        inner.copy(doc, offset); offset += inner.length;
+        doc[offset] = 0x00;
+        inner = doc;
+      }
+      const obj = BSON.deserialize(inner);
+      const result = BSON.serialize(obj);
+      expect(result.byteLength).to.be.greaterThan(0);
+    });
+
+    it('can serialize a document containing a deeply nested array without a stack overflow', () => {
+      const result = BSON.serialize({ a: buildDeeplyNestedArray(20_000) });
+      expect(result.byteLength).to.be.greaterThan(0);
+    });
   });
 
   describe('validates input types', () => {

--- a/test/node/parser/serializer.test.ts
+++ b/test/node/parser/serializer.test.ts
@@ -71,11 +71,13 @@ describe('serialize()', () => {
         const docSize = 4 + 1 + 2 + inner.length + 1;
         const doc = Buffer.allocUnsafe(docSize);
         let offset = 0;
-        doc.writeInt32LE(docSize, 0); offset += 4;
+        doc.writeInt32LE(docSize, 0);
+        offset += 4;
         doc[offset++] = 0x03; // BSON_DATA_OBJECT
         doc[offset++] = 0x61; // 'a'
         doc[offset++] = 0x00;
-        inner.copy(doc, offset); offset += inner.length;
+        inner.copy(doc, offset);
+        offset += inner.length;
         doc[offset] = 0x00;
         inner = doc;
       }

--- a/test/node/parser/serializer.test.ts
+++ b/test/node/parser/serializer.test.ts
@@ -92,6 +92,20 @@ describe('serialize()', () => {
     });
   });
 
+  describe('DBRef serialization consistency with calculateObjectSize', () => {
+    for (const [label, db] of [
+      ['empty string db', ''],
+      ['defined db', 'mydb'],
+      ['undefined db', undefined]
+    ] as const) {
+      it(`calculateObjectSize matches serialize byte count for DBRef with ${label}`, () => {
+        const dbref = new BSON.DBRef('users', new BSON.ObjectId(), db);
+        const doc = { ref: dbref };
+        expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+      });
+    }
+  });
+
   describe('validates input types', () => {
     it('does not permit arrays as the root input', () => {
       expect(() => BSON.serialize([])).to.throw(/does not support an array/);

--- a/test/node/tools/utils.js
+++ b/test/node/tools/utils.js
@@ -218,3 +218,19 @@ module.exports.sorted = (iterable, how) => {
   items.sort(how);
   return items;
 };
+
+module.exports.buildDeeplyNestedObject = function (depth) {
+  let inner = {};
+  for (let i = 0; i < depth; i++) {
+    inner = { a: inner };
+  }
+  return inner;
+};
+
+module.exports.buildDeeplyNestedArray = function (depth) {
+  let inner = [];
+  for (let i = 0; i < depth; i++) {
+    inner = [inner];
+  }
+  return inner;
+};


### PR DESCRIPTION
### Description

#### Summary of Changes

Rewrite `deserialize` method so it's no longer recursive.

The AC Neal wrote is pretty succinct:
> Replace recursive deserializeObject() with an iterative implementation using an explicit stack (array of frames with push/pop)
> Each stack frame holds the document being built, current buffer position, size, options, and a continuation describing what to do when the child completes (object assignment, array assignment + terminator check, or code-with-scope assembly)

So the new approach is to parse everything in a single pass, but when we are faced with nested objects, we change where the deserialized values are placed:
1. if there are no nested objects, the while-loop populates a single document with all of the fields
2. if there are nested objects, the while-loop parses their contents and puts the properties into a nested document, which itself is then added to the "original" document (which can be either the root object, or the preceding container object) when we get to the last index the current frame is expected to parse

Once I wrote the `deserialize` method, I used Claude to make similar changes to `serializeInto` (the frame stack approach is identical), `internalCalculateObjectSize`, which we labeled as stretch goals for this ticket. Claude's code was updated, modified, and commented by me.

EJSON has not been updated. EJSON is more involved and will be completed later. We have created a follow-up JIRA ticket for that: https://jira.mongodb.org/browse/NODE-7595

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

Latest `run-spec-benchmarks` run: https://spruce.corp.mongodb.com/task/node_bson_perf_run_spec_benchmarks_patch_ba29d33ff0ed5ba6fc63e598fe8b7e7879e4753f_6a10d1d207c6d40007b93b59_26_05_22_21_59_47/trend-charts?execution=0

<img width="2233" height="953" alt="Screenshot 2026-05-22 at 3 07 08 PM" src="https://github.com/user-attachments/assets/baf11adf-6fd9-4c7a-a703-873d2a124d39" />

zscore mostly went down, and even the downward move is within the +-5% of last time

#### What is the motivation for this change?

Avoid stack overflow when parsing heavily-nested content.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### `BSON` operations no longer throw on deeply nested documents

Core serialization and deserialization function (`serialize`, `deserialize`, `calculateObjectSize`) have been rewritten as iterative algorithms, so a sufficiently-nested document will no longer exhaust the call stack.

#### Behavior change: Code with Scope scopes are no longer promoted to DBRef

As a side effect of the rewrite, a `Code with Scope` scope that happens to carry `$ref`, `$id`, and `$db` keys is no longer promoted to a DBRef instance. The scope is returned as a plain object, which is the correct behavior: a scope represents JavaScript variable bindings, not a document reference.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
