### PR TITLE
feat(NODE-7069): deprecate Long members inapplicable to Timestamp

### DIFF
--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -312,7 +312,7 @@ export class Timestamp extends LongWithoutOverridesClass {
   /** @deprecated Not applicable to Timestamp; use `.t` instead. */
   declare high: Long['high'];
 
-  /** @deprecated Not applicable to Timestamp. Use `_bsontype === 'Timestamp'` to identify a Timestamp. */
+  /** @deprecated Not applicable to Timestamp. Use `bsontype === 'Timestamp'` to identify a Timestamp. */
   declare __isLong__: Long['__isLong__'];
   /** @deprecated Not applicable to Timestamp. */
   declare getNumBitsAbs: Long['getNumBitsAbs'];

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -27,6 +27,7 @@ export type TimestampOverrides =
 type TimestampKept =
   | 'toBigInt'
   | 'toString'
+  | 'compare'
   | 'equals'
   | 'eq'
   | 'notEquals'
@@ -310,8 +311,6 @@ export class Timestamp extends LongWithoutOverridesClass {
   /** @deprecated Not applicable to Timestamp; use `.t` instead. */
   declare high: Long['high'];
 
-  /** @deprecated Use `.equals()`, `.lessThan()`, or `.greaterThan()` for comparisons. */
-  declare compare: Long['compare'];
   /** @deprecated Use `.equals()`, `.lessThan()`, or `.greaterThan()` for comparisons. */
   declare comp: Long['comp'];
   /** @deprecated Compare `.t` and `.i` against `0` explicitly. */

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -41,11 +41,7 @@ type TimestampKept =
   | 'gt'
   | 'greaterThanOrEqual'
   | 'gte'
-  | 'ge'
-  | 'compare'
-  | 'comp'
-  | 'isZero'
-  | 'eqz';
+  | 'ge';
 
 /** @public */
 export type LongWithoutOverrides = new (
@@ -310,6 +306,15 @@ export class Timestamp extends LongWithoutOverridesClass {
   declare low: Long['low'];
   /** @deprecated Not applicable to Timestamp; use `.t` instead. */
   declare high: Long['high'];
+
+  /** @deprecated Use `.equals()`, `.lessThan()`, or `.greaterThan()` for comparisons. */
+  declare compare: Long['compare'];
+  /** @deprecated Use `.equals()`, `.lessThan()`, or `.greaterThan()` for comparisons. */
+  declare comp: Long['comp'];
+  /** @deprecated Compare `.t` and `.i` against `0` explicitly. */
+  declare isZero: Long['isZero'];
+  /** @deprecated Compare `.t` and `.i` against `0` explicitly. */
+  declare eqz: Long['eqz'];
 
   /** @deprecated Not applicable to Timestamp. Use `bsontype === 'Timestamp'` to identify a Timestamp. */
   declare __isLong__: Long['__isLong__'];

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -25,8 +25,6 @@ export type TimestampOverrides =
  * the public type — preventing accidental behavioral bleed-through.
  */
 type TimestampKept =
-  | 'high'
-  | 'low'
   | 'toString'
   | 'equals'
   | 'eq'
@@ -309,6 +307,11 @@ export class Timestamp extends LongWithoutOverridesClass {
   declare getLowBits: Long['getLowBits'];
   /** @deprecated Not applicable to Timestamp; use `.i` for the increment ordinal. */
   declare getLowBitsUnsigned: Long['getLowBitsUnsigned'];
+
+  /** @deprecated Not applicable to Timestamp; use `.i` instead. */
+  declare low: Long['low'];
+  /** @deprecated Not applicable to Timestamp; use `.t` instead. */
+  declare high: Long['high'];
 
   /** @deprecated Not applicable to Timestamp. Use `_bsontype === 'Timestamp'` to identify a Timestamp. */
   declare __isLong__: Long['__isLong__'];

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -17,7 +17,7 @@ export type TimestampOverrides =
 
 /**
  * @public
- * 
+ *
  * Inherited `Long` members surfaced on `Timestamp`.
  * When `Long` gains a new member: add it here if it should pass through, or
  * add a `@deprecated declare` line on the `Timestamp` class if it should be

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -16,7 +16,7 @@ export type TimestampOverrides =
   | typeof bsonType;
 
 /**
- * @internal
+ * @public
  * 
  * Inherited `Long` members surfaced on `Timestamp`.
  * When `Long` gains a new member: add it here if it should pass through, or

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -77,6 +77,9 @@ export class Timestamp extends LongWithoutOverridesClass {
     return 'Timestamp';
   }
 
+  /**
+   * @deprecated Use `Long.MAX_UNSIGNED_VALUE` instead.
+   */
   static readonly MAX_VALUE = Long.MAX_UNSIGNED_VALUE;
 
   /**

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -25,6 +25,7 @@ export type TimestampOverrides =
  * the public type — preventing accidental behavioral bleed-through.
  */
 type TimestampKept =
+  | 'toBigInt'
   | 'toString'
   | 'equals'
   | 'eq'
@@ -288,8 +289,6 @@ export class Timestamp extends LongWithoutOverridesClass {
   declare toInt: Long['toInt'];
   /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
   declare toNumber: Long['toNumber'];
-  /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
-  declare toBigInt: Long['toBigInt'];
   /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
   declare toBytes: Long['toBytes'];
   /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -183,6 +183,7 @@ export class Timestamp extends LongWithoutOverridesClass {
 
   /**
    * Returns a Timestamp from the given string, optionally using the given radix.
+   * @deprecated Interprets `str` as a uint64, splitting it across (t, i); the result rarely matches user intent. Use `new Timestamp({ t, i })` or `Timestamp.fromBits(lowBits, highBits)` for explicit construction.
    *
    * @param str - the textual representation of the Timestamp.
    * @param optRadix - the radix in which the text is written.

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -279,7 +279,7 @@ export class Timestamp extends LongWithoutOverridesClass {
   declare toUnsigned: Long['toUnsigned'];
   /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (is always false). */
   declare isNegative: Long['isNegative'];
-  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (is always true except for the zero Timestamp). */
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (is always true). */
   declare isPositive: Long['isPositive'];
   /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (is always true). */
   declare unsigned: Long['unsigned'];
@@ -311,14 +311,14 @@ export class Timestamp extends LongWithoutOverridesClass {
   /** @deprecated Not applicable to Timestamp; use `.t` instead. */
   declare high: Long['high'];
 
-  /** @deprecated Use `.equals()`, `.lessThan()`, or `.greaterThan()` for comparisons. */
+  /** @deprecated Use .compare() for general comparison, or .equals(), .lessThan(), .greaterThan() for specific cases. */
   declare comp: Long['comp'];
   /** @deprecated Compare `.t` and `.i` against `0` explicitly. */
   declare isZero: Long['isZero'];
   /** @deprecated Compare `.t` and `.i` against `0` explicitly. */
   declare eqz: Long['eqz'];
 
-  /** @deprecated Not applicable to Timestamp. Use `bsontype === 'Timestamp'` to identify a Timestamp. */
+  /** @deprecated Not applicable to Timestamp. Use the bsonType symbol or _bsontype === 'Timestamp' to identify a Timestamp. */
   declare __isLong__: Long['__isLong__'];
   /** @deprecated Not applicable to Timestamp. */
   declare getNumBitsAbs: Long['getNumBitsAbs'];

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -279,11 +279,11 @@ export class Timestamp extends LongWithoutOverridesClass {
   declare toSigned: Long['toSigned'];
   /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (this is a no-op). */
   declare toUnsigned: Long['toUnsigned'];
-  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (always returns false). */
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (is always false). */
   declare isNegative: Long['isNegative'];
-  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (returns true except for the zero Timestamp). */
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (is always true except for the zero Timestamp). */
   declare isPositive: Long['isPositive'];
-  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (always returns true). */
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (is always true). */
   declare unsigned: Long['unsigned'];
 
   // Conversion

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -16,6 +16,8 @@ export type TimestampOverrides =
   | typeof bsonType;
 
 /**
+ * @internal
+ * 
  * Inherited `Long` members surfaced on `Timestamp`.
  * When `Long` gains a new member: add it here if it should pass through, or
  * add a `@deprecated declare` line on the `Timestamp` class if it should be

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -20,12 +20,28 @@ export type TimestampOverrides =
  * the public type — preventing accidental behavioral bleed-through.
  */
 type TimestampKept =
-  | 'high' | 'low'
-  | 'equals' | 'eq' | 'notEquals' | 'neq' | 'ne'
-  | 'lessThan' | 'lt' | 'lessThanOrEqual' | 'lte' | 'le'
-  | 'greaterThan' | 'gt' | 'greaterThanOrEqual' | 'gte' | 'ge'
-  | 'compare' | 'comp'
-  | 'isZero' | 'eqz';
+  | 'high'
+  | 'low'
+  | 'toString'
+  | 'equals'
+  | 'eq'
+  | 'notEquals'
+  | 'neq'
+  | 'ne'
+  | 'lessThan'
+  | 'lt'
+  | 'lessThanOrEqual'
+  | 'lte'
+  | 'le'
+  | 'greaterThan'
+  | 'gt'
+  | 'greaterThanOrEqual'
+  | 'gte'
+  | 'ge'
+  | 'compare'
+  | 'comp'
+  | 'isZero'
+  | 'eqz';
 
 /** @public */
 export type LongWithoutOverrides = new (
@@ -199,7 +215,6 @@ export class Timestamp extends LongWithoutOverridesClass {
   // ********************
   // **** DEPRECATED ****
   // ********************
-  
   // Declare used to avoid runtime effects for field declaration.
   // See: https://www.typescriptlang.org/docs/handbook/2/classes.html#type-only-field-declarations
 
@@ -278,8 +293,6 @@ export class Timestamp extends LongWithoutOverridesClass {
   declare toBytesLE: Long['toBytesLE'];
   /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
   declare toBytesBE: Long['toBytesBE'];
-  /** @deprecated Not applicable to Timestamp; renders the underlying Long. Use `inspect()` for a debug representation, or `toJSON()` for the Extended JSON form. */
-  declare toString: Long['toString'];
 
   // Other
   /** @deprecated Incompatible with Timestamp: returns a signed integer, but Timestamp is always unsigned. Use `.t` for seconds since the Unix epoch. */
@@ -299,5 +312,4 @@ export class Timestamp extends LongWithoutOverridesClass {
   declare isEven: Long['isEven'];
   /** @deprecated Not applicable to Timestamp; tests parity of the increment only. */
   declare isOdd: Long['isOdd'];
-
 }

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -183,7 +183,6 @@ export class Timestamp extends LongWithoutOverridesClass {
 
   /**
    * Returns a Timestamp from the given string, optionally using the given radix.
-   * @deprecated Interprets `str` as a uint64, splitting it across (t, i); the result rarely matches user intent. Use `new Timestamp({ t, i })` or `Timestamp.fromBits(lowBits, highBits)` for explicit construction.
    *
    * @param str - the textual representation of the Timestamp.
    * @param optRadix - the radix in which the text is written.

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -11,13 +11,29 @@ export type TimestampOverrides =
   | 'fromExtendedJSON'
   | 'inspect'
   | typeof bsonType;
+
+/**
+ * Inherited `Long` members surfaced on `Timestamp`.
+ * When `Long` gains a new member: add it here if it should pass through, or
+ * add a `@deprecated declare` line on the `Timestamp` class if it should be
+ * surfaced as deprecated. Anything left unclassified is silently dropped from
+ * the public type — preventing accidental behavioral bleed-through.
+ */
+type TimestampKept =
+  | 'high' | 'low'
+  | 'equals' | 'eq' | 'notEquals' | 'neq' | 'ne'
+  | 'lessThan' | 'lt' | 'lessThanOrEqual' | 'lte' | 'le'
+  | 'greaterThan' | 'gt' | 'greaterThanOrEqual' | 'gte' | 'ge'
+  | 'compare' | 'comp'
+  | 'isZero' | 'eqz';
+
 /** @public */
 export type LongWithoutOverrides = new (
   low: unknown,
   high?: number | boolean,
   unsigned?: boolean
 ) => {
-  [P in Exclude<keyof Long, TimestampOverrides>]: Long[P];
+  [P in TimestampKept]: Long[P];
 };
 /** @public */
 export const LongWithoutOverridesClass: LongWithoutOverrides =
@@ -120,12 +136,18 @@ export class Timestamp extends LongWithoutOverridesClass {
     };
   }
 
-  /** Returns a Timestamp represented by the given (32-bit) integer value. */
+  /**
+   * Returns a Timestamp represented by the given (32-bit) integer value.
+   * @deprecated Stores `value` in the low 32 bits (increment), leaving t = 0. Use `new Timestamp({ t, i })` or `Timestamp.fromBits(lowBits, highBits)` for explicit construction.
+   */
   static fromInt(value: number): Timestamp {
     return new Timestamp(Long.fromInt(value, true));
   }
 
-  /** Returns a Timestamp representing the given number value, provided that it is a finite number. Otherwise, zero is returned. */
+  /**
+   * Returns a Timestamp representing the given number value, provided that it is a finite number. Otherwise, zero is returned.
+   * @deprecated Splits `value` across (t, i) as a uint64; the result rarely matches user intent. Use `new Timestamp({ t, i })` or `Timestamp.fromBits(lowBits, highBits)` for explicit construction.
+   */
   static fromNumber(value: number): Timestamp {
     return new Timestamp(Long.fromNumber(value, true));
   }
@@ -173,4 +195,109 @@ export class Timestamp extends LongWithoutOverridesClass {
     const i = inspect(this.i, options);
     return `new Timestamp({ t: ${t}, i: ${i} })`;
   }
+
+  // ********************
+  // **** DEPRECATED ****
+  // ********************
+  
+  // Declare used to avoid runtime effects for field declaration.
+  // See: https://www.typescriptlang.org/docs/handbook/2/classes.html#type-only-field-declarations
+
+  // Arithmetic
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare add: Long['add'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare subtract: Long['subtract'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare sub: Long['sub'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare multiply: Long['multiply'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare mul: Long['mul'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare divide: Long['divide'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare div: Long['div'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare modulo: Long['modulo'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare mod: Long['mod'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare rem: Long['rem'];
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned. */
+  declare negate: Long['negate'];
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned. */
+  declare neg: Long['neg'];
+
+  // Bitwise / shifts
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare and: Long['and'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare or: Long['or'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare xor: Long['xor'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare not: Long['not'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare shiftLeft: Long['shiftLeft'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare shl: Long['shl'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare shiftRight: Long['shiftRight'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare shr: Long['shr'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare shiftRightUnsigned: Long['shiftRightUnsigned'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare shr_u: Long['shr_u'];
+  /** @deprecated Not applicable to Timestamp; Timestamp is not intended to be used as a Long. */
+  declare shru: Long['shru'];
+
+  // Signing
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned. */
+  declare toSigned: Long['toSigned'];
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (this is a no-op). */
+  declare toUnsigned: Long['toUnsigned'];
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (always returns false). */
+  declare isNegative: Long['isNegative'];
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (returns true except for the zero Timestamp). */
+  declare isPositive: Long['isPositive'];
+  /** @deprecated Not applicable to Timestamp as the underlying Long is always unsigned (always returns true). */
+  declare unsigned: Long['unsigned'];
+
+  // Conversion
+  /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
+  declare toInt: Long['toInt'];
+  /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
+  declare toNumber: Long['toNumber'];
+  /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
+  declare toBigInt: Long['toBigInt'];
+  /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
+  declare toBytes: Long['toBytes'];
+  /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
+  declare toBytesLE: Long['toBytesLE'];
+  /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch, or `.i` for the increment ordinal. */
+  declare toBytesBE: Long['toBytesBE'];
+  /** @deprecated Not applicable to Timestamp; renders the underlying Long. Use `inspect()` for a debug representation, or `toJSON()` for the Extended JSON form. */
+  declare toString: Long['toString'];
+
+  // Other
+  /** @deprecated Incompatible with Timestamp: returns a signed integer, but Timestamp is always unsigned. Use `.t` for seconds since the Unix epoch. */
+  declare getHighBits: Long['getHighBits'];
+  /** @deprecated Not applicable to Timestamp; use `.t` for seconds since the Unix epoch. */
+  declare getHighBitsUnsigned: Long['getHighBitsUnsigned'];
+  /** @deprecated Incompatible with Timestamp: returns a signed integer, but Timestamp is always unsigned. Use `.i` for the increment ordinal. */
+  declare getLowBits: Long['getLowBits'];
+  /** @deprecated Not applicable to Timestamp; use `.i` for the increment ordinal. */
+  declare getLowBitsUnsigned: Long['getLowBitsUnsigned'];
+
+  /** @deprecated Not applicable to Timestamp. Use `_bsontype === 'Timestamp'` to identify a Timestamp. */
+  declare __isLong__: Long['__isLong__'];
+  /** @deprecated Not applicable to Timestamp. */
+  declare getNumBitsAbs: Long['getNumBitsAbs'];
+  /** @deprecated Not applicable to Timestamp; tests parity of the increment only. */
+  declare isEven: Long['isEven'];
+  /** @deprecated Not applicable to Timestamp; tests parity of the increment only. */
+  declare isOdd: Long['isOdd'];
+
 }

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -4,7 +4,10 @@ import type { Int32 } from './int_32';
 import { Long } from './long';
 import { type InspectFn, defaultInspect } from './parser/utils';
 
-/** @public */
+/**
+ * @public
+ * @deprecated This type is no longer used internally and will be removed in a future version.
+ */
 export type TimestampOverrides =
   | '_bsontype'
   | 'toExtendedJSON'

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -119,3 +119,93 @@ expectError(new ObjectId(42 as string | number));
 new Timestamp(new Timestamp(0n))
 
 expectType<(position: number, length: number) => Uint8Array>(Binary.prototype.read);
+
+// NODE-7069: TimestampKept members must be accessible and non-deprecated
+declare const timestamp: Timestamp;
+expectNotDeprecated(timestamp.high);
+expectNotDeprecated(timestamp.low);
+expectNotDeprecated(timestamp.toString);
+expectNotDeprecated(timestamp.equals);
+expectNotDeprecated(timestamp.eq);
+expectNotDeprecated(timestamp.notEquals);
+expectNotDeprecated(timestamp.neq);
+expectNotDeprecated(timestamp.ne);
+expectNotDeprecated(timestamp.lessThan);
+expectNotDeprecated(timestamp.lt);
+expectNotDeprecated(timestamp.lessThanOrEqual);
+expectNotDeprecated(timestamp.lte);
+expectNotDeprecated(timestamp.le);
+expectNotDeprecated(timestamp.greaterThan);
+expectNotDeprecated(timestamp.gt);
+expectNotDeprecated(timestamp.greaterThanOrEqual);
+expectNotDeprecated(timestamp.gte);
+expectNotDeprecated(timestamp.ge);
+expectNotDeprecated(timestamp.compare);
+expectNotDeprecated(timestamp.comp);
+expectNotDeprecated(timestamp.isZero);
+expectNotDeprecated(timestamp.eqz);
+
+// Timestamp's own instance members must not be deprecated
+expectNotDeprecated(timestamp.t);
+expectNotDeprecated(timestamp.i);
+expectNotDeprecated(timestamp.toJSON);
+
+// Non-deprecated static methods
+expectNotDeprecated(Timestamp.fromBits);
+expectNotDeprecated(Timestamp.fromString);
+
+// Deprecated static methods
+expectDeprecated(Timestamp.fromInt);
+expectDeprecated(Timestamp.fromNumber);
+
+// Deprecated instance members: Arithmetic
+expectDeprecated(timestamp.add);
+expectDeprecated(timestamp.subtract);
+expectDeprecated(timestamp.sub);
+expectDeprecated(timestamp.multiply);
+expectDeprecated(timestamp.mul);
+expectDeprecated(timestamp.divide);
+expectDeprecated(timestamp.div);
+expectDeprecated(timestamp.modulo);
+expectDeprecated(timestamp.mod);
+expectDeprecated(timestamp.rem);
+expectDeprecated(timestamp.negate);
+expectDeprecated(timestamp.neg);
+
+// Deprecated instance members: Bitwise
+expectDeprecated(timestamp.and);
+expectDeprecated(timestamp.or);
+expectDeprecated(timestamp.xor);
+expectDeprecated(timestamp.not);
+expectDeprecated(timestamp.shiftLeft);
+expectDeprecated(timestamp.shl);
+expectDeprecated(timestamp.shiftRight);
+expectDeprecated(timestamp.shr);
+expectDeprecated(timestamp.shiftRightUnsigned);
+expectDeprecated(timestamp.shr_u);
+expectDeprecated(timestamp.shru);
+
+// Deprecated instance members: Signing
+expectDeprecated(timestamp.toSigned);
+expectDeprecated(timestamp.toUnsigned);
+expectDeprecated(timestamp.isNegative);
+expectDeprecated(timestamp.isPositive);
+expectDeprecated(timestamp.unsigned);
+
+// Deprecated instance members: Conversion
+expectDeprecated(timestamp.toInt);
+expectDeprecated(timestamp.toNumber);
+expectDeprecated(timestamp.toBigInt);
+expectDeprecated(timestamp.toBytes);
+expectDeprecated(timestamp.toBytesLE);
+expectDeprecated(timestamp.toBytesBE);
+
+// Deprecated instance members: Other
+expectDeprecated(timestamp.getHighBits);
+expectDeprecated(timestamp.getHighBitsUnsigned);
+expectDeprecated(timestamp.getLowBits);
+expectDeprecated(timestamp.getLowBitsUnsigned);
+expectDeprecated(timestamp.__isLong__);
+expectDeprecated(timestamp.getNumBitsAbs);
+expectDeprecated(timestamp.isEven);
+expectDeprecated(timestamp.isOdd);

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -123,6 +123,7 @@ expectType<(position: number, length: number) => Uint8Array>(Binary.prototype.re
 // NODE-7069: TimestampKept members must be accessible and non-deprecated
 declare const timestamp: Timestamp;
 expectNotDeprecated(timestamp.toString);
+expectNotDeprecated(timestamp.compare);
 expectNotDeprecated(timestamp.equals);
 expectNotDeprecated(timestamp.eq);
 expectNotDeprecated(timestamp.notEquals);
@@ -166,7 +167,6 @@ expectDeprecated(timestamp.mod);
 expectDeprecated(timestamp.rem);
 expectDeprecated(timestamp.negate);
 expectDeprecated(timestamp.neg);
-expectDeprecated(timestamp.compare);
 expectDeprecated(timestamp.comp);
 expectDeprecated(timestamp.isZero);
 expectDeprecated(timestamp.eqz);

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -150,7 +150,8 @@ expectNotDeprecated(timestamp.toJSON);
 expectNotDeprecated(Timestamp.fromBits);
 expectNotDeprecated(Timestamp.fromString);
 
-// Deprecated static methods
+// Deprecated static members
+expectDeprecated(Timestamp.MAX_VALUE);
 expectDeprecated(Timestamp.fromInt);
 expectDeprecated(Timestamp.fromNumber);
 

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -122,8 +122,6 @@ expectType<(position: number, length: number) => Uint8Array>(Binary.prototype.re
 
 // NODE-7069: TimestampKept members must be accessible and non-deprecated
 declare const timestamp: Timestamp;
-expectNotDeprecated(timestamp.high);
-expectNotDeprecated(timestamp.low);
 expectNotDeprecated(timestamp.toString);
 expectNotDeprecated(timestamp.equals);
 expectNotDeprecated(timestamp.eq);
@@ -140,10 +138,7 @@ expectNotDeprecated(timestamp.gt);
 expectNotDeprecated(timestamp.greaterThanOrEqual);
 expectNotDeprecated(timestamp.gte);
 expectNotDeprecated(timestamp.ge);
-expectNotDeprecated(timestamp.compare);
-expectNotDeprecated(timestamp.comp);
-expectNotDeprecated(timestamp.isZero);
-expectNotDeprecated(timestamp.eqz);
+expectNotDeprecated(timestamp.toBigInt);
 
 // Timestamp's own instance members must not be deprecated
 expectNotDeprecated(timestamp.t);
@@ -152,7 +147,7 @@ expectNotDeprecated(timestamp.toJSON);
 
 // Non-deprecated static methods
 expectNotDeprecated(Timestamp.fromBits);
-expectDeprecated(Timestamp.fromString);
+expectNotDeprecated(Timestamp.fromString);
 
 // Deprecated static methods
 expectDeprecated(Timestamp.fromInt);
@@ -171,6 +166,12 @@ expectDeprecated(timestamp.mod);
 expectDeprecated(timestamp.rem);
 expectDeprecated(timestamp.negate);
 expectDeprecated(timestamp.neg);
+expectDeprecated(timestamp.compare);
+expectDeprecated(timestamp.comp);
+expectDeprecated(timestamp.isZero);
+expectDeprecated(timestamp.eqz);
+expectDeprecated(timestamp.high);
+expectDeprecated(timestamp.low);
 
 // Deprecated instance members: Bitwise
 expectDeprecated(timestamp.and);
@@ -195,7 +196,6 @@ expectDeprecated(timestamp.unsigned);
 // Deprecated instance members: Conversion
 expectDeprecated(timestamp.toInt);
 expectDeprecated(timestamp.toNumber);
-expectDeprecated(timestamp.toBigInt);
 expectDeprecated(timestamp.toBytes);
 expectDeprecated(timestamp.toBytesLE);
 expectDeprecated(timestamp.toBytesBE);

--- a/test/types/bson.test-d.ts
+++ b/test/types/bson.test-d.ts
@@ -152,7 +152,7 @@ expectNotDeprecated(timestamp.toJSON);
 
 // Non-deprecated static methods
 expectNotDeprecated(Timestamp.fromBits);
-expectNotDeprecated(Timestamp.fromString);
+expectDeprecated(Timestamp.fromString);
 
 // Deprecated static methods
 expectDeprecated(Timestamp.fromInt);


### PR DESCRIPTION
### Description

#### Summary of Changes

Timestamp extends Long for storage convenience, but its semantics are strictly a (t, i) pair — not a general 64-bit integer. Inherited Long members that don't map cleanly to that model (arithmetic, bitwise ops, sign-related methods, raw conversions, and bit accessors) are now marked @deprecated, with declare-only redeclarations so no runtime behavior changes. The LongWithoutOverrides type is narrowed from an open denylist to an explicit allowlist (TimestampKept), preventing future Long additions from silently appearing on Timestamp's public surface. This lays the groundwork for a future refactor where Long becomes a private backing field rather than a base class.

##### Notes for Reviewers

Sets up a future refactor toward wrapping (Long as a backing field, as
suggested in https://jira.mongodb.org/browse/NODE-2624)
which the type surface already accommodates.

There's also no practical need to convert Timestamp to/from number, since the conversion is imprecise (lossful).

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Deprecated inapplicable `Long` members on `Timestamp`

`Timestamp` inherits from `Long` for storage convenience, but it is semantically a `(t, i)` pair, not a general 64-bit integer. If you have called `Long` methods directly on `Timestamp` instances (for example `toNumber()`, `getHighBits()`, `getLowBits()`, or aithmetic and bitwise operations), those are now marked `@deprecated` with no runtime behavior changes. The `.t` and `.i` accessors provide direct, semantically consistent access to the two timestamp components.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
