### PR TITLE
chore(NODE-7599): tighten workflow permissions and update docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,7 @@ on:
 name: Build
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can learn more about it in [the specification](http://bsonspec.org).
 
 ### Release Integrity
 
-Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). This applies to the git tag as well as all release packages provided as part of a GitHub release. To verify the provided packages, download the key and import it using gpg:
+Releases are created automatically and signed using the [Node team's GPG key](https://pgp.mongodb.com/node-driver.asc). All release packages provided as part of a GitHub release are signed. To verify the provided packages, download the key and import it using gpg:
 
 ```shell
 gpg --import node-driver.asc
@@ -37,6 +37,12 @@ gpg --verify bson-X.Y.Z.tgz.sig bson-X.Y.Z.tgz
 
 >[!Note]
 No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
+
+Releases published to the npm registry also include a [provenance attestation](https://docs.npmjs.com/generating-provenance-statements), which cryptographically links the package to its source repository and build workflow. To verify provenance:
+
+```shell
+npm audit signatures
+```
 
 ## Bugs / Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ gpg --verify bson-X.Y.Z.tgz.sig bson-X.Y.Z.tgz
 ```
 
 >[!Note]
-No verification is done when using npm to install the package. The contents of the Github tarball and npm's tarball are identical.
+No GPG verification is done when using npm to install the package. The contents of the GitHub tarball and npm's tarball are identical.
 
 Releases published to the npm registry also include a [provenance attestation](https://docs.npmjs.com/generating-provenance-statements), which cryptographically links the package to its source repository and build workflow. To verify provenance:
 


### PR DESCRIPTION
### Description

#### Summary of Changes

Maintenance changes.

<!-- Please describe the changes in this PR in a high-level overview. -->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

The build.yml permissions were overly broad - a hygiene fix to follow the principle of least privilege, consistent with the same change made in mongodb-js/mongodb-client-encryption#129. The `README` has had an incorrect claim about git tag signing since it was introduced, and was missing documentation on npm provenance verification which is now available.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
