### PR TITLE
fix(NODE-7606): restore serializer performance by removing generator-based iteration

### DIFF
--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -147,14 +147,36 @@ interface NestedParsingFrame {
   raw: boolean;
   // When true, this frame may be a DBRef. This is set to false if we encounter a key that is not valid for a DBRef, and is left as null for arrays since they cannot be DBRefs.
   isPossibleDBRef: boolean | null;
-  // The global utf-8 validation setting for this frame, used to determine the default utf-8 validation behavior for keys in this frame if the validation option is not an object specifying specific keys.
-  globalUTFValidation: boolean;
   // The utf-8 validation setting for this frame, used to determine whether to utf-8 validate keys in this frame. This is determined based on the global utf-8 validation setting and the specific keys specified in the validation option.
   validationSetting: boolean;
   functionString: string | null; // only used for Code with Scope
 }
 
 const allowedDBRefKeys = /^\$ref$|^\$id$|^\$db$/;
+
+// Assigns a parsed value into the destination document, guarding the __proto__ key to avoid
+// prototype pollution.
+function assignValue(dest: Document, name: string | number, value: unknown): void {
+  if (name === '__proto__') {
+    Object.defineProperty(dest, name, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true
+    });
+  } else {
+    dest[name] = value;
+  }
+}
+
+// Promotes a plain document to a DBRef instance when it has the DBRef shape ($ref/$id[/$db]).
+function toPotentialDbRef(doc: Document): DBRef | Document {
+  if (isDBRefLike(doc)) {
+    const { $ref, $id, $db, ...fields } = doc;
+    return new DBRef($ref, $id, $db, fields);
+  }
+  return doc;
+}
 
 function deserializeObject(
   buffer: Uint8Array,
@@ -166,9 +188,6 @@ function deserializeObject(
 
   // Strips prototype chain so inherited properties don't affect option reads.
   options = { ...options };
-
-  // Used to track whether we are parsing an array or object, affects how keys are interpreted and when we hit the end of the document
-  const originalIsArray = isArray;
 
   // Used to track fields that should be returned as raw bson buffers without parsing, this is set based on the fieldsAsRaw option and is inherited by nested frames when parsing nested objects
   const fieldsAsRaw = options['fieldsAsRaw'] == null ? null : options['fieldsAsRaw'];
@@ -260,30 +279,12 @@ function deserializeObject(
 
   // Tracks the top of nestedParsingStack, or null if there is no nested document currently being parsed.
   let currentFrame: NestedParsingFrame | null = null;
-
-  // How we set the value in the destination object, with special handling for __proto__ to avoid prototype pollution vulnerabilities
-  const setValue = (name: string | number, value: unknown) => {
-    const frame = currentFrame;
-    const dest = frame !== null ? frame.holdingDocument : rootObject;
-    if (name === '__proto__') {
-      Object.defineProperty(dest, name, {
-        value,
-        writable: true,
-        enumerable: true,
-        configurable: true
-      });
-    } else {
-      dest[name] = value;
-    }
-  };
-
-  const toPotentialDbRef = (doc: Document): DBRef | Document => {
-    if (isDBRefLike(doc)) {
-      const { $ref, $id, $db, ...fields } = doc;
-      return new DBRef($ref, $id, $db, fields);
-    }
-    return doc;
-  };
+  // Destination object for the current frame (the parent's holdingDocument, or rootObject at the
+  // top level). Maintained alongside currentFrame so per-field assignment never recomputes it.
+  let currentDest: Document = rootObject;
+  // Whether the current frame is an array. Maintained alongside currentFrame so the per-field key
+  // logic does not branch on currentFrame every iteration.
+  let currentIsArray = isArray;
 
   // While we have more left data left keep parsing
   while (true) {
@@ -299,10 +300,15 @@ function deserializeObject(
           // Snapshot the completed frame before updating currentFrame to the parent.
           const completedFrame = currentFrame;
           nestedParsingStack.pop();
-          currentFrame =
-            nestedParsingStack.length === 0
-              ? null
-              : nestedParsingStack[nestedParsingStack.length - 1];
+          if (nestedParsingStack.length === 0) {
+            currentFrame = null;
+            currentDest = rootObject;
+            currentIsArray = isArray;
+          } else {
+            currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
+            currentDest = currentFrame.holdingDocument;
+            currentIsArray = currentFrame.isArray;
+          }
           // finish the frame
           let result: Document = completedFrame.holdingDocument;
           switch (completedFrame.elementType) {
@@ -322,8 +328,8 @@ function deserializeObject(
             default:
               throw new BSONError('Unexpected element type in frame stack');
           }
-          // set the value in the parent document (setValue reads currentFrame, now pointing to parent)
-          setValue(completedFrame.propertyName, result);
+          // set the value in the parent document (currentDest now points to the parent's document)
+          assignValue(currentDest, completedFrame.propertyName, result);
           continue;
         } else {
           // Current index does not match the last index of the frame, the document is malformed
@@ -338,14 +344,6 @@ function deserializeObject(
       }
     }
 
-    if (currentFrame) {
-      // If we're in a frame, use the frame's array setting
-      isArray = currentFrame.isArray;
-    } else {
-      // If we're not in a frame, use the original isArray value that was passed in for the root document
-      isArray = originalIsArray;
-    }
-
     // Get the start search index
     let i = index;
     // Locate the end of the c string
@@ -357,8 +355,8 @@ function deserializeObject(
     if (i >= buffer.byteLength) throw new BSONError('Bad BSON Document: illegal CString');
 
     // Represents the key
-    const name = isArray
-      ? currentFrame && currentFrame.isArray
+    const name = currentIsArray
+      ? currentFrame !== null
         ? currentFrame.arrayIndex++
         : arrayIndex++
       : ByteUtils.toUTF8(buffer, index, i, false);
@@ -437,7 +435,7 @@ function deserializeObject(
         index = index + objectSize;
       } else {
         isDeferredValue = true;
-        nestedParsingStack.push({
+        const objectFrame: NestedParsingFrame = {
           holdingDocument: {},
           elementType: constants.BSON_DATA_OBJECT,
           propertyName: name,
@@ -447,10 +445,12 @@ function deserializeObject(
           arrayIndex: 0,
           raw: false,
           isPossibleDBRef: null, // we don't know if this is a DBRef until we parse the keys, so we start with null and set to false if we encounter a key that is not valid for a DBRef
-          globalUTFValidation: true,
           validationSetting: shouldValidateKey
-        });
-        currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
+        };
+        nestedParsingStack.push(objectFrame);
+        currentFrame = objectFrame;
+        currentDest = objectFrame.holdingDocument;
+        currentIsArray = false;
         index = index + 4;
       }
     } else if (elementType === constants.BSON_DATA_ARRAY) {
@@ -466,7 +466,7 @@ function deserializeObject(
       // Also propagate raw from the parent frame (nested arrays inside a raw array stay raw).
       const arrayRaw = !!(fieldsAsRaw && fieldsAsRaw[name]) || (currentFrame?.raw ?? false);
       isDeferredValue = true;
-      nestedParsingStack.push({
+      const arrayFrame: NestedParsingFrame = {
         holdingDocument: [],
         elementType: constants.BSON_DATA_ARRAY,
         propertyName: name,
@@ -476,10 +476,12 @@ function deserializeObject(
         arrayIndex: 0,
         raw: arrayRaw,
         isPossibleDBRef: false,
-        globalUTFValidation: true,
         validationSetting: shouldValidateKey
-      });
-      currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
+      };
+      nestedParsingStack.push(arrayFrame);
+      currentFrame = arrayFrame;
+      currentDest = arrayFrame.holdingDocument;
+      currentIsArray = true;
       index = index + 4;
     } else if (elementType === constants.BSON_DATA_UNDEFINED) {
       value = undefined;
@@ -713,7 +715,7 @@ function deserializeObject(
       }
 
       isDeferredValue = true;
-      nestedParsingStack.push({
+      const scopeFrame: NestedParsingFrame = {
         holdingDocument: {},
         elementType: constants.BSON_DATA_CODE_W_SCOPE,
         propertyName: name,
@@ -723,10 +725,12 @@ function deserializeObject(
         arrayIndex: 0,
         raw: false,
         isPossibleDBRef: null,
-        globalUTFValidation: true,
         validationSetting: shouldValidateKey
-      });
-      currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
+      };
+      nestedParsingStack.push(scopeFrame);
+      currentFrame = scopeFrame;
+      currentDest = scopeFrame.holdingDocument;
+      currentIsArray = false;
       index = index + 4; // move index past the size of the object, the rest of the object will be parsed in subsequent iterations of this loop
     } else if (elementType === constants.BSON_DATA_DBPOINTER) {
       // Get the code string size
@@ -762,7 +766,7 @@ function deserializeObject(
 
     // If we have the value, set it on the target object
     if (!isDeferredValue) {
-      setValue(name, value);
+      assignValue(currentDest, name, value);
     }
   }
 

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -150,6 +150,9 @@ interface NestedParsingFrame {
   // The utf-8 validation setting for this frame, used to determine whether to utf-8 validate keys in this frame. This is determined based on the global utf-8 validation setting and the specific keys specified in the validation option.
   validationSetting: boolean;
   functionString: string | null; // only used for Code with Scope
+  // The enclosing frame, or null at the top level. The parsing stack is a linked list threaded
+  // through this field rather than a separate array, which avoids array push/pop churn per frame.
+  prev: NestedParsingFrame | null;
 }
 
 const allowedDBRefKeys = /^\$ref$|^\$id$|^\$db$/;
@@ -271,13 +274,12 @@ function deserializeObject(
 
   // Create holding object
   const rootObject: Document = isArray ? [] : {};
-  const nestedParsingStack: NestedParsingFrame[] = [];
   // Used for arrays to skip having to perform utf8 decoding
   let arrayIndex = 0;
 
   let isPossibleDBRef = isArray ? false : null;
 
-  // Tracks the top of nestedParsingStack, or null if there is no nested document currently being parsed.
+  // Top of the parsing stack (a linked list via each frame's `prev`), or null at the top level.
   let currentFrame: NestedParsingFrame | null = null;
   // Destination object for the current frame (the parent's holdingDocument, or rootObject at the
   // top level). Maintained alongside currentFrame so per-field assignment never recomputes it.
@@ -298,14 +300,12 @@ function deserializeObject(
         // If we're in a frame, that means the end of the current nested document
         if (index === currentFrame.lastIndex) {
           // Snapshot the completed frame before updating currentFrame to the parent.
-          const completedFrame = currentFrame;
-          nestedParsingStack.pop();
-          if (nestedParsingStack.length === 0) {
-            currentFrame = null;
+          const completedFrame: NestedParsingFrame = currentFrame;
+          currentFrame = completedFrame.prev;
+          if (currentFrame === null) {
             currentDest = rootObject;
             currentIsArray = isArray;
           } else {
-            currentFrame = nestedParsingStack[nestedParsingStack.length - 1];
             currentDest = currentFrame.holdingDocument;
             currentIsArray = currentFrame.isArray;
           }
@@ -445,9 +445,9 @@ function deserializeObject(
           arrayIndex: 0,
           raw: false,
           isPossibleDBRef: null, // we don't know if this is a DBRef until we parse the keys, so we start with null and set to false if we encounter a key that is not valid for a DBRef
-          validationSetting: shouldValidateKey
+          validationSetting: shouldValidateKey,
+          prev: currentFrame
         };
-        nestedParsingStack.push(objectFrame);
         currentFrame = objectFrame;
         currentDest = objectFrame.holdingDocument;
         currentIsArray = false;
@@ -476,9 +476,9 @@ function deserializeObject(
         arrayIndex: 0,
         raw: arrayRaw,
         isPossibleDBRef: false,
-        validationSetting: shouldValidateKey
+        validationSetting: shouldValidateKey,
+        prev: currentFrame
       };
-      nestedParsingStack.push(arrayFrame);
       currentFrame = arrayFrame;
       currentDest = arrayFrame.holdingDocument;
       currentIsArray = true;
@@ -725,9 +725,9 @@ function deserializeObject(
         arrayIndex: 0,
         raw: false,
         isPossibleDBRef: null,
-        validationSetting: shouldValidateKey
+        validationSetting: shouldValidateKey,
+        prev: currentFrame
       };
-      nestedParsingStack.push(scopeFrame);
       currentFrame = scopeFrame;
       currentDest = scopeFrame.holdingDocument;
       currentIsArray = false;
@@ -771,7 +771,7 @@ function deserializeObject(
   }
 
   // Check if we have any frames left on the stack, if we do then we had a malformed document
-  if (nestedParsingStack.length !== 0) {
+  if (currentFrame !== null) {
     throw new BSONError('corrupted bson, more objects expected based on the current document size');
   }
   const object = rootObject;

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -1,5 +1,6 @@
 import { Binary, validateBinaryVector } from '../binary';
 import type { BSONSymbol, DBRef, Document, MaxKey } from '../bson';
+import { bsonType } from '../bson_value';
 import type { Code } from '../code';
 import * as constants from '../constants';
 import type { Decimal128 } from '../decimal128';
@@ -206,7 +207,7 @@ function serializeMinMax(buffer: Uint8Array, key: string, value: MinKey | MaxKey
   // Write the type of either min or max key
   if (value === null) {
     buffer[index++] = constants.BSON_DATA_NULL;
-  } else if (value._bsontype === 'MinKey') {
+  } else if (value[bsonType] === 'MinKey') {
     buffer[index++] = constants.BSON_DATA_MIN_KEY;
   } else {
     buffer[index++] = constants.BSON_DATA_MAX_KEY;
@@ -276,7 +277,7 @@ function serializeDecimal128(buffer: Uint8Array, key: string, value: Decimal128,
 function serializeLong(buffer: Uint8Array, key: string, value: Long, index: number) {
   // Write the type
   buffer[index++] =
-    value._bsontype === 'Long' ? constants.BSON_DATA_LONG : constants.BSON_DATA_TIMESTAMP;
+    value[bsonType] === 'Long' ? constants.BSON_DATA_LONG : constants.BSON_DATA_TIMESTAMP;
   // Number of written bytes
   const numberOfWrittenBytes = ByteUtils.encodeUTF8Into(buffer, key, index);
   // Encode the name
@@ -640,16 +641,16 @@ export function serializeInto(
       if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
         throw new BSONVersionError();
       }
-      const bsontype = value._bsontype;
-      if (bsontype === 'ObjectId') {
+      const tag = value[bsonType];
+      if (tag === 'ObjectId') {
         index = serializeObjectId(buffer, key, value, index);
-      } else if (bsontype === 'Decimal128') {
+      } else if (tag === 'Decimal128') {
         index = serializeDecimal128(buffer, key, value, index);
-      } else if (bsontype === 'Long' || bsontype === 'Timestamp') {
+      } else if (tag === 'Long' || tag === 'Timestamp') {
         index = serializeLong(buffer, key, value, index);
-      } else if (bsontype === 'Double') {
+      } else if (tag === 'Double') {
         index = serializeDouble(buffer, key, value, index);
-      } else if (bsontype === 'Code') {
+      } else if (tag === 'Code') {
         const codeValue = value as Code;
         if (codeValue.scope && typeof codeValue.scope === 'object') {
           buffer[index++] = constants.BSON_DATA_CODE_W_SCOPE;
@@ -679,11 +680,11 @@ export function serializeInto(
           index = index + 4 + size - 1;
           buffer[index++] = 0;
         }
-      } else if (bsontype === 'Binary') {
+      } else if (tag === 'Binary') {
         index = serializeBinary(buffer, key, value, index);
-      } else if (bsontype === 'BSONSymbol') {
+      } else if (tag === 'BSONSymbol') {
         index = serializeSymbol(buffer, key, value, index);
-      } else if (bsontype === 'DBRef') {
+      } else if (tag === 'DBRef') {
         const dbref = value as DBRef;
         const orderedValues: Document = Object.assign(
           { $ref: dbref.collection, $id: dbref.oid },
@@ -696,14 +697,14 @@ export function serializeInto(
         path.add(orderedValues);
         currentFrame = makeFrame(orderedValues, index, null, frame);
         index += 4;
-      } else if (bsontype === 'BSONRegExp') {
+      } else if (tag === 'BSONRegExp') {
         index = serializeBSONRegExp(buffer, key, value, index);
-      } else if (bsontype === 'Int32') {
+      } else if (tag === 'Int32') {
         index = serializeInt32(buffer, key, value, index);
-      } else if (bsontype === 'MinKey' || bsontype === 'MaxKey') {
+      } else if (tag === 'MinKey' || tag === 'MaxKey') {
         index = serializeMinMax(buffer, key, value, index);
-      } else if (typeof bsontype !== 'undefined') {
-        throw new BSONError(`Unrecognized or invalid _bsontype: ${String(bsontype)}`);
+      } else if (typeof value._bsontype !== 'undefined') {
+        throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
       }
     } else if (type === 'function' && serializeFunctions) {
       index = serializeFunction(buffer, key, value, index);

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -425,12 +425,15 @@ interface SerializationFrame {
   keyIndex: number;
   /** Active iterator for Map objects; null for arrays and plain objects. */
   mapIterator: IterableIterator<[unknown, unknown]> | null;
+  /** The enclosing frame, or null at the root. The stack is a linked list via this field. */
+  prev: SerializationFrame | null;
 }
 
 function makeFrame(
   sourceObject: Document,
   objectSizeIndex: number,
-  codeSizeIndex: number | null
+  codeSizeIndex: number | null,
+  prev: SerializationFrame | null
 ): SerializationFrame {
   if (Array.isArray(sourceObject)) {
     return {
@@ -441,7 +444,8 @@ function makeFrame(
       iterTarget: sourceObject,
       keys: null,
       keyIndex: 0,
-      mapIterator: null
+      mapIterator: null,
+      prev
     };
   }
   if (sourceObject instanceof Map || isMap(sourceObject)) {
@@ -453,7 +457,8 @@ function makeFrame(
       iterTarget: sourceObject,
       keys: null,
       keyIndex: 0,
-      mapIterator: (sourceObject as Map<unknown, unknown>).entries()
+      mapIterator: (sourceObject as Map<unknown, unknown>).entries(),
+      prev
     };
   }
   // Plain object: call toBSON() if defined to obtain the object to iterate.
@@ -474,7 +479,8 @@ function makeFrame(
     iterTarget: target,
     keys: Object.keys(target as object),
     keyIndex: 0,
-    mapIterator: null
+    mapIterator: null,
+    prev
   };
 }
 
@@ -522,11 +528,11 @@ export function serializeInto(
 
   path.add(object);
 
-  const stack: SerializationFrame[] = [makeFrame(object, startingIndex, null)];
+  let currentFrame: SerializationFrame | null = makeFrame(object, startingIndex, null, null);
   let index = startingIndex + 4;
 
-  while (stack.length > 0) {
-    const frame = stack[stack.length - 1];
+  while (currentFrame !== null) {
+    const frame: SerializationFrame = currentFrame;
 
     // Advance to the next key-value pair, or finalize the frame if exhausted.
     let key: string;
@@ -541,7 +547,7 @@ export function serializeInto(
           NumberUtils.setInt32LE(buffer, frame.codeSizeIndex, index - frame.codeSizeIndex);
         }
         path.delete(frame.sourceObject);
-        stack.pop();
+        currentFrame = frame.prev;
         continue;
       }
       key = next.value[0] as string;
@@ -554,7 +560,7 @@ export function serializeInto(
           NumberUtils.setInt32LE(buffer, frame.codeSizeIndex, index - frame.codeSizeIndex);
         }
         path.delete(frame.sourceObject);
-        stack.pop();
+        currentFrame = frame.prev;
         continue;
       }
       key = frame.keys[frame.keyIndex++];
@@ -569,7 +575,7 @@ export function serializeInto(
           NumberUtils.setInt32LE(buffer, frame.codeSizeIndex, index - frame.codeSizeIndex);
         }
         path.delete(frame.sourceObject);
-        stack.pop();
+        currentFrame = frame.prev;
         continue;
       }
       const i = frame.keyIndex++;
@@ -627,7 +633,7 @@ export function serializeInto(
         buffer[index++] = 0x00;
         const nestedStartIndex = index;
         path.add(value);
-        stack.push(makeFrame(value, nestedStartIndex, null));
+        currentFrame = makeFrame(value, nestedStartIndex, null, frame);
         index += 4;
       }
     } else if (type === 'object') {
@@ -661,7 +667,7 @@ export function serializeInto(
             throw new BSONError('Cannot convert circular structure to BSON');
           }
           path.add(scope);
-          stack.push(makeFrame(scope, index, codeTotalSizeIndex));
+          currentFrame = makeFrame(scope, index, codeTotalSizeIndex, frame);
           index += 4;
         } else {
           buffer[index++] = constants.BSON_DATA_CODE;
@@ -688,7 +694,7 @@ export function serializeInto(
         index += ByteUtils.encodeUTF8Into(buffer, key, index);
         buffer[index++] = 0x00;
         path.add(orderedValues);
-        stack.push(makeFrame(orderedValues, index, null));
+        currentFrame = makeFrame(orderedValues, index, null, frame);
         index += 4;
       } else if (bsontype === 'BSONRegExp') {
         index = serializeBSONRegExp(buffer, key, value, index);

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -587,7 +587,7 @@ export function serializeInto(
       value = value.toBSON();
     }
 
-    if (!frame.isArray && !(key[0] === '$' && ignoreKeys.has(key))) {
+    if (!frame.isArray && typeof key === 'string' && !(key[0] === '$' && ignoreKeys.has(key))) {
       if (regexp.test(key)) {
         throw new BSONError('key ' + key + ' must not contain null bytes');
       }

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -581,8 +581,8 @@ export function serializeInto(
       value = value.toBSON();
     }
 
-    if (!frame.isArray && typeof key === 'string' && !ignoreKeys.has(key)) {
-      if (key.match(regexp) != null) {
+    if (!frame.isArray && !(key[0] === '$' && ignoreKeys.has(key))) {
+      if (regexp.test(key)) {
         throw new BSONError('key ' + key + ' must not contain null bytes');
       }
       if (checkKeys) {
@@ -633,15 +633,17 @@ export function serializeInto(
     } else if (type === 'object') {
       if (value[constants.BSON_VERSION_SYMBOL] !== constants.BSON_MAJOR_VERSION) {
         throw new BSONVersionError();
-      } else if (value._bsontype === 'ObjectId') {
+      }
+      const bsontype = value._bsontype;
+      if (bsontype === 'ObjectId') {
         index = serializeObjectId(buffer, key, value, index);
-      } else if (value._bsontype === 'Decimal128') {
+      } else if (bsontype === 'Decimal128') {
         index = serializeDecimal128(buffer, key, value, index);
-      } else if (value._bsontype === 'Long' || value._bsontype === 'Timestamp') {
+      } else if (bsontype === 'Long' || bsontype === 'Timestamp') {
         index = serializeLong(buffer, key, value, index);
-      } else if (value._bsontype === 'Double') {
+      } else if (bsontype === 'Double') {
         index = serializeDouble(buffer, key, value, index);
-      } else if (value._bsontype === 'Code') {
+      } else if (bsontype === 'Code') {
         const codeValue = value as Code;
         if (codeValue.scope && typeof codeValue.scope === 'object') {
           buffer[index++] = constants.BSON_DATA_CODE_W_SCOPE;
@@ -671,11 +673,11 @@ export function serializeInto(
           index = index + 4 + size - 1;
           buffer[index++] = 0;
         }
-      } else if (value._bsontype === 'Binary') {
+      } else if (bsontype === 'Binary') {
         index = serializeBinary(buffer, key, value, index);
-      } else if (value._bsontype === 'BSONSymbol') {
+      } else if (bsontype === 'BSONSymbol') {
         index = serializeSymbol(buffer, key, value, index);
-      } else if (value._bsontype === 'DBRef') {
+      } else if (bsontype === 'DBRef') {
         const dbref = value as DBRef;
         const orderedValues: Document = Object.assign(
           { $ref: dbref.collection, $id: dbref.oid },
@@ -688,14 +690,14 @@ export function serializeInto(
         path.add(orderedValues);
         stack.push(makeFrame(orderedValues, index, null));
         index += 4;
-      } else if (value._bsontype === 'BSONRegExp') {
+      } else if (bsontype === 'BSONRegExp') {
         index = serializeBSONRegExp(buffer, key, value, index);
-      } else if (value._bsontype === 'Int32') {
+      } else if (bsontype === 'Int32') {
         index = serializeInt32(buffer, key, value, index);
-      } else if (value._bsontype === 'MinKey' || value._bsontype === 'MaxKey') {
+      } else if (bsontype === 'MinKey' || bsontype === 'MaxKey') {
         index = serializeMinMax(buffer, key, value, index);
-      } else if (typeof value._bsontype !== 'undefined') {
-        throw new BSONError(`Unrecognized or invalid _bsontype: ${String(value._bsontype)}`);
+      } else if (typeof bsontype !== 'undefined') {
+        throw new BSONError(`Unrecognized or invalid _bsontype: ${String(bsontype)}`);
       }
     } else if (type === 'function' && serializeFunctions) {
       index = serializeFunction(buffer, key, value, index);

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -44,12 +44,6 @@ export interface SerializeOptions {
 const regexp = /\x00/; // eslint-disable-line no-control-regex
 const ignoreKeys = new Set(['$db', '$ref', '$id', '$clusterTime']);
 
-/*
- * isArray indicates if we are writing to a BSON array (type 0x04)
- * which forces the "key" which really an array index as a string to be written as ascii
- * This will catch any errors in index as a string generation
- */
-
 function serializeString(buffer: Uint8Array, key: string, value: string, index: number) {
   // Encode String type
   buffer[index++] = constants.BSON_DATA_STRING;
@@ -409,41 +403,79 @@ function serializeSymbol(buffer: Uint8Array, key: string, value: BSONSymbol, ind
 }
 
 interface SerializationFrame {
-  // The object being serialized at this frame.
-  // Held so it can be removed from the cycle-detection path when this frame completes.
+  /** Original object passed to this frame — used for cycle-detection (path.delete). */
   sourceObject: Document;
-  // Whether the object we are serializing is an array.
-  // This forces the keys to be serialized as ASCII strings of their index in the array.
+  /** True when serializing a BSON array; affects key format and type byte. */
   isArray: boolean;
-  // Lazy iterator over the key-value pairs of the object being serialized.
-  // Avoids materializing intermediate arrays for Maps and Arrays.
-  pairs: Iterator<[string, unknown]>;
-  // The index in the buffer where the size of the current serialized object is stored.
-  // We will only know the size of the object once we have finished serializing it, so we keep track of where to write the size once we know it.
+  /** Buffer offset where this object's 4-byte size field will be written. */
   objectSizeIndex: number;
-  // The index in the buffer where the size of the code with scope object is stored.
-  // Used for Code with Scope serialization.
-  // We will only know the size of the code with scope object once we have finished serializing it, so we keep track of where to write the size once we know it.
+  /** Buffer offset for code-with-scope wrapper size, or null if not applicable. */
   codeSizeIndex: number | null;
+  /**
+   * Object being iterated. For plain objects this may be the toBSON() result of
+   * sourceObject; for arrays and Maps it equals sourceObject.
+   */
+  iterTarget: Document;
+  /**
+   * Pre-computed Object.keys() of iterTarget for plain objects.
+   * Null for arrays (use keyIndex as numeric index) and Maps (use mapIterator).
+   */
+  keys: string[] | null;
+  /** Next index into keys[] for plain objects, or next array index for arrays. */
+  keyIndex: number;
+  /** Active iterator for Map objects; null for arrays and plain objects. */
+  mapIterator: IterableIterator<[unknown, unknown]> | null;
 }
 
-function* toKvPairs(object: Document): Iterator<[string, unknown]> {
-  if (Array.isArray(object)) {
-    yield* Object.entries(object);
-  } else if (object instanceof Map || isMap(object)) {
-    yield* object as Map<unknown, unknown> as Iterable<[string, unknown]>;
-  } else {
-    let target: Document = object;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (typeof (target as any)?.toBSON === 'function') {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      target = (target as any).toBSON() as Document;
-      if (target != null && typeof target !== 'object') {
-        throw new BSONError('toBSON function did not return an object');
-      }
-    }
-    yield* Object.entries(target);
+function makeFrame(
+  sourceObject: Document,
+  objectSizeIndex: number,
+  codeSizeIndex: number | null
+): SerializationFrame {
+  if (Array.isArray(sourceObject)) {
+    return {
+      sourceObject,
+      isArray: true,
+      objectSizeIndex,
+      codeSizeIndex,
+      iterTarget: sourceObject,
+      keys: null,
+      keyIndex: 0,
+      mapIterator: null
+    };
   }
+  if (sourceObject instanceof Map || isMap(sourceObject)) {
+    return {
+      sourceObject,
+      isArray: false,
+      objectSizeIndex,
+      codeSizeIndex,
+      iterTarget: sourceObject,
+      keys: null,
+      keyIndex: 0,
+      mapIterator: (sourceObject as Map<unknown, unknown>).entries()
+    };
+  }
+  // Plain object: call toBSON() if defined to obtain the object to iterate.
+  let target: Document = sourceObject;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof (target as any)?.toBSON === 'function') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    target = (target as any).toBSON() as Document;
+    if (target != null && typeof target !== 'object') {
+      throw new BSONError('toBSON function did not return an object');
+    }
+  }
+  return {
+    sourceObject,
+    isArray: false,
+    objectSizeIndex,
+    codeSizeIndex,
+    iterTarget: target,
+    keys: Object.keys(target as object),
+    keyIndex: 0,
+    mapIterator: null
+  };
 }
 
 export function serializeInto(
@@ -490,36 +522,60 @@ export function serializeInto(
 
   path.add(object);
 
-  const stack: SerializationFrame[] = [
-    {
-      pairs: toKvPairs(object),
-      objectSizeIndex: startingIndex,
-      codeSizeIndex: null,
-      sourceObject: object,
-      isArray: Array.isArray(object)
-    }
-  ];
+  const stack: SerializationFrame[] = [makeFrame(object, startingIndex, null)];
   let index = startingIndex + 4;
 
   while (stack.length > 0) {
     const frame = stack[stack.length - 1];
-    const next = frame.pairs.next();
 
-    if (next.done) {
-      buffer[index++] = 0x00;
-      NumberUtils.setInt32LE(buffer, frame.objectSizeIndex, index - frame.objectSizeIndex);
-      if (frame.codeSizeIndex !== null) {
-        NumberUtils.setInt32LE(buffer, frame.codeSizeIndex, index - frame.codeSizeIndex);
-      }
-      path.delete(frame.sourceObject);
-      stack.pop();
-      continue;
-    }
-
-    const pair = next.value;
-    const key = pair[0];
+    // Advance to the next key-value pair, or finalize the frame if exhausted.
+    let key: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let value: any = pair[1];
+    let value: any;
+    if (frame.mapIterator !== null) {
+      const next = frame.mapIterator.next();
+      if (next.done) {
+        buffer[index++] = 0x00;
+        NumberUtils.setInt32LE(buffer, frame.objectSizeIndex, index - frame.objectSizeIndex);
+        if (frame.codeSizeIndex !== null) {
+          NumberUtils.setInt32LE(buffer, frame.codeSizeIndex, index - frame.codeSizeIndex);
+        }
+        path.delete(frame.sourceObject);
+        stack.pop();
+        continue;
+      }
+      key = next.value[0] as string;
+      value = next.value[1];
+    } else if (frame.keys !== null) {
+      if (frame.keyIndex >= frame.keys.length) {
+        buffer[index++] = 0x00;
+        NumberUtils.setInt32LE(buffer, frame.objectSizeIndex, index - frame.objectSizeIndex);
+        if (frame.codeSizeIndex !== null) {
+          NumberUtils.setInt32LE(buffer, frame.codeSizeIndex, index - frame.codeSizeIndex);
+        }
+        path.delete(frame.sourceObject);
+        stack.pop();
+        continue;
+      }
+      key = frame.keys[frame.keyIndex++];
+      value = (frame.iterTarget as Record<string, unknown>)[key];
+    } else {
+      // Array: use keyIndex as the numeric index.
+      const arr = frame.iterTarget as unknown[];
+      if (frame.keyIndex >= arr.length) {
+        buffer[index++] = 0x00;
+        NumberUtils.setInt32LE(buffer, frame.objectSizeIndex, index - frame.objectSizeIndex);
+        if (frame.codeSizeIndex !== null) {
+          NumberUtils.setInt32LE(buffer, frame.codeSizeIndex, index - frame.codeSizeIndex);
+        }
+        path.delete(frame.sourceObject);
+        stack.pop();
+        continue;
+      }
+      const i = frame.keyIndex++;
+      key = String(i);
+      value = arr[i];
+    }
 
     if (typeof value?.toBSON === 'function') {
       value = value.toBSON();
@@ -571,13 +627,7 @@ export function serializeInto(
         buffer[index++] = 0x00;
         const nestedStartIndex = index;
         path.add(value);
-        stack.push({
-          pairs: toKvPairs(value),
-          objectSizeIndex: nestedStartIndex,
-          codeSizeIndex: null,
-          sourceObject: value,
-          isArray: nestedIsArray
-        });
+        stack.push(makeFrame(value, nestedStartIndex, null));
         index += 4;
       }
     } else if (type === 'object') {
@@ -609,13 +659,7 @@ export function serializeInto(
             throw new BSONError('Cannot convert circular structure to BSON');
           }
           path.add(scope);
-          stack.push({
-            pairs: toKvPairs(scope),
-            objectSizeIndex: index,
-            codeSizeIndex: codeTotalSizeIndex,
-            sourceObject: scope,
-            isArray: false
-          });
+          stack.push(makeFrame(scope, index, codeTotalSizeIndex));
           index += 4;
         } else {
           buffer[index++] = constants.BSON_DATA_CODE;
@@ -642,13 +686,7 @@ export function serializeInto(
         index += ByteUtils.encodeUTF8Into(buffer, key, index);
         buffer[index++] = 0x00;
         path.add(orderedValues);
-        stack.push({
-          pairs: toKvPairs(orderedValues),
-          objectSizeIndex: index,
-          codeSizeIndex: null,
-          sourceObject: orderedValues,
-          isArray: false
-        });
+        stack.push(makeFrame(orderedValues, index, null));
         index += 4;
       } else if (value._bsontype === 'BSONRegExp') {
         index = serializeBSONRegExp(buffer, key, value, index);


### PR DESCRIPTION
### Description

#### Summary of Changes

#886 (NODE-5937) made `serializeInto` iterative and, along the way, started producing each frame's key/value pairs from a generator (`toKvPairs`). Generators aren't free: every `.next()` saves and restores execution state and hands back a fresh `{value, done}` object, and `Object.entries()` builds a `[key, value]` array for each field on top of that. On a flat document with 145 fields that's hundreds of throwaway allocations per `serialize`, and it cost about 54% on `flat_bson._serialize_bson`.

This PR drops the generator. `makeFrame()` calls `Object.keys()` once when the frame is created and the loop walks them by index. Maps keep an `entries()` iterator since they have no random access, and arrays index straight into `keyIndex`.

A few smaller changes in the same hot loops:

- `regexp.test(key)` replaces `key.match(regexp)`, and the `ignoreKeys` Set lookup only runs when `key[0] === '$'`.
- `value._bsontype` is read once per BSON-typed value instead of several times down the dispatch chain.
- In the deserializer, the per-field `isArray` recompute becomes a maintained `currentIsArray`; the `setValue` closure becomes a top-level `assignValue(dest, …)` with `currentDest` tracked next to `currentFrame` so the destination is never recomputed per field; and a dead `globalUTFValidation` frame field is removed.
- Both parsers now thread their frame stack as a linked list (a `prev` pointer per frame) instead of a separate array, which drops the array push/pop per nested frame (suggested by @addaleax in the #886 review).

#### What is the motivation for this change?

`flat_bson._serialize_bson` normalized throughput dropped from ~216 to ~99 after #886 merged. The perf alerting context on the `perf` build variant caught it.

## Benchmarks

`rhel90-dbx-perf-large`, Node v22.11.0, 10 000 iterations, 1 000 warmup. `normalized_throughput`, higher is better.

| Test | Baseline (`2ea8dbb`) | Regression (`0231603`) | This PR | vs Baseline | vs Regression |
|------|--------------------:|----------------------:|--------:|:-----------:|:-------------:|
| `flat_bson._serialize_bson`   | 215.58 |  98.87 | 228.42 | **+6.0%**  | **+131%** |
| `deep_bson._serialize_bson`   |  76.61 |  56.94 |  83.63 | **+9.2%**  | **+47%**  |
| `full_bson._serialize_bson`   |  92.33 |  85.76 | 132.01 | **+43%**   | **+54%**  |
| `flat_bson._deserialize_bson` |  93.62 |  90.76 |  92.23 |    −1.5%   |    +1.6%    |
| `deep_bson._deserialize_bson` |  69.00 |  63.87 |  64.19 |    −7.0%   |    +0.5%    |
| `full_bson._deserialize_bson` |  82.04 |  77.12 |  80.12 |    −2.3%   |    +3.9%    |

Serialize is back above baseline on all three document shapes. Flat and full deserialize sit within noise of baseline.

https://spruce.corp.mongodb.com/task/node_bson_perf_run_spec_benchmarks_patch_c5d1dd89d933556a9c9880152156d15caa0f293b_6a282aa58fce9500076b6fbc_26_06_09_15_00_55/trend-charts?execution=0

<table>
    <tr>
      <td><img width="1075" height="300" alt="image" src="https://github.com/user-attachments/assets/98132664-2a2d-418b-897c-3525ff7715dd" /></td>
<td><img width="1075" height="275" alt="image" src="https://github.com/user-attachments/assets/0c2fec9f-ac22-4b44-a4ac-d23ea45485d4" /></td></tr>
<td><img width="1066" height="288" alt="image" src="https://github.com/user-attachments/assets/68203e47-868b-4480-af6f-74ceed468141" /></td>
<td><img width="1081" height="285" alt="image" src="https://github.com/user-attachments/assets/b876b650-00fd-48ee-8e4f-ed1156ea9b76" /></td></tr>
<td><img width="1074" height="279" alt="image" src="https://github.com/user-attachments/assets/6556558e-eb4c-4526-9b00-53a0cbdb79e3" /></td>
<td><img width="1083" height="278" alt="image" src="https://github.com/user-attachments/assets/92adcd3c-0df5-4898-8b2e-f1140c3bb139" /></td></tr>
<td><img width="1070" height="270" alt="image" src="https://github.com/user-attachments/assets/38452372-3ce4-46d5-a184-c5204fa18ebb" /></td>
<td><img width="1070" height="276" alt="image" src="https://github.com/user-attachments/assets/e0d1b156-2d46-412a-b14c-16a47a4a3ca9" /></td></tr>
<td><img width="1075" height="271" alt="image" src="https://github.com/user-attachments/assets/0d68f1b9-bf53-4e55-b6c6-ddda5fd242b4" /></td>
<td><img width="1087" height="279" alt="image" src="https://github.com/user-attachments/assets/19cf34af-3e03-4498-9f07-72b722b80539" /></td></tr>
<td><img width="1076" height="273" alt="image" src="https://github.com/user-attachments/assets/3c6fd5b3-f4b6-4cb7-b871-82ded0cc71f3" /></td>
<td><img width="1086" height="280" alt="image" src="https://github.com/user-attachments/assets/7401ee7c-5a9b-49fe-b88b-98b6d48d39c8" /></td></tr>
<td><img width="1079" height="273" alt="image" src="https://github.com/user-attachments/assets/8156868e-d78f-43c1-acf0-dae28d222f57" /></td>
</table>

The only metric still under baseline is `deep_bson._deserialize_bson` (−7.0%), and that's structural rather than something this PR introduced. [deep_bson](https://github.com/mongodb/js-bson/blob/main/test/bench/documents/deep_bson.json) is 63 documents nested six deep, so the iterative deserializer allocates a frame object for each nested document where the old recursive code just leaned on the call stack. Those allocations are most of the gap. This PR nudges the number up (63.87 to 64.19) and makes deep serialize a lot faster, but it doesn't close it. We can probably claw the rest back with lighter or pooled frames; I left that for a follow-up, since what remains is small and inside the benchmark's run-to-run noise.

#### Driver benchmarks

I also ran the driver's spec benchmark suite end to end with `node-mongodb-native` pointed at this branch (the `performance-tests` variant), comparing against the bson `^7.2.0` it currently ships, which predates #886 and is the known-good recursive code. Nothing regressed on the BSON-sensitive benchmarks. Serialize came out at parity or faster. Deserialize was at parity apart from a ~6% dip on the 1M-tiny-document aggregate, which is the same per-document setup cost from #886 noted above and not new here. The large-document bulk-insert benchmark bounced between −22% and +5% across runs, with the slow slot moving between it and the single-document variant; a micro-benchmark and the benchmark's own ~8% mainline CV confirm that's noise from the 2.73 MB document, not the serializer.
[1 run](https://spruce.corp.mongodb.com/version/6a28567c5f93d700079108da/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[2 run](https://spruce.corp.mongodb.com/version/6a2865aa5883a70007e16084/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
