### PR TITLE
fix(NODE-7618): propagate serializing flags to the parsing frames

### DIFF
--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -10,11 +10,15 @@ export function internalCalculateObjectSize(
   serializeFunctions?: boolean,
   ignoreUndefined?: boolean
 ): number {
-  const objectStack: Document[] = [object];
+  // Each stack entry carries its own ignoreUndefined so DBRef fields can force ignoreUndefined=true
+  // regardless of the caller's setting, matching the behavior of serializeInto.
+  const objectStack: Array<{ obj: Document; ignoreUndefined: boolean }> = [
+    { obj: object, ignoreUndefined: ignoreUndefined ?? false }
+  ];
   let total = 0;
 
   while (objectStack.length > 0) {
-    const obj = objectStack.pop()!;
+    const { obj, ignoreUndefined: frameIgnoreUndefined } = objectStack.pop()!;
     total += 5; // 4-byte size field + null terminator
 
     const isObjArray = Array.isArray(obj);
@@ -33,7 +37,7 @@ export function internalCalculateObjectSize(
           array[i],
           serializeFunctions,
           true,
-          ignoreUndefined,
+          frameIgnoreUndefined,
           objectStack
         );
       }
@@ -44,7 +48,7 @@ export function internalCalculateObjectSize(
           target[key],
           serializeFunctions,
           false,
-          ignoreUndefined,
+          frameIgnoreUndefined,
           objectStack
         );
       }
@@ -62,7 +66,7 @@ function calculateElementSize(
   serializeFunctions = false,
   isArray = false,
   ignoreUndefined = false,
-  objectStack: Document[]
+  objectStack: Array<{ obj: Document; ignoreUndefined: boolean }>
 ): number {
   // If we have toBSON defined, override the current object
   if (typeof value?.toBSON === 'function') {
@@ -123,7 +127,7 @@ function calculateElementSize(
       } else if (value._bsontype === 'Code') {
         // Calculate size depending on the availability of a scope
         if (value.scope != null && Object.keys(value.scope).length > 0) {
-          objectStack.push(value.scope);
+          objectStack.push({ obj: value.scope, ignoreUndefined });
           return (
             ByteUtils.utf8ByteLength(name) +
             1 +
@@ -170,7 +174,8 @@ function calculateElementSize(
           ordered_values['$db'] = value.db;
         }
 
-        objectStack.push(ordered_values);
+        // DBRef fields always use ignoreUndefined=true to match serializeInto behavior.
+        objectStack.push({ obj: ordered_values, ignoreUndefined: true });
         return ByteUtils.utf8ByteLength(name) + 1 + 1;
       } else if (value instanceof RegExp || isRegExp(value)) {
         return (
@@ -195,7 +200,7 @@ function calculateElementSize(
           1
         );
       } else {
-        objectStack.push(value);
+        objectStack.push({ obj: value, ignoreUndefined });
         return ByteUtils.utf8ByteLength(name) + 1 + 1;
       }
     case 'function':

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -541,7 +541,14 @@ export function serializeInto(
 
   path.add(object);
 
-  let currentFrame: SerializationFrame | null = makeFrame(object, startingIndex, null, null, checkKeys, ignoreUndefined);
+  let currentFrame: SerializationFrame | null = makeFrame(
+    object,
+    startingIndex,
+    null,
+    null,
+    checkKeys,
+    ignoreUndefined
+  );
   let index = startingIndex + 4;
 
   while (currentFrame !== null) {
@@ -646,7 +653,14 @@ export function serializeInto(
         buffer[index++] = 0x00;
         const nestedStartIndex = index;
         path.add(value);
-        currentFrame = makeFrame(value, nestedStartIndex, null, frame, frame.checkKeys, frame.ignoreUndefined);
+        currentFrame = makeFrame(
+          value,
+          nestedStartIndex,
+          null,
+          frame,
+          frame.checkKeys,
+          frame.ignoreUndefined
+        );
         index += 4;
       }
     } else if (type === 'object') {
@@ -680,7 +694,14 @@ export function serializeInto(
             throw new BSONError('Cannot convert circular structure to BSON');
           }
           path.add(scope);
-          currentFrame = makeFrame(scope, index, codeTotalSizeIndex, frame, frame.checkKeys, frame.ignoreUndefined);
+          currentFrame = makeFrame(
+            scope,
+            index,
+            codeTotalSizeIndex,
+            frame,
+            frame.checkKeys,
+            frame.ignoreUndefined
+          );
           index += 4;
         } else {
           buffer[index++] = constants.BSON_DATA_CODE;

--- a/src/parser/serializer.ts
+++ b/src/parser/serializer.ts
@@ -428,13 +428,19 @@ interface SerializationFrame {
   mapIterator: IterableIterator<[unknown, unknown]> | null;
   /** The enclosing frame, or null at the root. The stack is a linked list via this field. */
   prev: SerializationFrame | null;
+  /** Whether to validate keys for this frame's document (may differ from caller, e.g. DBRef uses false). */
+  checkKeys: boolean;
+  /** Whether undefined values are skipped (may differ from caller, e.g. DBRef uses true). */
+  ignoreUndefined: boolean;
 }
 
 function makeFrame(
   sourceObject: Document,
   objectSizeIndex: number,
   codeSizeIndex: number | null,
-  prev: SerializationFrame | null
+  prev: SerializationFrame | null,
+  checkKeys: boolean,
+  ignoreUndefined: boolean
 ): SerializationFrame {
   if (Array.isArray(sourceObject)) {
     return {
@@ -446,7 +452,9 @@ function makeFrame(
       keys: null,
       keyIndex: 0,
       mapIterator: null,
-      prev
+      prev,
+      checkKeys,
+      ignoreUndefined
     };
   }
   if (sourceObject instanceof Map || isMap(sourceObject)) {
@@ -459,7 +467,9 @@ function makeFrame(
       keys: null,
       keyIndex: 0,
       mapIterator: (sourceObject as Map<unknown, unknown>).entries(),
-      prev
+      prev,
+      checkKeys,
+      ignoreUndefined
     };
   }
   // Plain object: call toBSON() if defined to obtain the object to iterate.
@@ -481,7 +491,9 @@ function makeFrame(
     keys: Object.keys(target as object),
     keyIndex: 0,
     mapIterator: null,
-    prev
+    prev,
+    checkKeys,
+    ignoreUndefined
   };
 }
 
@@ -529,7 +541,7 @@ export function serializeInto(
 
   path.add(object);
 
-  let currentFrame: SerializationFrame | null = makeFrame(object, startingIndex, null, null);
+  let currentFrame: SerializationFrame | null = makeFrame(object, startingIndex, null, null, checkKeys, ignoreUndefined);
   let index = startingIndex + 4;
 
   while (currentFrame !== null) {
@@ -592,7 +604,7 @@ export function serializeInto(
       if (regexp.test(key)) {
         throw new BSONError('key ' + key + ' must not contain null bytes');
       }
-      if (checkKeys) {
+      if (frame.checkKeys) {
         if ('$' === key[0]) {
           throw new BSONError('key ' + key + " must not start with '$'");
         } else if (key.includes('.')) {
@@ -604,7 +616,7 @@ export function serializeInto(
     const type = typeof value;
 
     if (value === undefined) {
-      if (frame.isArray || ignoreUndefined === false) {
+      if (frame.isArray || frame.ignoreUndefined === false) {
         index = serializeNull(buffer, key, value, index);
       }
     } else if (value === null) {
@@ -634,7 +646,7 @@ export function serializeInto(
         buffer[index++] = 0x00;
         const nestedStartIndex = index;
         path.add(value);
-        currentFrame = makeFrame(value, nestedStartIndex, null, frame);
+        currentFrame = makeFrame(value, nestedStartIndex, null, frame, frame.checkKeys, frame.ignoreUndefined);
         index += 4;
       }
     } else if (type === 'object') {
@@ -668,7 +680,7 @@ export function serializeInto(
             throw new BSONError('Cannot convert circular structure to BSON');
           }
           path.add(scope);
-          currentFrame = makeFrame(scope, index, codeTotalSizeIndex, frame);
+          currentFrame = makeFrame(scope, index, codeTotalSizeIndex, frame, frame.checkKeys, frame.ignoreUndefined);
           index += 4;
         } else {
           buffer[index++] = constants.BSON_DATA_CODE;
@@ -695,7 +707,7 @@ export function serializeInto(
         index += ByteUtils.encodeUTF8Into(buffer, key, index);
         buffer[index++] = 0x00;
         path.add(orderedValues);
-        currentFrame = makeFrame(orderedValues, index, null, frame);
+        currentFrame = makeFrame(orderedValues, index, null, frame, false, true);
         index += 4;
       } else if (tag === 'BSONRegExp') {
         index = serializeBSONRegExp(buffer, key, value, index);

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -46,23 +46,6 @@ describe('deserializer()', () => {
       expect(result.fields).to.deep.equal({});
     });
 
-    it('does not throw when checkKeys=true and a DBRef has a $-prefixed extra field', () => {
-      // Old serializeDBRef always used checkKeys=false internally.
-      // The new iterative serializer applies the ambient checkKeys to DBRef fields,
-      // causing this to throw BSONError when it should not.
-      const dbref = new BSON.DBRef('col', new BSON.ObjectId(), undefined, { $custom: 1 });
-      expect(() => BSON.serialize({ ref: dbref }, { checkKeys: true })).not.to.throw();
-    });
-
-    it('omits undefined DBRef extra fields even when ignoreUndefined=false', () => {
-      // Old serializeDBRef hardcoded ignoreUndefined=true for its inner serialization.
-      // New code uses the ambient value, so undefined fields become BSON null when
-      // the caller sets ignoreUndefined=false.
-      const dbref = new BSON.DBRef('col', new BSON.ObjectId(), undefined, { extra: undefined });
-      const bytes = BSON.serialize({ ref: dbref }, { ignoreUndefined: false });
-      const result = BSON.deserialize(bytes) as { ref: BSON.DBRef };
-      expect(result.ref.fields).not.to.have.property('extra');
-    });
   });
 
   describe('when the fieldsAsRaw options is present and has a value that corresponds to a key in the object', () => {

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -45,7 +45,6 @@ describe('deserializer()', () => {
       expect(result).to.have.property('_bsontype', 'DBRef');
       expect(result.fields).to.deep.equal({});
     });
-
   });
 
   describe('when the fieldsAsRaw options is present and has a value that corresponds to a key in the object', () => {

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -45,6 +45,24 @@ describe('deserializer()', () => {
       expect(result).to.have.property('_bsontype', 'DBRef');
       expect(result.fields).to.deep.equal({});
     });
+
+    it('does not throw when checkKeys=true and a DBRef has a $-prefixed extra field', () => {
+      // Old serializeDBRef always used checkKeys=false internally.
+      // The new iterative serializer applies the ambient checkKeys to DBRef fields,
+      // causing this to throw BSONError when it should not.
+      const dbref = new BSON.DBRef('col', new BSON.ObjectId(), undefined, { $custom: 1 });
+      expect(() => BSON.serialize({ ref: dbref }, { checkKeys: true })).not.to.throw();
+    });
+
+    it('omits undefined DBRef extra fields even when ignoreUndefined=false', () => {
+      // Old serializeDBRef hardcoded ignoreUndefined=true for its inner serialization.
+      // New code uses the ambient value, so undefined fields become BSON null when
+      // the caller sets ignoreUndefined=false.
+      const dbref = new BSON.DBRef('col', new BSON.ObjectId(), undefined, { extra: undefined });
+      const bytes = BSON.serialize({ ref: dbref }, { ignoreUndefined: false });
+      const result = BSON.deserialize(bytes) as { ref: BSON.DBRef };
+      expect(result.ref.fields).not.to.have.property('extra');
+    });
   });
 
   describe('when the fieldsAsRaw options is present and has a value that corresponds to a key in the object', () => {

--- a/test/node/parser/serializer.test.ts
+++ b/test/node/parser/serializer.test.ts
@@ -42,6 +42,27 @@ describe('serialize()', () => {
     expect(emptyDocumentNull).to.deep.equal(nestedNull);
   });
 
+  it('does not throw when checkKeys=true and a DBRef has a $-prefixed extra field', () => {
+    const dbref = new BSON.DBRef('col', new BSON.ObjectId(), undefined, { $custom: 1 });
+    const bytes = BSON.serialize({ ref: dbref }, { checkKeys: true });
+    const result = BSON.deserialize(bytes) as { ref: BSON.DBRef };
+    expect(result.ref).to.have.property('$custom', 1);
+  });
+
+  it('omits undefined DBRef extra fields even when ignoreUndefined=false', () => {
+    const dbref = new BSON.DBRef('col', new BSON.ObjectId(), undefined, { extra: undefined });
+    const bytes = BSON.serialize({ ref: dbref }, { ignoreUndefined: false });
+    const result = BSON.deserialize(bytes) as { ref: BSON.DBRef };
+    expect(result.ref.fields).not.to.have.property('extra');
+  });
+
+  it('calculateObjectSize matches serialize byteLength for DBRef with undefined fields when ignoreUndefined=false', () => {
+    const dbref = new BSON.DBRef('col', new BSON.ObjectId(), undefined, { extra: undefined });
+    const doc = { ref: dbref };
+    const bytes = BSON.serialize(doc, { ignoreUndefined: false });
+    expect(BSON.calculateObjectSize(doc, { ignoreUndefined: false })).to.equal(bytes.byteLength);
+  });
+
   describe('when serializing deeply nested documents', () => {
     it('can serialize a document with 20,000 nesting levels without a stack overflow', () => {
       // Calling serialize directly: if it throws, mocha fails the test.
@@ -90,6 +111,20 @@ describe('serialize()', () => {
         const dbref = new BSON.DBRef('users', new BSON.ObjectId(), db);
         const doc = { ref: dbref };
         expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+      });
+    }
+  });
+
+  describe('DBRef serialization consistency with calculateObjectSize and ignoreUndefined', () => {
+    for (const [label, db] of [
+      ['empty string db', ''],
+      ['defined db', 'mydb'],
+      ['undefined db', undefined]
+    ] as const) {
+      it(`calculateObjectSize matches serialize byte count for DBRef with ${label} and ignoreUndefined option`, () => {
+        const dbref = new BSON.DBRef('users', new BSON.ObjectId(), db, { extra: undefined });
+        const doc = { ref: dbref };
+        expect(BSON.calculateObjectSize(doc, { ignoreUndefined: false })).to.equal(BSON.serialize(doc, { ignoreUndefined: false }).byteLength);
       });
     }
   });

--- a/test/node/parser/serializer.test.ts
+++ b/test/node/parser/serializer.test.ts
@@ -124,7 +124,9 @@ describe('serialize()', () => {
       it(`calculateObjectSize matches serialize byte count for DBRef with ${label} and ignoreUndefined option`, () => {
         const dbref = new BSON.DBRef('users', new BSON.ObjectId(), db, { extra: undefined });
         const doc = { ref: dbref };
-        expect(BSON.calculateObjectSize(doc, { ignoreUndefined: false })).to.equal(BSON.serialize(doc, { ignoreUndefined: false }).byteLength);
+        expect(BSON.calculateObjectSize(doc, { ignoreUndefined: false })).to.equal(
+          BSON.serialize(doc, { ignoreUndefined: false }).byteLength
+        );
       });
     }
   });


### PR DESCRIPTION
### Description

#### Summary of Changes

Pass two extra flags into the serialization frames: `checkKeys` and `ignoreUndefined`. This allows the nested structures to be properly serialized, since we are now configuring these values as appropriate, instead of using the same input for everything.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket