### PR TITLE
fix(NODE-7619): reject embedded BSON document sizes below minimum valid length

### DIFF
--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -704,6 +704,9 @@ function deserializeObject(
       // Decode the size of the object document
       const objectSize = NumberUtils.getInt32LE(buffer, index);
 
+      if (objectSize <= 0 || objectSize > buffer.length - index)
+        throw new BSONError('bad scope document size in code_w_scope');
+
       // Check if field length is too short
       if (totalSize < 4 + 4 + objectSize + stringSize) {
         throw new BSONError('code_w_scope total size is too short, truncating scope');

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -426,7 +426,7 @@ function deserializeObject(
     } else if (elementType === constants.BSON_DATA_OBJECT) {
       const objectSize = NumberUtils.getInt32LE(buffer, index);
 
-      if (objectSize <= 0 || objectSize > buffer.length - index)
+      if (objectSize < 5 || objectSize > buffer.length - index)
         throw new BSONError('bad embedded document length in bson');
 
       // We have a raw value: either the global raw option, or the parent frame requested raw elements.
@@ -456,7 +456,7 @@ function deserializeObject(
     } else if (elementType === constants.BSON_DATA_ARRAY) {
       const objectSize = NumberUtils.getInt32LE(buffer, index);
 
-      if (objectSize <= 0 || objectSize > buffer.length - index)
+      if (objectSize < 5 || objectSize > buffer.length - index)
         throw new BSONError('bad embedded array length in bson');
 
       // Stop index
@@ -704,7 +704,7 @@ function deserializeObject(
       // Decode the size of the object document
       const objectSize = NumberUtils.getInt32LE(buffer, index);
 
-      if (objectSize <= 0 || objectSize > buffer.length - index)
+      if (objectSize < 5 || objectSize > buffer.length - index)
         throw new BSONError('bad scope document size in code_w_scope');
 
       // Check if field length is too short

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -81,6 +81,32 @@ describe('deserializer()', () => {
       expect(code.scope.$id).to.be.instanceOf(BSON.ObjectId);
       expect(code.scope.$id.toHexString()).to.equal(oid.toHexString());
     });
+
+    it('throws a precise error when the scope document size field is negative', () => {
+      // Craft a code_w_scope element whose scope objectSize = -1.
+      //
+      // The totalSize cross-check computes:
+      //   4 (totalSize field) + 4 (string_size field) + stringSize + objectSize
+      // With stringSize = 6 ("hello\0") and objectSize = -1:
+      //   4 + 4 + 6 + (-1) = 13, which equals totalSize = 13.
+      // Both inequality guards pass, and 13 also clears the minimum-length check (>= 13).
+      //
+      // Without the objectSize <= 0 guard the frame is created with lastIndex = _index - 1.
+      // Since lastIndex is already behind the current index, the outer null terminator is
+      // consumed by the scope's terminator check, which fails the exact-match (index !== lastIndex)
+      // and throws 'Bad BSON Document: object not properly terminated' — pointing at the outer
+      // document rather than the malformed scope size field.  The fix produces a precise error
+      // from the right layer instead.
+      const buf = bufferFromHexArray([
+        '0f',                                    // BSON_DATA_CODE_W_SCOPE
+        '6600',                                  // key 'f' + null
+        int32LEToHex(13),                        // totalSize = 4+4+6+(-1) = 13
+        int32LEToHex(6),                         // code string length = 6 ("hello" + null)
+        '68656c6c6f00',                          // code string "hello\0"
+        'ffffffff'                               // scope objectSize = -1 — the malicious value
+      ]);
+      expect(() => BSON.deserialize(buf)).to.throw(BSON.BSONError, 'bad scope document size');
+    });
   });
 
   describe('when passing an evalFunctions option', () => {

--- a/test/node/parser/deserializer.test.ts
+++ b/test/node/parser/deserializer.test.ts
@@ -83,27 +83,30 @@ describe('deserializer()', () => {
     });
 
     it('throws a precise error when the scope document size field is negative', () => {
-      // Craft a code_w_scope element whose scope objectSize = -1.
-      //
-      // The totalSize cross-check computes:
-      //   4 (totalSize field) + 4 (string_size field) + stringSize + objectSize
-      // With stringSize = 6 ("hello\0") and objectSize = -1:
-      //   4 + 4 + 6 + (-1) = 13, which equals totalSize = 13.
-      // Both inequality guards pass, and 13 also clears the minimum-length check (>= 13).
-      //
-      // Without the objectSize <= 0 guard the frame is created with lastIndex = _index - 1.
-      // Since lastIndex is already behind the current index, the outer null terminator is
-      // consumed by the scope's terminator check, which fails the exact-match (index !== lastIndex)
-      // and throws 'Bad BSON Document: object not properly terminated' — pointing at the outer
-      // document rather than the malformed scope size field.  The fix produces a precise error
-      // from the right layer instead.
+      // objectSize = -1 satisfies the totalSize cross-check (4+4+6+(-1) = 13 = totalSize),
+      // so only the direct size guard catches it.
       const buf = bufferFromHexArray([
-        '0f',                                    // BSON_DATA_CODE_W_SCOPE
-        '6600',                                  // key 'f' + null
-        int32LEToHex(13),                        // totalSize = 4+4+6+(-1) = 13
-        int32LEToHex(6),                         // code string length = 6 ("hello" + null)
-        '68656c6c6f00',                          // code string "hello\0"
-        'ffffffff'                               // scope objectSize = -1 — the malicious value
+        '0f', // BSON_DATA_CODE_W_SCOPE
+        '6600', // key 'f' + null
+        int32LEToHex(13), // totalSize = 4+4+6+(-1) = 13
+        int32LEToHex(6), // code string length = 6 ("hello" + null)
+        '68656c6c6f00', // code string "hello\0"
+        'ffffffff' // scope objectSize = -1
+      ]);
+      expect(() => BSON.deserialize(buf)).to.throw(BSON.BSONError, 'bad scope document size');
+    });
+
+    it('throws a precise error when the scope document size is too small to be a valid BSON document', () => {
+      // objectSize = 4 is positive so it passes a naive (<= 0) guard, but a valid BSON document
+      // requires at least 5 bytes: the 4-byte int32 size header plus the 0x00 terminator.
+      // totalSize = 4+4+6+4 = 18, which satisfies the cross-check, so only the < 5 guard catches it.
+      const buf = bufferFromHexArray([
+        '0f', // BSON_DATA_CODE_W_SCOPE
+        '6600', // key 'f' + null
+        int32LEToHex(18), // totalSize = 4+4+6+4 = 18
+        int32LEToHex(6), // code string length = 6 ("hello" + null)
+        '68656c6c6f00', // code string "hello\0"
+        int32LEToHex(4) // scope objectSize = 4 — positive but structurally impossible
       ]);
       expect(() => BSON.deserialize(buf)).to.throw(BSON.BSONError, 'bad scope document size');
     });
@@ -312,6 +315,16 @@ describe('deserializer()', () => {
       );
     });
 
+    it('throws "bad embedded array length in bson" for a nested array with a too-small size', () => {
+      const valid = Buffer.from(BSON.serialize({ a: [new BSON.Int32(1)] }));
+      const arraySizeOffset = 7;
+      valid.writeInt32LE(4, arraySizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(
+        BSON.BSONError,
+        'bad embedded array length in bson'
+      );
+    });
+
     it('throws "bad embedded array length in bson" for a nested array whose size exceeds the buffer', () => {
       const valid = Buffer.from(BSON.serialize({ a: [new BSON.Int32(1)] }));
       const arraySizeOffset = 7;
@@ -319,6 +332,47 @@ describe('deserializer()', () => {
       expect(() => BSON.deserialize(valid)).to.throw(
         BSON.BSONError,
         'bad embedded array length in bson'
+      );
+    });
+
+    it('throws "bad embedded document length in bson" for a nested object with size zero', () => {
+      const valid = Buffer.from(BSON.serialize({ a: { b: new BSON.Int32(1) } }));
+      // Layout: [outer size(4)][0x03 type(1)]['a\0'(2)][inner object size(4)...]
+      const objectSizeOffset = 7;
+      valid.writeInt32LE(0, objectSizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(
+        BSON.BSONError,
+        'bad embedded document length in bson'
+      );
+    });
+
+    it('throws "bad embedded document length in bson" for a nested object with a negative size', () => {
+      const valid = Buffer.from(BSON.serialize({ a: { b: new BSON.Int32(1) } }));
+      const objectSizeOffset = 7;
+      valid.writeInt32LE(-1, objectSizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(
+        BSON.BSONError,
+        'bad embedded document length in bson'
+      );
+    });
+
+    it('throws "bad embedded document length in bson" for a nested object with a too-small size', () => {
+      const valid = Buffer.from(BSON.serialize({ a: { b: new BSON.Int32(1) } }));
+      const objectSizeOffset = 7;
+      valid.writeInt32LE(4, objectSizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(
+        BSON.BSONError,
+        'bad embedded document length in bson'
+      );
+    });
+
+    it('throws "bad embedded document length in bson" for a nested object whose size exceeds the buffer', () => {
+      const valid = Buffer.from(BSON.serialize({ a: { b: new BSON.Int32(1) } }));
+      const objectSizeOffset = 7;
+      valid.writeInt32LE(valid.length + 1, objectSizeOffset);
+      expect(() => BSON.deserialize(valid)).to.throw(
+        BSON.BSONError,
+        'bad embedded document length in bson'
       );
     });
   });


### PR DESCRIPTION
### Description

#### Summary of Changes

Tighten the `objectSize` guard from `<= 0` to `< 5` for embedded objects, arrays, and code_w_scope scope documents. A valid BSON document requires at least 5 bytes (4-byte int32 size header + 0x00 terminator), so sizes 1–4 are structurally impossible and previously produced a misleading error.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
