### PR TITLE
perf(NODE-6246): store ObjectId bytes as four packed integers

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -71,22 +71,22 @@ export class ObjectId extends BSONValue {
    * inline, which keeps the object small. The fields are enumerable own properties (not `#`
    * private) so two ObjectIds with the same bytes stay equal under structural comparison such
    * as deepStrictEqual.
+   * @internal
    */
-  // @internal
   private i0!: number;
-  // @internal
+  /** @internal */
   private i1!: number;
-  // @internal
+  /** @internal */
   private i2!: number;
-  // @internal
+  /** @internal */
   private i3!: number;
 
   /** Pack 12 bytes into the four integer fields. @internal */
-  private setFromBytes(b: Uint8Array): void {
-    this.i0 = (b[0] << 16) | (b[1] << 8) | b[2];
-    this.i1 = (b[3] << 16) | (b[4] << 8) | b[5];
-    this.i2 = (b[6] << 16) | (b[7] << 8) | b[8];
-    this.i3 = (b[9] << 16) | (b[10] << 8) | b[11];
+  private setFromBytes(b: Uint8Array, offset = 0): void {
+    this.i0 = (b[offset] << 16) | (b[offset + 1] << 8) | b[offset + 2];
+    this.i1 = (b[offset + 3] << 16) | (b[offset + 4] << 8) | b[offset + 5];
+    this.i2 = (b[offset + 6] << 16) | (b[offset + 7] << 8) | b[offset + 8];
+    this.i3 = (b[offset + 9] << 16) | (b[offset + 10] << 8) | b[offset + 11];
   }
 
   /**
@@ -159,12 +159,23 @@ export class ObjectId extends BSONValue {
    */
   constructor(inputId?: string | ObjectId | ObjectIdLike | Uint8Array);
   /**
+   * Read 12 bytes from `source` starting at `offset` into a new ObjectId, without allocating an
+   * intermediate view. Used by the deserializer on a hot path.
+   * @internal
+   */
+  constructor(source: Uint8Array, offset: number);
+  /**
    * Create a new ObjectId.
    *
    * @param inputId - An input value to create a new ObjectId from.
    */
-  constructor(inputId?: string | ObjectId | ObjectIdLike | Uint8Array) {
+  constructor(inputId?: string | ObjectId | ObjectIdLike | Uint8Array, offset?: number) {
     super();
+    if (typeof offset === 'number') {
+      // Fast path used by the deserializer: read the 12 bytes directly from source at offset.
+      this.setFromBytes(inputId as Uint8Array, offset);
+      return;
+    }
     // workingId is set based on type of input and whether valid id exists for the input
     let workingId;
     if (typeof inputId === 'object' && inputId && 'id' in inputId) {

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -68,9 +68,8 @@ export class ObjectId extends BSONValue {
   /**
    * The 12 ObjectId bytes packed as four 24-bit integers (bytes 0-2, 3-5, 6-8, 9-11).
    * The 24-bit width keeps each value inside V8's small-integer (Smi) range so it stays stored
-   * inline, which keeps the object small. The fields are enumerable own properties (not `#`
-   * private) so two ObjectIds with the same bytes stay equal under structural comparison such
-   * as deepStrictEqual.
+   * inline, which keeps the object small. The fields are enumerable own properties, so two
+   * ObjectIds with the same bytes stay equal under structural comparison such as deepStrictEqual.
    * @internal
    */
   private i0!: number;
@@ -159,8 +158,8 @@ export class ObjectId extends BSONValue {
    */
   constructor(inputId?: string | ObjectId | ObjectIdLike | Uint8Array);
   /**
-   * Read 12 bytes from `source` starting at `offset` into a new ObjectId, without allocating an
-   * intermediate view. Used by the deserializer on a hot path.
+   * Read 12 bytes from `source` starting at `offset` directly into the packed fields.
+   * Used by the deserializer on a hot path.
    * @internal
    */
   constructor(source: Uint8Array, offset: number);
@@ -203,7 +202,11 @@ export class ObjectId extends BSONValue {
       this.i2 = (pu[2] << 16) | (pu[3] << 8) | pu[4];
       this.i3 = inc & 0xffffff;
     } else if (ArrayBuffer.isView(workingId) && workingId.byteLength === 12) {
-      this.setFromBytes(workingId);
+      // Normalize a non-Uint8Array view (DataView, Int8Array, ...) to a byte buffer so its
+      // bytes are read correctly.
+      this.setFromBytes(
+        workingId instanceof Uint8Array ? workingId : ByteUtils.toLocalBufferType(workingId)
+      );
     } else if (typeof workingId === 'string') {
       if (ObjectId.validateHexString(workingId)) {
         this.setFromHex(workingId);
@@ -244,9 +247,10 @@ export class ObjectId extends BSONValue {
   }
 
   set id(value: Uint8Array) {
-    this.setFromBytes(value);
+    const bytes = value instanceof Uint8Array ? value : ByteUtils.toLocalBufferType(value);
+    this.setFromBytes(bytes);
     if (ObjectId.cacheHexString) {
-      __idCache.set(this, ByteUtils.toHex(value));
+      __idCache.set(this, ByteUtils.toHex(bytes));
     }
   }
 
@@ -381,9 +385,15 @@ export class ObjectId extends BSONValue {
       return false;
     }
 
-    if (ObjectId.is(otherId) && typeof otherId.i3 === 'number') {
-      // Same-build ObjectId: compare the packed integer fields directly. i3 (the counter /
-      // low bytes) differs most often between two ids, so checking it first fails fast.
+    if (
+      ObjectId.is(otherId) &&
+      typeof otherId.i0 === 'number' &&
+      typeof otherId.i1 === 'number' &&
+      typeof otherId.i2 === 'number' &&
+      typeof otherId.i3 === 'number'
+    ) {
+      // Same-build ObjectId (all four packed fields present): compare them directly. i3 (the
+      // counter / low bytes) differs most often between two ids, so checking it first fails fast.
       return (
         this.i3 === otherId.i3 &&
         this.i0 === otherId.i0 &&

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -178,6 +178,21 @@ export class ObjectId extends BSONValue {
     // workingId is set based on type of input and whether valid id exists for the input
     let workingId;
     if (typeof inputId === 'object' && inputId && 'id' in inputId) {
+      if (
+        ObjectId.is(inputId) &&
+        typeof inputId.i0 === 'number' &&
+        typeof inputId.i1 === 'number' &&
+        typeof inputId.i2 === 'number' &&
+        typeof inputId.i3 === 'number'
+      ) {
+        // Same-build ObjectId: copy the packed fields directly. The general path below would
+        // hit the id getter (which allocates) and then re-decode a hex round trip.
+        this.i0 = inputId.i0;
+        this.i1 = inputId.i1;
+        this.i2 = inputId.i2;
+        this.i3 = inputId.i3;
+        return;
+      }
       if (typeof inputId.id !== 'string' && !ArrayBuffer.isView(inputId.id)) {
         throw new BSONError('Argument passed in must have an id that is of type string or Buffer');
       }

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -246,17 +246,17 @@ export class ObjectId extends BSONValue {
    */
   get id(): Uint8Array {
     const b = ByteUtils.allocateUnsafe(12);
-    b[0] = (this.i0 >> 16) & 0xff;
-    b[1] = (this.i0 >> 8) & 0xff;
+    b[0] = (this.i0 >>> 16) & 0xff;
+    b[1] = (this.i0 >>> 8) & 0xff;
     b[2] = this.i0 & 0xff;
-    b[3] = (this.i1 >> 16) & 0xff;
-    b[4] = (this.i1 >> 8) & 0xff;
+    b[3] = (this.i1 >>> 16) & 0xff;
+    b[4] = (this.i1 >>> 8) & 0xff;
     b[5] = this.i1 & 0xff;
-    b[6] = (this.i2 >> 16) & 0xff;
-    b[7] = (this.i2 >> 8) & 0xff;
+    b[6] = (this.i2 >>> 16) & 0xff;
+    b[7] = (this.i2 >>> 8) & 0xff;
     b[8] = this.i2 & 0xff;
-    b[9] = (this.i3 >> 16) & 0xff;
-    b[10] = (this.i3 >> 8) & 0xff;
+    b[9] = (this.i3 >>> 16) & 0xff;
+    b[10] = (this.i3 >>> 8) & 0xff;
     b[11] = this.i3 & 0xff;
     return b;
   }
@@ -305,17 +305,17 @@ export class ObjectId extends BSONValue {
     const i2 = this.i2;
     const i3 = this.i3;
     const hexString =
-      byteToHex[(i0 >> 16) & 0xff] +
-      byteToHex[(i0 >> 8) & 0xff] +
+      byteToHex[(i0 >>> 16) & 0xff] +
+      byteToHex[(i0 >>> 8) & 0xff] +
       byteToHex[i0 & 0xff] +
-      byteToHex[(i1 >> 16) & 0xff] +
-      byteToHex[(i1 >> 8) & 0xff] +
+      byteToHex[(i1 >>> 16) & 0xff] +
+      byteToHex[(i1 >>> 8) & 0xff] +
       byteToHex[i1 & 0xff] +
-      byteToHex[(i2 >> 16) & 0xff] +
-      byteToHex[(i2 >> 8) & 0xff] +
+      byteToHex[(i2 >>> 16) & 0xff] +
+      byteToHex[(i2 >>> 8) & 0xff] +
       byteToHex[i2 & 0xff] +
-      byteToHex[(i3 >> 16) & 0xff] +
-      byteToHex[(i3 >> 8) & 0xff] +
+      byteToHex[(i3 >>> 16) & 0xff] +
+      byteToHex[(i3 >>> 8) & 0xff] +
       byteToHex[i3 & 0xff];
 
     if (ObjectId.cacheHexString) {
@@ -359,8 +359,8 @@ export class ObjectId extends BSONValue {
 
     // 3-byte counter
     buffer[11] = inc & 0xff;
-    buffer[10] = (inc >> 8) & 0xff;
-    buffer[9] = (inc >> 16) & 0xff;
+    buffer[10] = (inc >>> 8) & 0xff;
+    buffer[9] = (inc >>> 16) & 0xff;
 
     return buffer;
   }
@@ -448,17 +448,17 @@ export class ObjectId extends BSONValue {
 
   /** @internal */
   serializeInto(uint8array: Uint8Array, index: number): 12 {
-    uint8array[index] = (this.i0 >> 16) & 0xff;
-    uint8array[index + 1] = (this.i0 >> 8) & 0xff;
+    uint8array[index] = (this.i0 >>> 16) & 0xff;
+    uint8array[index + 1] = (this.i0 >>> 8) & 0xff;
     uint8array[index + 2] = this.i0 & 0xff;
-    uint8array[index + 3] = (this.i1 >> 16) & 0xff;
-    uint8array[index + 4] = (this.i1 >> 8) & 0xff;
+    uint8array[index + 3] = (this.i1 >>> 16) & 0xff;
+    uint8array[index + 4] = (this.i1 >>> 8) & 0xff;
     uint8array[index + 5] = this.i1 & 0xff;
-    uint8array[index + 6] = (this.i2 >> 16) & 0xff;
-    uint8array[index + 7] = (this.i2 >> 8) & 0xff;
+    uint8array[index + 6] = (this.i2 >>> 16) & 0xff;
+    uint8array[index + 7] = (this.i2 >>> 8) & 0xff;
     uint8array[index + 8] = this.i2 & 0xff;
-    uint8array[index + 9] = (this.i3 >> 16) & 0xff;
-    uint8array[index + 10] = (this.i3 >> 8) & 0xff;
+    uint8array[index + 9] = (this.i3 >>> 16) & 0xff;
+    uint8array[index + 10] = (this.i3 >>> 8) & 0xff;
     uint8array[index + 11] = this.i3 & 0xff;
     return 12;
   }

--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -7,6 +7,16 @@ import { NumberUtils } from './utils/number_utils';
 /** ObjectId hexString cache @internal */
 const __idCache = new WeakMap(); // TODO(NODE-6549): convert this to #__id private field when target updated to ES2022
 
+/** byte (0-255): its 2-character lowercase hex pair @internal */
+const byteToHex: string[] = [];
+for (let n = 0; n < 256; n++) byteToHex.push(n.toString(16).padStart(2, '0'));
+
+/** hex char code: nibble (0-15); indices are the codes of 0-9, a-f, A-F @internal */
+const hexCharCodeToNibble = new Int8Array(103);
+for (let c = 48; c <= 57; c++) hexCharCodeToNibble[c] = c - 48; // '0'-'9'
+for (let c = 65; c <= 70; c++) hexCharCodeToNibble[c] = c - 55; // 'A'-'F'
+for (let c = 97; c <= 102; c++) hexCharCodeToNibble[c] = c - 87; // 'a'-'f'
+
 /** @public */
 export interface ObjectIdLike {
   id: string | Uint8Array;
@@ -55,8 +65,66 @@ export class ObjectId extends BSONValue {
 
   static cacheHexString: boolean;
 
-  /** ObjectId Bytes @internal */
-  private buffer!: Uint8Array;
+  /**
+   * The 12 ObjectId bytes packed as four 24-bit integers (bytes 0-2, 3-5, 6-8, 9-11).
+   * The 24-bit width keeps each value inside V8's small-integer (Smi) range so it stays stored
+   * inline, which keeps the object small. The fields are enumerable own properties (not `#`
+   * private) so two ObjectIds with the same bytes stay equal under structural comparison such
+   * as deepStrictEqual.
+   */
+  // @internal
+  private i0!: number;
+  // @internal
+  private i1!: number;
+  // @internal
+  private i2!: number;
+  // @internal
+  private i3!: number;
+
+  /** Pack 12 bytes into the four integer fields. @internal */
+  private setFromBytes(b: Uint8Array): void {
+    this.i0 = (b[0] << 16) | (b[1] << 8) | b[2];
+    this.i1 = (b[3] << 16) | (b[4] << 8) | b[5];
+    this.i2 = (b[6] << 16) | (b[7] << 8) | b[8];
+    this.i3 = (b[9] << 16) | (b[10] << 8) | b[11];
+  }
+
+  /**
+   * Pack a validated 24-character hex string into the four integer fields. The caller must have
+   * already validated the string; every character is assumed to be a hex digit.
+   * @internal
+   */
+  private setFromHex(s: string): void {
+    const t = hexCharCodeToNibble;
+    this.i0 =
+      (t[s.charCodeAt(0)] << 20) |
+      (t[s.charCodeAt(1)] << 16) |
+      (t[s.charCodeAt(2)] << 12) |
+      (t[s.charCodeAt(3)] << 8) |
+      (t[s.charCodeAt(4)] << 4) |
+      t[s.charCodeAt(5)];
+    this.i1 =
+      (t[s.charCodeAt(6)] << 20) |
+      (t[s.charCodeAt(7)] << 16) |
+      (t[s.charCodeAt(8)] << 12) |
+      (t[s.charCodeAt(9)] << 8) |
+      (t[s.charCodeAt(10)] << 4) |
+      t[s.charCodeAt(11)];
+    this.i2 =
+      (t[s.charCodeAt(12)] << 20) |
+      (t[s.charCodeAt(13)] << 16) |
+      (t[s.charCodeAt(14)] << 12) |
+      (t[s.charCodeAt(15)] << 8) |
+      (t[s.charCodeAt(16)] << 4) |
+      t[s.charCodeAt(17)];
+    this.i3 =
+      (t[s.charCodeAt(18)] << 20) |
+      (t[s.charCodeAt(19)] << 16) |
+      (t[s.charCodeAt(20)] << 12) |
+      (t[s.charCodeAt(21)] << 8) |
+      (t[s.charCodeAt(22)] << 4) |
+      t[s.charCodeAt(23)];
+  }
 
   /** To generate a new ObjectId, use ObjectId() with no argument. */
   constructor();
@@ -114,15 +182,20 @@ export class ObjectId extends BSONValue {
 
     // The following cases use workingId to construct an ObjectId
     if (workingId == null) {
-      // The most common use case (blank id, new objectId instance)
-      // Generate a new id
-      this.buffer = ObjectId.generate();
+      // The most common use case (blank id, new objectId instance):
+      // generate a new id directly into the packed fields.
+      const time = Math.floor(Date.now() / 1000);
+      const inc = ObjectId.getInc();
+      const pu = ObjectId.PROCESS_UNIQUE!;
+      this.i0 = (time >>> 8) & 0xffffff;
+      this.i1 = ((time & 0xff) << 16) | (pu[0] << 8) | pu[1];
+      this.i2 = (pu[2] << 16) | (pu[3] << 8) | pu[4];
+      this.i3 = inc & 0xffffff;
     } else if (ArrayBuffer.isView(workingId) && workingId.byteLength === 12) {
-      // If instanceof matches we can escape calling ensure buffer in Node.js environments
-      this.buffer = ByteUtils.toLocalBufferType(workingId);
+      this.setFromBytes(workingId);
     } else if (typeof workingId === 'string') {
       if (ObjectId.validateHexString(workingId)) {
-        this.buffer = ByteUtils.fromHex(workingId);
+        this.setFromHex(workingId);
         // If we are caching the hex string
         if (ObjectId.cacheHexString) {
           __idCache.set(this, workingId);
@@ -138,15 +211,29 @@ export class ObjectId extends BSONValue {
   }
 
   /**
-   * The ObjectId bytes
+   * The ObjectId bytes, rebuilt from the packed integer fields on each access. Every read
+   * returns a freshly allocated 12-byte buffer.
    * @readonly
    */
   get id(): Uint8Array {
-    return this.buffer;
+    const b = ByteUtils.allocateUnsafe(12);
+    b[0] = (this.i0 >> 16) & 0xff;
+    b[1] = (this.i0 >> 8) & 0xff;
+    b[2] = this.i0 & 0xff;
+    b[3] = (this.i1 >> 16) & 0xff;
+    b[4] = (this.i1 >> 8) & 0xff;
+    b[5] = this.i1 & 0xff;
+    b[6] = (this.i2 >> 16) & 0xff;
+    b[7] = (this.i2 >> 8) & 0xff;
+    b[8] = this.i2 & 0xff;
+    b[9] = (this.i3 >> 16) & 0xff;
+    b[10] = (this.i3 >> 8) & 0xff;
+    b[11] = this.i3 & 0xff;
+    return b;
   }
 
   set id(value: Uint8Array) {
-    this.buffer = value;
+    this.setFromBytes(value);
     if (ObjectId.cacheHexString) {
       __idCache.set(this, ByteUtils.toHex(value));
     }
@@ -182,7 +269,24 @@ export class ObjectId extends BSONValue {
       if (__id) return __id;
     }
 
-    const hexString = ByteUtils.toHex(this.id);
+    // Encode the four packed integers to hex via a byte->pair lookup table.
+    const i0 = this.i0;
+    const i1 = this.i1;
+    const i2 = this.i2;
+    const i3 = this.i3;
+    const hexString =
+      byteToHex[(i0 >> 16) & 0xff] +
+      byteToHex[(i0 >> 8) & 0xff] +
+      byteToHex[i0 & 0xff] +
+      byteToHex[(i1 >> 16) & 0xff] +
+      byteToHex[(i1 >> 8) & 0xff] +
+      byteToHex[i1 & 0xff] +
+      byteToHex[(i2 >> 16) & 0xff] +
+      byteToHex[(i2 >> 8) & 0xff] +
+      byteToHex[i2 & 0xff] +
+      byteToHex[(i3 >> 16) & 0xff] +
+      byteToHex[(i3 >> 8) & 0xff] +
+      byteToHex[i3 & 0xff];
 
     if (ObjectId.cacheHexString) {
       __idCache.set(this, hexString);
@@ -236,7 +340,6 @@ export class ObjectId extends BSONValue {
    * @param encoding - hex or base64
    */
   toString(encoding?: 'hex' | 'base64'): string {
-    // Is the id a buffer then use the buffer toString method to return the format
     if (encoding === 'base64') return ByteUtils.toBase64(this.id);
     if (encoding === 'hex') return this.toHexString();
     return this.toHexString();
@@ -267,9 +370,14 @@ export class ObjectId extends BSONValue {
       return false;
     }
 
-    if (ObjectId.is(otherId)) {
+    if (ObjectId.is(otherId) && typeof otherId.i3 === 'number') {
+      // Same-build ObjectId: compare the packed integer fields directly. i3 (the counter /
+      // low bytes) differs most often between two ids, so checking it first fails fast.
       return (
-        this.buffer[11] === otherId.buffer[11] && ByteUtils.equals(this.buffer, otherId.buffer)
+        this.i3 === otherId.i3 &&
+        this.i0 === otherId.i0 &&
+        this.i1 === otherId.i1 &&
+        this.i2 === otherId.i2
       );
     }
 
@@ -278,6 +386,8 @@ export class ObjectId extends BSONValue {
     }
 
     if (typeof otherId === 'object' && typeof otherId.toHexString === 'function') {
+      // ObjectId-like values, and ObjectIds from a different bson build, compare by their
+      // public hex representation.
       const otherIdString = otherId.toHexString();
       const thisIdString = this.toHexString();
       return typeof otherIdString === 'string' && otherIdString.toLowerCase() === thisIdString;
@@ -289,8 +399,9 @@ export class ObjectId extends BSONValue {
   /** Returns the generation date (accurate up to the second) that this ID was generated. */
   getTimestamp(): Date {
     const timestamp = new Date();
-    const time = NumberUtils.getUint32BE(this.buffer, 0);
-    timestamp.setTime(Math.floor(time) * 1000);
+    // Bytes 0-3 (the big-endian timestamp) are i0's three bytes followed by i1's top byte.
+    const time = this.i0 * 0x100 + (this.i1 >>> 16);
+    timestamp.setTime(time * 1000);
     return timestamp;
   }
 
@@ -301,18 +412,18 @@ export class ObjectId extends BSONValue {
 
   /** @internal */
   serializeInto(uint8array: Uint8Array, index: number): 12 {
-    uint8array[index] = this.buffer[0];
-    uint8array[index + 1] = this.buffer[1];
-    uint8array[index + 2] = this.buffer[2];
-    uint8array[index + 3] = this.buffer[3];
-    uint8array[index + 4] = this.buffer[4];
-    uint8array[index + 5] = this.buffer[5];
-    uint8array[index + 6] = this.buffer[6];
-    uint8array[index + 7] = this.buffer[7];
-    uint8array[index + 8] = this.buffer[8];
-    uint8array[index + 9] = this.buffer[9];
-    uint8array[index + 10] = this.buffer[10];
-    uint8array[index + 11] = this.buffer[11];
+    uint8array[index] = (this.i0 >> 16) & 0xff;
+    uint8array[index + 1] = (this.i0 >> 8) & 0xff;
+    uint8array[index + 2] = this.i0 & 0xff;
+    uint8array[index + 3] = (this.i1 >> 16) & 0xff;
+    uint8array[index + 4] = (this.i1 >> 8) & 0xff;
+    uint8array[index + 5] = this.i1 & 0xff;
+    uint8array[index + 6] = (this.i2 >> 16) & 0xff;
+    uint8array[index + 7] = (this.i2 >> 8) & 0xff;
+    uint8array[index + 8] = this.i2 & 0xff;
+    uint8array[index + 9] = (this.i3 >> 16) & 0xff;
+    uint8array[index + 10] = (this.i3 >> 8) & 0xff;
+    uint8array[index + 11] = this.i3 & 0xff;
     return 12;
   }
 

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -399,9 +399,9 @@ function deserializeObject(
       value = ByteUtils.toUTF8(buffer, index, index + stringSize - 1, shouldValidateKey);
       index = index + stringSize;
     } else if (elementType === constants.BSON_DATA_OID) {
-      const oid = ByteUtils.allocateUnsafe(12);
-      for (let i = 0; i < 12; i++) oid[i] = buffer[index + i];
-      value = new ObjectId(oid);
+      // ObjectId copies these bytes into its own fields and keeps no reference to the source,
+      // so it is safe to hand it a view onto the wire buffer.
+      value = new ObjectId(buffer.subarray(index, index + 12));
       index = index + 12;
     } else if (elementType === constants.BSON_DATA_INT && promoteValues === false) {
       value = new Int32(NumberUtils.getInt32LE(buffer, index));

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -399,9 +399,9 @@ function deserializeObject(
       value = ByteUtils.toUTF8(buffer, index, index + stringSize - 1, shouldValidateKey);
       index = index + stringSize;
     } else if (elementType === constants.BSON_DATA_OID) {
-      // ObjectId copies these bytes into its own fields and keeps no reference to the source,
-      // so it is safe to hand it a view onto the wire buffer.
-      value = new ObjectId(buffer.subarray(index, index + 12));
+      // ObjectId reads the 12 bytes directly from the wire buffer at this offset into its
+      // fields and keeps no reference to it, so there is no copy or intermediate view.
+      value = new ObjectId(buffer, index);
       index = index + 12;
     } else if (elementType === constants.BSON_DATA_INT && promoteValues === false) {
       value = new Int32(NumberUtils.getInt32LE(buffer, index));

--- a/src/parser/deserializer.ts
+++ b/src/parser/deserializer.ts
@@ -399,8 +399,8 @@ function deserializeObject(
       value = ByteUtils.toUTF8(buffer, index, index + stringSize - 1, shouldValidateKey);
       index = index + stringSize;
     } else if (elementType === constants.BSON_DATA_OID) {
-      // ObjectId reads the 12 bytes directly from the wire buffer at this offset into its
-      // fields and keeps no reference to it, so there is no copy or intermediate view.
+      // ObjectId reads these 12 bytes from the wire buffer at this offset into its own fields
+      // and keeps no reference to the source, so the buffer can be passed directly.
       value = new ObjectId(buffer, index);
       index = index + 12;
     } else if (elementType === constants.BSON_DATA_INT && promoteValues === false) {

--- a/test/node/object_id.test.ts
+++ b/test/node/object_id.test.ts
@@ -360,7 +360,6 @@ describe('ObjectId', function () {
      */
     const oidString = '6b61666665656b6c61746368';
     const oid = new ObjectId(oidString);
-    const oidKId = 'buffer';
     it('should return false for an undefined otherId', () => {
       // otherId === undefined || otherId === null
       expect(oid.equals(null)).to.be.false;
@@ -398,45 +397,46 @@ describe('ObjectId', function () {
       expect(oid.equals({ toHexString: () => 100 })).to.be.false;
     });
 
-    it('should not rely on toString for otherIds that are instanceof ObjectId', () => {
-      // Note: the method access the symbol prop directly instead of the getter
-      const equalId = { toString: () => oidString + 'wrong', [oidKId]: oid.id };
-      Object.setPrototypeOf(equalId, ObjectId.prototype);
+    it('does not rely on toString when comparing against another ObjectId', () => {
+      // A real ObjectId with the same bytes; tampering with toString must not change the result,
+      // because equality of two ObjectId instances is by value, not by their string form.
+      const equalId = new ObjectId(oid.id);
+      equalId.toString = () => oidString + 'wrong';
       expect(oid.toString()).to.not.equal(equalId.toString());
       expect(oid.equals(equalId)).to.be.true;
     });
 
-    it('should use otherId[kId] Buffer for equality when otherId has _bsontype === ObjectId', () => {
-      let equalId = { _bsontype: 'ObjectId', [oidKId]: oid.id };
+    it('compares by value against an ObjectId from a different bson build', () => {
+      // A different copy of bson yields ObjectIds with the same _bsontype and public API but a
+      // different internal layout; equality must fall back to the public hex representation.
+      const foreignEqual = {
+        _bsontype: 'ObjectId',
+        id: oid.id,
+        toHexString: () => oidString
+      } as unknown as ObjectId;
+      const other = new ObjectId();
+      const foreignOther = {
+        _bsontype: 'ObjectId',
+        id: other.id,
+        toHexString: () => other.toHexString()
+      } as unknown as ObjectId;
 
-      const propAccessRecord: string[] = [];
-      equalId = new Proxy(equalId, {
-        get(target, prop: string, recv) {
-          if (prop !== '_bsontype') {
-            propAccessRecord.push(prop);
-          }
-          return Reflect.get(target, prop, recv);
-        }
-      });
-
-      expect(oid.equals(equalId)).to.be.true;
-      // once for the 11th byte shortcut
-      // once for the total equality
-      expect(propAccessRecord).to.deep.equal([oidKId, oidKId]);
+      expect(oid.equals(foreignEqual)).to.be.true;
+      expect(oid.equals(foreignOther)).to.be.false;
     });
   });
 
-  it('should return the same instance if a buffer is passed in', function () {
-    const inBuffer = Buffer.from('00'.repeat(12), 'hex');
+  it('preserves the bytes of a buffer passed to the constructor', function () {
+    const inBuffer = Buffer.from('00112233445566778899aabb', 'hex');
 
-    const outBuffer = new ObjectId(inBuffer);
+    const objectId = new ObjectId(inBuffer);
 
-    // instance equality
-    expect(inBuffer).to.equal(outBuffer.id);
-    // deep equality
-    expect(inBuffer).to.deep.equal(outBuffer.id);
-    // class method equality
-    expect(Buffer.prototype.equals.call(inBuffer, outBuffer.id)).to.be.true;
+    // .id is rebuilt from the stored fields on each access, so it is a distinct buffer instance
+    expect(objectId.id).to.not.equal(inBuffer);
+    // with equal contents
+    expect(objectId.id).to.deep.equal(inBuffer);
+    expect(Buffer.prototype.equals.call(inBuffer, objectId.id)).to.be.true;
+    expect(objectId.toHexString()).to.equal('00112233445566778899aabb');
   });
 
   context('createFromHexString()', () => {

--- a/test/node/object_id.test.ts
+++ b/test/node/object_id.test.ts
@@ -424,6 +424,17 @@ describe('ObjectId', function () {
       expect(oid.equals(foreignEqual)).to.be.true;
       expect(oid.equals(foreignOther)).to.be.false;
     });
+
+    it('falls back to hex when the other id is ObjectId-like with a stray numeric i3', () => {
+      // _bsontype 'ObjectId' plus a numeric `i3` must not trigger the same-build fast path;
+      // without all four packed fields it should compare by the public hex string.
+      const lookalike = {
+        _bsontype: 'ObjectId',
+        i3: 123,
+        toHexString: () => oidString
+      } as unknown as ObjectId;
+      expect(oid.equals(lookalike)).to.be.true;
+    });
   });
 
   it('preserves the bytes of a buffer passed to the constructor', function () {
@@ -437,6 +448,14 @@ describe('ObjectId', function () {
     expect(objectId.id).to.deep.equal(inBuffer);
     expect(Buffer.prototype.equals.call(inBuffer, objectId.id)).to.be.true;
     expect(objectId.toHexString()).to.equal('00112233445566778899aabb');
+  });
+
+  it('accepts a non-Uint8Array view of 12 bytes', function () {
+    const hex = '0011223344556677889900ff';
+    const ab = new ArrayBuffer(12);
+    new Uint8Array(ab).set(Buffer.from(hex, 'hex'));
+    expect(new ObjectId(new Int8Array(ab) as unknown as Uint8Array).toHexString()).to.equal(hex);
+    expect(new ObjectId(new Uint16Array(ab) as unknown as Uint8Array).toHexString()).to.equal(hex);
   });
 
   context('createFromHexString()', () => {

--- a/test/node/object_id.test.ts
+++ b/test/node/object_id.test.ts
@@ -304,6 +304,26 @@ describe('ObjectId', function () {
     done();
   });
 
+  it('constructs a structurally equal copy from another ObjectId instance', function () {
+    const original = new ObjectId('6b61666665656b6c61746368');
+    const copy = new ObjectId(original);
+    expect(copy.equals(original)).to.be.true;
+    expect(copy.id).to.deep.equal(original.id);
+    expect(copy.toHexString()).to.equal(original.toHexString());
+    // The copy holds the same packed fields, so a structural comparison treats the two as equal.
+    expect(copy).to.deep.equal(original);
+  });
+
+  it('constructs from a different-build ObjectId-like via its hex representation', function () {
+    const hex = '6b61666665656b6c61746368';
+    const foreign = {
+      _bsontype: 'ObjectId',
+      id: new ObjectId(hex).id,
+      toHexString: () => hex
+    } as unknown as ObjectId;
+    expect(new ObjectId(foreign).toHexString()).to.equal(hex);
+  });
+
   context('isValid()', () => {
     context('when called with typed array', () => {
       it('returns true for 12 byteLength', () =>


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

This replaces `ObjectId`'s per-instance `Uint8Array` with four 24-bit integer fields (`i0`, `i1`, `i2`, `i3`) holding bytes 0-2, 3-5, 6-8, and 9-11. With the bytes stored inline in the object instead of in a separate typed array, retained memory drops by about 63% per `ObjectId`, and serialization doesn't regress. It also keeps deep equality working (`assert.deepStrictEqual`, plus lodash `isEqual` and `cloneDeep`), which is what blocked the buffer pool in #707 and the `#`-private fields in #830.

Deep equality is the constraint that stalled the previous approaches:
- #830 moved the bytes into `#` private fields. lodash `cloneDeep` can't see private fields, so clones came out broken, and it was reverted for v7.
- The buffer pool in #707 stores a per-instance offset into a shared buffer. Two equal ObjectIds get different offsets, so lodash `isEqual` reports them as unequal.

Packed integers avoid both. The four fields are ordinary enumerable properties (not `#`), so `cloneDeep` copies them, and their values are a pure function of the 12 bytes, so two equal ObjectIds always have identical fields and `isEqual` returns true. I verified both against the built bundle with the real lodash package: `isEqual` is `true` for equal ids and `false` for different ones, and `cloneDeep` produces a working ObjectId that serializes to the same bytes. `equals` compares the four fields for two same-build ObjectIds and falls back to the public hex string for an `ObjectId` from a different copy of `bson`.

##### 24-bit chunks

Each field holds at most `0xffffff`, which is inside V8's small-integer (Smi) range, so all four stay inline in the object. Wider fields (`uint32`, `double`, `BigInt`) go past the Smi range and get boxed onto the heap, which uses more memory rather than less.
References:
https://v8.dev/blog/fast-properties
https://github.com/v8/v8/blob/main/src/objects/smi.h

#### Memory

Measured on Node v24 with forced GC, counting retained heapUsed + arrayBuffers.

| Per ObjectId | main | this PR |
|---|---|---|
| `new ObjectId()` / `(hex)` | 152 B | 56 B (63% less) |
| deserialized `{ _id }` (per doc) | 208 B | 112 B (46% less) |

`find().toArray()` 1_000_000 docs (3 ObjectIds each)
|  | main | this PR |
|---|---|---|
| total retained | 588.5 MB | 313.6 MB (47% less) |

On main the `new ObjectId()` cost depends on allocation: generated and deserialized ids use a pooled `Buffer` (152 B), while constructing from a standalone `Uint8Array` is 244 B, because each id gets its own `ArrayBuffer`. This PR stores the bytes inline, so all of them are a flat 56 B.

#### Representations considered

Before settling on packed integers, I compared the storage options in a microbenchmark. The packed mini-class measures the same 56 B as the shipped bundle, so the benchmark matches the real implementation. All of these options keep lodash `isEqual` and `cloneDeep` working, so the difference comes down to memory and serialization speed. Packed 24-bit integers are the smallest and the fastest:

| representation | memory/instance | serializeInto |
|---|---|---|
| packed, four 24-bit ints (this PR) | 56 B | 3.1 ns |
| latin1 string | 64 B | 14.5 ns |
| three uint32 | 80 B | 3.4 ns |
| two 48-bit doubles | 72 B | 89.5 ns |
| one BigInt | 64 B | 200.3 ns |

#### Performance

Per-operation timings, main vs this PR (ns/op, lower is better):

| operation | main | this PR |
|---|---|---|
| `new ObjectId()` | 43 | 49 |
| `new ObjectId(hex)` | 89 | 83 |
| `new ObjectId(buffer)` | 38 | 38 |
| `getTimestamp()` | 36 | 36 |
| `equals` | 31 | 4 |
| `toHexString` | 46 | 6.6 |
| `.id` getter | 0.4 | 25 |
| serialize (doc with one `_id`) | 128 | 128 |
| deserialize (per id, array of 1000) | 50 | 20 |

`.id` is the only regression: main returns the stored buffer (no allocation), while this PR rebuilds the bytes into a fresh buffer on each call (~25 ns, ~40M ops/sec). The library no longer uses `.id` internally, so it only affects callers reading raw `.id` bytes in a loop.

The only driver consumer of `ObjectId#id` is [`compareObjectId`](https://github.com/mongodb/node-mongodb-native/blob/main/src/utils.ts#L1105), used by SDAM to order replica-set `electionIds`. It runs only while processing `hello` responses - initial discovery, monitoring heartbeats (default every 10s per server), and topology changes such as elections - never during server selection, command execution, or document (de)serialization. Its call rate is bounded by topology activity, not by application throughput, so the extra allocation from `.id` has no effect on steady-state read/write performance. The load-scaling paths (serialize, deserialize, equals) don't read `.id`.

##### Notes for Reviewers

Full driver CI run with this branch (including perf) - everything is green, driver perf is not affected either:
https://spruce.corp.mongodb.com/version/6a327cabd8bc53000702c17d

Behavior change (not semver-breaking): `ObjectId#id` now returns a freshly allocated buffer on each access instead of the live internal buffer, so `new ObjectId(buf).id === buf` is `false` again. The bytes still compare equal and `.id` is still a `Uint8Array`. That `=== buf` identity was only ever true because #498 introduced it in a patch release for performance; it was never part of the semver API, so this restores the prior behavior rather than breaking a contract.

Deserializer: the `ObjectId` path reads the 12 bytes straight from the wire buffer via an `@internal (buffer, offset) constructor`. That is safe because `ObjectId` decodes the bytes into its fields and keeps no reference to the source.

Tests: three existing tests asserted the old internal layout (one checked that `.id` returned the same buffer instance; two reached into the `buffer` field through `equals`). I rewrote them to assert the public contract instead: byte equality for `.id`, and value equality against an ObjectId from a different `bson` build.

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Smaller ObjectIds

`ObjectId` now stores its 12 bytes as four inline integers instead of a `Uint8Array`, cutting per-`ObjectId` memory by about 63% (and roughly 45 to 47% across large result sets) with no serialization slowdown. Deep equality and cloning are preserved (`assert.deepStrictEqual`, and lodash `isEqual` / `cloneDeep`).

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
