### PR TITLE
fix(NODE-7630): make startup snapshot calls more defensive

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -47,9 +47,9 @@ export class ObjectId extends BSONValue {
     this.resetState();
     // https://nodejs.org/api/v8.html#startup-snapshot-api
     // @ts-expect-error Node.js types not present since this is an optional API
-    const { startupSnapshot } = globalThis?.process?.getBuiltinModule('v8') ?? {};
-    if (startupSnapshot?.isBuildingSnapshot()) {
-      startupSnapshot?.addDeserializeCallback(this.resetState);
+    const { startupSnapshot } = globalThis?.process?.getBuiltinModule?.('v8') ?? {};
+    if (startupSnapshot?.isBuildingSnapshot?.()) {
+      startupSnapshot?.addDeserializeCallback?.(this.resetState);
     }
   }
 

--- a/test/node/startup_snapshot.test.ts
+++ b/test/node/startup_snapshot.test.ts
@@ -2,6 +2,7 @@ import * as child_process from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
+import * as vm from 'node:vm';
 import { promisify } from 'node:util';
 import { expect } from 'chai';
 
@@ -86,5 +87,15 @@ describe('snapshot support', () => {
     expect(oid1.uniq).to.not.equal(oid2.uniq);
     // Distinct counter values
     expect(oid1.counter).to.not.equal(oid2.counter);
+  });
+
+  it('allows loading the BSON bundle with varying degrees of `process` polyfilling', async () => {
+    const bsonBundleSource = path.join(__dirname, '..', '..', 'lib', 'bson.bundle.js');
+    const script = await fs.readFile(bsonBundleSource, 'utf8');
+    vm.runInNewContext(script, { __proto__: null });
+    vm.runInNewContext(script, { __proto__: null, process: {} });
+    vm.runInNewContext(script, { __proto__: null, process: { getBuiltinModule: null } });
+    vm.runInNewContext(script, { __proto__: null, process: { getBuiltinModule: () => null } });
+    vm.runInNewContext(script, { __proto__: null, process: { getBuiltinModule: () => ({}) } });
   });
 });


### PR DESCRIPTION
### Description

#### Summary of Changes

There are environments where `process` may be partially polyfilled, so let's make this code a bit more defensive.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### `ObjectId` initialization now tolerates partial `process` polyfills

Adds optional chaining to Node.js startup snapshot API calls in ObjectId so that environments with a stubbed or partial `process` global no longer throw a `TypeError` at startup.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
