### PR TITLE
fix(NODE-7631): count Int32 and BSONSymbol in calculateObjectSize

### DIFF
--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -124,6 +124,8 @@ function calculateElementSize(
         return ByteUtils.utf8ByteLength(name) + 1 + (8 + 1);
       } else if (value._bsontype === 'Decimal128') {
         return ByteUtils.utf8ByteLength(name) + 1 + (16 + 1);
+      } else if (value._bsontype === 'Int32') {
+        return ByteUtils.utf8ByteLength(name) + 1 + (4 + 1);
       } else if (value._bsontype === 'Code') {
         // Calculate size depending on the availability of a scope
         if (value.scope != null && Object.keys(value.scope).length > 0) {
@@ -155,7 +157,7 @@ function calculateElementSize(
         } else {
           return ByteUtils.utf8ByteLength(name) + 1 + (binary.position + 1 + 4 + 1);
         }
-      } else if (value._bsontype === 'Symbol') {
+      } else if (value._bsontype === 'BSONSymbol') {
         return (
           ByteUtils.utf8ByteLength(name) + 1 + ByteUtils.utf8ByteLength(value.value) + 4 + 1 + 1
         );

--- a/test/node/parser/calculate_size.test.ts
+++ b/test/node/parser/calculate_size.test.ts
@@ -57,9 +57,24 @@ describe('calculateSize()', () => {
     });
   });
 
-  describe('when given a BSONSymbol value with a single character key', function () {
+  describe('when given an array of Int32 values', function () {
     it('matches the serialized byte length', function () {
+      const doc = { a: [new BSON.Int32(1), new BSON.Int32(2)] };
+      expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+    });
+  });
+
+  describe('when given an Int32 value nested in a subdocument', function () {
+    it('matches the serialized byte length', function () {
+      const doc = { a: { b: new BSON.Int32(1) } };
+      expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+    });
+  });
+
+  describe('when given a BSONSymbol value with a single character key', function () {
+    it('returns the exact byte count (+4 bytes for document size + 1 type byte + 1 byte for "a" + 4 bytes string length + 4 bytes "sym\\0" + 2 null terminators)', function () {
       const doc = { a: new BSON.BSONSymbol('sym') };
+      expect(BSON.calculateObjectSize(doc)).to.equal(4 + 1 + 1 + 4 + 4 + 1 + 1);
       expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
     });
   });

--- a/test/node/parser/calculate_size.test.ts
+++ b/test/node/parser/calculate_size.test.ts
@@ -48,4 +48,19 @@ describe('calculateSize()', () => {
       expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
     });
   });
+
+  describe('when given an Int32 value with a single character key', function () {
+    it('returns 12 bytes (+4 bytes for document size + 1 type byte + 1 byte for "a" + 4 bytes int32 + 2 null terminators)', function () {
+      const doc = { a: new BSON.Int32(2) };
+      expect(BSON.calculateObjectSize(doc)).to.equal(4 + 1 + 1 + 4 + 1 + 1);
+      expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+    });
+  });
+
+  describe('when given a BSONSymbol value with a single character key', function () {
+    it('matches the serialized byte length', function () {
+      const doc = { a: new BSON.BSONSymbol('sym') };
+      expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+    });
+  });
 });


### PR DESCRIPTION
`calculateObjectSize()` documents (and tests, for `bigint`/`Symbol`) the invariant that it returns the exact byte length `serialize()` will produce. It breaks for two BSON types: it **over-reports by 12 bytes per occurrence** (recursively) for documents containing `Int32` or `BSONSymbol` values.

```js
calculateObjectSize({ a: new Int32(2) })          // 24, serialize().byteLength = 12
calculateObjectSize({ a: new BSONSymbol('sym') })  // 28, serialize().byteLength = 16
calculateObjectSize({ a: [new Int32(1), new Int32(2)] }) // 51 vs 27
```

### Cause (`src/parser/calculate_size.ts`, `calculateElementSize`)
- **`Int32` has no branch.** It falls through to the final `else`, which treats the wrapper as a sub-document and walks its own enumerable `value` property (`Object.keys(new Int32(2))` → `['value']`), adding 5 bytes of fake-document overhead plus a phantom 7-byte `value` field = 12 extra bytes.
- **`BSONSymbol` guard is stale.** The branch tests `value._bsontype === 'Symbol'`, but the tag is `'BSONSymbol'` (`src/symbol.ts`, and the serializer's own `tag === 'BSONSymbol'`). It never matches, so `BSONSymbol` falls through the same way.

### Impact
`calculateObjectSize` is the documented way to pre-check the 16 MB `maxBsonObjectSize` limit and to size write batches before sending to the server. Over-counting causes documents/batches that are actually within the limit to be rejected client-side as too large, and over-allocation in any consumer that pre-sizes a buffer from this value. `Int32` is extremely common (any explicit 32-bit integer).

### Fix
Add an `Int32` branch returning the int32 element size (`4 + 1`, identical to the existing `number`/int32 path) and correct the `BSONSymbol` type guard. No other type is affected.

### Tests
Added cases asserting `calculateObjectSize(doc) === serialize(doc).byteLength` for `Int32` and `BSONSymbol`, mirroring the existing `bigint`/`Symbol` tests. They fail on the current code (24≠12, 28≠16) and pass with the fix. Full `test/node` suite green (4523 passing).

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### `calculateObjectSize()` now returns accurate byte counts for `Int32` and `BSONSymbol`

Previously, each `Int32` or `BSONSymbol` value caused a 12-byte overcount. Thanks to @spokodev for the fix!

<!-- RELEASE_HIGHLIGHT_END -->