### PR TITLE
fix(NODE-7642): respect Binary position in toExtendedJSON

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -256,7 +256,7 @@ export class Binary extends BSONValue {
       validateBinaryVector(this);
     }
 
-    const base64String = ByteUtils.toBase64(this.buffer);
+    const base64String = ByteUtils.toBase64(this.buffer.subarray(0, this.position));
 
     const subType = Number(this.sub_type).toString(16);
     if (options.legacy) {

--- a/test/node/binary.test.ts
+++ b/test/node/binary.test.ts
@@ -272,6 +272,26 @@ describe('class Binary', () => {
     });
   });
 
+  context('toExtendedJSON()', () => {
+    it('should respect position when converting to Extended JSON', () => {
+      const bin = new Binary();
+      expect(bin.toExtendedJSON()).to.deep.equal({ $binary: { base64: '', subType: '00' } });
+      bin.put(1);
+      bin.put(2);
+      bin.put(3);
+      // toExtendedJSON uses base64
+      expect(bin.toExtendedJSON()).to.deep.equal({ $binary: { base64: 'AQID', subType: '00' } });
+    });
+
+    it('should remain same after round trip', () => {
+      const bin = new BSON.Binary();
+      bin.put(1);
+      const ejson = BSON.EJSON.stringify(bin);
+      const roundTrippedBin = BSON.EJSON.parse(ejson);
+      expect(roundTrippedBin.toExtendedJSON()).to.deep.equal(bin.toExtendedJSON());
+    });
+  });
+
   describe('sub_type vector', () => {
     describe('datatype constants', () => {
       it('has Int8, Float32 and PackedBit', () => {


### PR DESCRIPTION
## Description

`Binary.toExtendedJSON()` base64-encodes the entire backing buffer instead of the written region `[0, position)`, corrupting Extended JSON output for any `Binary` built incrementally with the documented `put()` / `write()` API.

`new Binary()` allocates a 256-byte buffer and tracks how much is used in `position`. Every other accessor (`value()`, `toJSON()`, `toString()`, `inspect()`) slices to `position`, but `toExtendedJSON()` encoded `this.buffer` in full. So a `Binary` with 3 bytes written serialized to a 344-character base64 string of mostly zero padding instead of the 4 characters for those 3 bytes.

```js
const bin = new BSON.Binary();
bin.put(1); bin.put(2); bin.put(3);
EJSON.stringify(bin);            // $binary.base64 was 'AQIDAAAA...' (256 bytes) instead of 'AQID'
EJSON.parse(EJSON.stringify(bin)).value(); // [1,2,3,0,0,...] instead of [1,2,3]
```

The BSON path already slices correctly, so BSON and Extended JSON representations of the same object disagreed. This violates MongoDB Extended JSON v2, where `$binary.base64` is the payload, not the internal allocation.

## Fix

```diff
-    const base64String = ByteUtils.toBase64(this.buffer);
+    const base64String = ByteUtils.toBase64(this.buffer.subarray(0, this.position));
```

Matches what `value()` / `toJSON()` / `toString()` already do.

## Test

Added a `toExtendedJSON()` case to `test/node/binary.test.ts` (mirrors the existing `toString` / `toJSON` "should respect position" tests). It fails before the change (full-buffer base64) and passes after. The full node suite stays green.
