### PR TITLE
fix(NODE-7652): count negative zero as a double in calculateObjectSize

### DIFF
--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -82,7 +82,11 @@ function calculateElementSize(
         value >= constants.JS_INT_MIN &&
         value <= constants.JS_INT_MAX
       ) {
-        if (value >= constants.BSON_INT32_MIN && value <= constants.BSON_INT32_MAX) {
+        if (
+          !Object.is(value, -0) &&
+          value >= constants.BSON_INT32_MIN &&
+          value <= constants.BSON_INT32_MAX
+        ) {
           // 32 bit
           return ByteUtils.utf8ByteLength(name) + 1 + (4 + 1);
         } else {

--- a/test/node/parser/calculate_size.test.ts
+++ b/test/node/parser/calculate_size.test.ts
@@ -78,4 +78,12 @@ describe('calculateSize()', () => {
       expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
     });
   });
+
+  describe('when given a negative zero value with a single character key', function () {
+    it('counts 8 bytes to match the double the serializer writes for -0', function () {
+      const doc = { a: -0 };
+      expect(BSON.calculateObjectSize(doc)).to.equal(4 + 1 + 1 + 8 + 1 + 1);
+      expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+    });
+  });
 });


### PR DESCRIPTION
## Description

`calculateObjectSize` undercounts a negative zero by 4 bytes, so serializing into a buffer sized by `calculateObjectSize` throws.

The serializer writes `-0` as a double (8 bytes) to preserve the sign (added in #529 / NODE-4850). But `calculateObjectSize` still counts `-0` as an int32 (4 bytes), because `Math.floor(-0) === -0` and `-0` is inside the int32 range.

```js
const doc = { a: -0 };
BSON.calculateObjectSize(doc);            // 12  (wrong)
BSON.serialize(doc).byteLength;           // 16
BSON.serializeWithBufferAndIndex(doc, Buffer.alloc(BSON.calculateObjectSize(doc)));
// throws: "Index out of range" / "offset is out of bounds"
```

Any code that pre-sizes a buffer with `calculateObjectSize` and then serializes into it (a common pattern, and what `serializeWithBufferAndIndex` is for) breaks on a document containing `-0`.

## Fix

Exclude `-0` from the int32 branch so it is counted as a double, mirroring the serializer's own `Object.is(value, -0)` guard.

```diff
-        if (value >= constants.BSON_INT32_MIN && value <= constants.BSON_INT32_MAX) {
+        if (
+          !Object.is(value, -0) &&
+          value >= constants.BSON_INT32_MIN &&
+          value <= constants.BSON_INT32_MAX
+        ) {
```

## Test

Added a case to `test/node/parser/calculate_size.test.ts` asserting `calculateObjectSize({ a: -0 })` equals `serialize().byteLength`. It fails before the change (`expected 12 to equal 16`) and passes after. This is the same family as #901 and #742, which fixed Int32/BSONSymbol and bigint sizing in the same function.
