### PR TITLE
fix(NODE-7646): count ES Map entries in calculateObjectSize

### DIFF
--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -3,7 +3,7 @@ import type { Document } from '../bson';
 import { BSONError, BSONVersionError } from '../error';
 import * as constants from '../constants';
 import { ByteUtils } from '../utils/byte_utils';
-import { isAnyArrayBuffer, isDate, isRegExp } from './utils';
+import { isAnyArrayBuffer, isDate, isMap, isRegExp } from './utils';
 
 export function internalCalculateObjectSize(
   object: Document,
@@ -22,9 +22,10 @@ export function internalCalculateObjectSize(
     total += 5; // 4-byte size field + null terminator
 
     const isObjArray = Array.isArray(obj);
+    const isObjMap = !isObjArray && (obj instanceof Map || isMap(obj));
     let target = obj;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (!isObjArray && typeof (obj as any)?.toBSON === 'function') {
+    if (!isObjArray && !isObjMap && typeof (obj as any)?.toBSON === 'function') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       target = (obj as any).toBSON();
     }
@@ -37,6 +38,17 @@ export function internalCalculateObjectSize(
           array[i],
           serializeFunctions,
           true,
+          frameIgnoreUndefined,
+          objectStack
+        );
+      }
+    } else if (isObjMap) {
+      for (const [key, value] of target as Map<string, unknown>) {
+        total += calculateElementSize(
+          key,
+          value,
+          serializeFunctions,
+          false,
           frameIgnoreUndefined,
           objectStack
         );

--- a/test/node/map.test.ts
+++ b/test/node/map.test.ts
@@ -64,3 +64,34 @@ describe('ES Map support in serialize()', () => {
     expect(result).to.deep.equal(expected);
   });
 });
+
+describe('ES Map support in calculateObjectSize()', () => {
+  it('counts a root Map to the same size that serialize() produces', () => {
+    const map = new Map<string, unknown>([
+      ['a', new BSON.Int32(1)],
+      ['b', 'hello']
+    ]);
+    expect(BSON.calculateObjectSize(map)).to.equal(BSON.serialize(map).byteLength);
+  });
+
+  it('counts a nested Map to the same size that serialize() produces', () => {
+    const doc = { m: new Map<string, unknown>([['x', new BSON.Int32(10)]]) };
+    expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+  });
+
+  it('counts a Map nested inside a Map to the same size that serialize() produces', () => {
+    const map = new Map<string, unknown>([
+      ['a', new Map<string, unknown>([['b', new BSON.Int32(2)]])]
+    ]);
+    expect(BSON.calculateObjectSize(map)).to.equal(BSON.serialize(map).byteLength);
+  });
+
+  it('produces a size large enough for serializeWithBufferAndIndex to write a Map', () => {
+    const map = new Map<string, unknown>([
+      ['a', new BSON.Int32(1)],
+      ['b', 'hello']
+    ]);
+    const buffer = Buffer.alloc(BSON.calculateObjectSize(map));
+    expect(() => BSON.serializeWithBufferAndIndex(map, buffer)).to.not.throw();
+  });
+});

--- a/test/node/map.test.ts
+++ b/test/node/map.test.ts
@@ -94,4 +94,29 @@ describe('ES Map support in calculateObjectSize()', () => {
     const buffer = Buffer.alloc(BSON.calculateObjectSize(map));
     expect(() => BSON.serializeWithBufferAndIndex(map, buffer)).to.not.throw();
   });
+
+  it('skips an undefined Map value to match serialize() when ignoreUndefined is true (default)', () => {
+    const map = new Map<string, unknown>([
+      ['a', new BSON.Int32(1)],
+      ['b', undefined]
+    ]);
+    // ignoreUndefined defaults to true, so the undefined entry is dropped by both
+    // serialize() and calculateObjectSize(), leaving only { a: Int32 } => 12 bytes.
+    expect(BSON.calculateObjectSize(map)).to.equal(BSON.serialize(map).byteLength);
+    expect(BSON.calculateObjectSize(map)).to.equal(12);
+  });
+
+  it('counts an undefined Map value as null to match serialize() when ignoreUndefined is false', () => {
+    const map = new Map<string, unknown>([
+      ['a', new BSON.Int32(1)],
+      ['b', undefined]
+    ]);
+    const options = { ignoreUndefined: false };
+    // With ignoreUndefined=false the undefined entry is written as a BSON null by both,
+    // adding a 3-byte null element (type + 'b' + terminator) => 15 bytes.
+    expect(BSON.calculateObjectSize(map, options)).to.equal(
+      BSON.serialize(map, options).byteLength
+    );
+    expect(BSON.calculateObjectSize(map, options)).to.equal(15);
+  });
 });


### PR DESCRIPTION
### Description

#### Summary of Changes

serialize() supports an ES Map as the root document and as a nested value,
but calculateObjectSize() does not. Its loop iterates Object.keys(target),
which is empty for a Map, so a Map is counted as an empty 5-byte document and
all of its entries are skipped.

Because of this, calculateObjectSize disagrees with serialize for any Map:

  calculateObjectSize(new Map([['a', new Int32(1)], ['b', 'hello']])) // 5
  serialize(new Map([['a', new Int32(1)], ['b', 'hello']])).byteLength // 25

The mismatch breaks buffer pre-allocation. Allocating a buffer of
calculateObjectSize(map) bytes and then calling serializeWithBufferAndIndex
throws "RangeError: offset is out of bounds" because the buffer is too small.
Documents that contain a nested Map are affected the same way.

This change adds a Map branch to internalCalculateObjectSize that mirrors the
serializer's makeFrame handling: it detects a Map, skips the object-level
toBSON call (the serializer also skips toBSON for Maps), and counts each entry
through the existing per-element accounting. Nested Maps are already pushed
onto the size stack, so both root and nested Maps are now counted correctly.

Tests added to test/node/map.test.ts assert that calculateObjectSize equals
serialize(...).byteLength for a root Map, a nested Map, and a Map nested inside
a Map, and that serializeWithBufferAndIndex succeeds when the buffer is sized
by calculateObjectSize.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fix issue with calculateObjectSize

This release of js-bson fixes an issue where we were incorrectly considering ES Map objects inside `calculateObjectSize`. This issue did not impact serialization, just size calculation.

<!-- RELEASE_HIGHLIGHT_END -->

