### PR TITLE
fix(NODE-7661): count empty-scope Code as code_with_scope in calculateObjectSize

### DIFF
--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -128,7 +128,7 @@ function calculateElementSize(
         return ByteUtils.utf8ByteLength(name) + 1 + (4 + 1);
       } else if (value._bsontype === 'Code') {
         // Calculate size depending on the availability of a scope
-        if (value.scope != null && Object.keys(value.scope).length > 0) {
+        if (value.scope != null && typeof value.scope === 'object') {
           objectStack.push({ obj: value.scope, ignoreUndefined });
           return (
             ByteUtils.utf8ByteLength(name) +

--- a/test/node/parser/calculate_size.test.ts
+++ b/test/node/parser/calculate_size.test.ts
@@ -78,4 +78,11 @@ describe('calculateSize()', () => {
       expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
     });
   });
+
+  describe('when given a Code value with an empty scope', function () {
+    it('matches the serialized byte length', function () {
+      const doc = { a: new BSON.Code('x', {}) };
+      expect(BSON.calculateObjectSize(doc)).to.equal(BSON.serialize(doc).byteLength);
+    });
+  });
 });


### PR DESCRIPTION
`calculateObjectSize` disagrees with `serialize` for a `Code` whose scope is a present but empty object.

The serializer emits `code_with_scope` (`0x0f`) whenever `scope` is a non-null object, including `{}`. `calculateObjectSize` instead required the scope to have at least one key before counting the `code_with_scope` layout, so it fell back to the plain `code` (`0x0d`) size and under-reported by 9 bytes (the 4-byte total-size field plus the 5-byte empty scope subdocument).

```js
const doc = { a: new Code('x', {}) };
calculateObjectSize(doc);   // 14
serialize(doc).byteLength;  // 23
```

Gate the `code_with_scope` size branch on `scope` being a non-null object, matching the serializer; the size-calculation stack already accounts for the empty scope subdocument. Adds a regression test asserting `calculateObjectSize === serialize().byteLength` for an empty-scope `Code`.
