### PR TITLE
chore: use bundled version of NPM

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -270,18 +270,21 @@ buildvariants:
   - name: linux
     display_name: RHEL 8.0
     run_on: rhel80-small
+    # TODO(NODE-7677): update to npm 12 once we figure out how to allow git packages to be installed with npm 12.
     expansions:
       NPM_VERSION: 11.11.1
     tasks: [".node", ".web", "check-eslint-plugin"]
   - name: linux-zseries
     display_name: RHEL 9.0 zSeries
     run_on: rhel9-zseries-small
+    # TODO(NODE-7677): update to npm 12 once we figure out how to allow git packages to be installed with npm 12.
     expansions:
       NPM_VERSION: 11.11.1
     tasks: [".node", ".web"]
   - name: lint
     display_name: lint
     run_on: rhel80-small
+    # TODO(NODE-7677): update to npm 12 once we figure out how to allow git packages to be installed with npm 12.
     expansions:
       NPM_VERSION: 11.11.1
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -149,7 +149,6 @@ tasks:
       - func: fetch source
         vars:
           NODE_LTS_VERSION: 22
-          NPM_VERSION: 11.11.1
       - func: install dependencies
       - func: run tests
   - name: node-tests-v24
@@ -236,10 +235,7 @@ tasks:
         vars:
           # This needs to stay pinned at Node v22.11.0 for consistency across perf runs.
           NODE_LTS_VERSION: v22.11.0
-          NPM_VERSION: 9
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: run granular benchmarks
         vars:
           WARMUP: 1000
@@ -253,10 +249,7 @@ tasks:
         vars:
           # This needs to stay pinned at Node v22.11.0 for consistency across perf runs.
           NODE_LTS_VERSION: v22.11.0
-          NPM_VERSION: 9
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: run custom benchmarks
       - func: perf send
         vars:
@@ -267,10 +260,7 @@ tasks:
         vars:
           # This needs to stay pinned at Node v22.11.0 for consistency across perf runs.
           NODE_LTS_VERSION: v22.11.0
-          NPM_VERSION: 9
       - func: install dependencies
-        vars:
-          NPM_VERSION: 9
       - func: run spec benchmarks
       - func: perf send
         vars:
@@ -280,14 +270,20 @@ buildvariants:
   - name: linux
     display_name: RHEL 8.0
     run_on: rhel80-small
+    expansions:
+      NPM_VERSION: 11.11.1
     tasks: [".node", ".web", "check-eslint-plugin"]
   - name: linux-zseries
     display_name: RHEL 9.0 zSeries
     run_on: rhel9-zseries-small
+    expansions:
+      NPM_VERSION: 11.11.1
     tasks: [".node", ".web"]
   - name: lint
     display_name: lint
     run_on: rhel80-small
+    expansions:
+      NPM_VERSION: 11.11.1
     tasks:
       - run-checks
       - check-typescript-oldest
@@ -298,6 +294,8 @@ buildvariants:
     display_name: RHEL 9.0 perf
     run_on: rhel90-dbx-perf-large
     activate: true
+    expansions:
+      NPM_VERSION: 9
     tasks:
       - run-granular-benchmarks
       - run-spec-benchmarks

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -270,23 +270,14 @@ buildvariants:
   - name: linux
     display_name: RHEL 8.0
     run_on: rhel80-small
-    # TODO(NODE-7677): update to npm 12 once we figure out how to allow git packages to be installed with npm 12.
-    expansions:
-      NPM_VERSION: 11.11.1
     tasks: [".node", ".web", "check-eslint-plugin"]
   - name: linux-zseries
     display_name: RHEL 9.0 zSeries
     run_on: rhel9-zseries-small
-    # TODO(NODE-7677): update to npm 12 once we figure out how to allow git packages to be installed with npm 12.
-    expansions:
-      NPM_VERSION: 11.11.1
     tasks: [".node", ".web"]
   - name: lint
     display_name: lint
     run_on: rhel80-small
-    # TODO(NODE-7677): update to npm 12 once we figure out how to allow git packages to be installed with npm 12.
-    expansions:
-      NPM_VERSION: 11.11.1
     tasks:
       - run-checks
       - check-typescript-oldest
@@ -297,8 +288,6 @@ buildvariants:
     display_name: RHEL 9.0 perf
     run_on: rhel90-dbx-perf-large
     activate: true
-    expansions:
-      NPM_VERSION: 9
     tasks:
       - run-granular-benchmarks
       - run-spec-benchmarks

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -6,9 +6,13 @@ set -o errexit  # Exit the script with error if any of the commands fail
 ## 'latest'
 ## a full nodejs version, in the format v<major>.<minor>.patch
 export NODE_LTS_VERSION=${NODE_LTS_VERSION:-20.19.0}
-# npm version can be defined in the environment for cases where we need to install
-# a version lower than latest to support EOL Node versions. When not provided will
-# be handled by this script in drivers tools.
+# Use the npm bundled with the installed Node.js release instead of upgrading to
+# npm@latest. The bundled npm is version-matched to the Node release; upgrading to
+# npm@latest (currently 12) breaks `npm install` of git dependencies (EALLOWGIT).
+# TODO(NODE-7677): revisit disabling the npm upgrade once our git dependency
+# (dbx-js-tools) can be installed under npm 12 — e.g. by publishing bson-bench to a
+# registry — at which point we can drop this flag and test on npm@latest again.
+export SKIP_NPM_UPGRADE=true
 source $DRIVERS_TOOLS/.evergreen/install-node.sh
 
 npm install "${NPM_OPTIONS}"


### PR DESCRIPTION
### Description

#### Summary of Changes

Pins npm to 11.11.1 in order to avoid npm 12's blockage of git installations.

npm 12 made a change to block git installs: https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/
This is currently breaking evergreen builds for this repo: https://spruce.corp.mongodb.com/version/6a54e66079eab700070e5b15/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

This change pins npm to 11.11.1, a version we already use in some spots here.

#### What is the motivation for this change?

npm 12 blocks installs from git by default.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
