### PR TITLE
chore(NODE-7681): allow git fetch for npm12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# npm 12 blocks git-URL dependencies by default (EALLOWGIT). The dbx-js-tools
+# dev dependency is a direct git dep, so allow root-level git fetches while
+# still refusing transitive ones. See NODE-7681.
+allow-git=root


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

npm12 disallow git fetch for dependencies, but we need it for dbx-js-tools, add simple .npmrc to fix the release.
https://github.com/mongodb/js-bson/actions/runs/29496824432/job/87617634724

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
