### PR TITLE
fix(NODE-7667): remove early initialization from ObjectId

### DIFF
--- a/src/objectid.ts
+++ b/src/objectid.ts
@@ -50,7 +50,10 @@ export class ObjectId extends BSONValue {
   /** @internal */
   private static resetState = (): void => {
     this.index = Math.floor(Math.random() * 0x1000000);
-    this.PROCESS_UNIQUE = ByteUtils.randomBytes(5);
+    // PROCESS_UNIQUE is (re)generated lazily on first use rather than here, so that merely loading
+    // BSON never calls secure random at module-evaluation time. Runtimes such as Cloudflare Workers
+    // forbid generating random values in the global scope.
+    this.PROCESS_UNIQUE = null;
   };
 
   static {
@@ -211,7 +214,7 @@ export class ObjectId extends BSONValue {
       // generate a new id directly into the packed fields.
       const time = Math.floor(Date.now() / 1000);
       const inc = ObjectId.getInc();
-      const pu = ObjectId.PROCESS_UNIQUE!;
+      const pu = (ObjectId.PROCESS_UNIQUE ??= ByteUtils.randomBytes(5));
       this.i0 = (time >>> 8) & 0xffffff;
       this.i1 = ((time & 0xff) << 16) | (pu[0] << 8) | pu[1];
       this.i2 = (pu[2] << 16) | (pu[3] << 8) | pu[4];
@@ -349,8 +352,8 @@ export class ObjectId extends BSONValue {
     // 4-byte timestamp
     NumberUtils.setInt32BE(buffer, 0, time);
 
-    // 5-byte process unique
-    const PROCESS_UNIQUE = this.PROCESS_UNIQUE!;
+    // 5-byte process unique (generated lazily on first use, see NODE-7667)
+    const PROCESS_UNIQUE = (this.PROCESS_UNIQUE ??= ByteUtils.randomBytes(5));
     buffer[4] = PROCESS_UNIQUE[0];
     buffer[5] = PROCESS_UNIQUE[1];
     buffer[6] = PROCESS_UNIQUE[2];

--- a/test/node/object_id.test.ts
+++ b/test/node/object_id.test.ts
@@ -4,6 +4,8 @@ import * as util from 'util';
 import { expect } from 'chai';
 import { bufferFromHexArray } from './tools/utils';
 import { isBufferOrUint8Array } from './tools/utils';
+import { loadCJSModuleBSON } from '../load_bson';
+import * as crypto from 'node:crypto';
 
 describe('ObjectId', function () {
   describe('static createFromTime()', () => {
@@ -546,6 +548,39 @@ describe('ObjectId', function () {
         b10: 0x61,
         b11: 0x61
       });
+    });
+  });
+
+  describe('lazy secure-random initialization (NODE-7667)', function () {
+    // Regression test for https://jira.mongodb.org/browse/NODE-7667
+    // Cloudflare Workers forbid generating random values in the global scope (i.e. during module
+    // evaluation, before any request handler runs). BSON must therefore not request secure random
+    // bytes when the module is loaded - only when an ObjectId is actually created.
+    it('does not request secure random bytes at module-evaluation time, only on first ObjectId creation', function () {
+      let getRandomValuesCalls = 0;
+      const { exports } = loadCJSModuleBSON({
+        crypto: {
+          getRandomValues(buffer: Uint8Array) {
+            getRandomValuesCalls += 1;
+            buffer.set(crypto.randomBytes(buffer.byteLength), 0);
+            return buffer;
+          }
+        }
+      });
+
+      // Loading BSON (running ObjectId's static initializer) must not touch secure random.
+      expect(
+        getRandomValuesCalls,
+        'BSON requested secure random bytes at module-evaluation time'
+      ).to.equal(0);
+
+      // The process-unique bytes are generated lazily, on the first ObjectId.
+      new exports.BSON.ObjectId();
+      expect(getRandomValuesCalls).to.equal(1);
+
+      // ...and cached: later ObjectIds reuse them rather than re-generating.
+      new exports.BSON.ObjectId();
+      expect(getRandomValuesCalls).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
### Description

#### Summary of Changes

Fix issue with Cloudflare Workers: crypto calls are not allowed during module initialization. Make the crypto calls lazy, rather than eager.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fix issue with ObjectId initialization in Cloudflare Workers

This release of js-bson fixes an issue where we were making crypto calls during module initialization, which is forbidden by Cloudflare Workers and other environments.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
