### PR TITLE
fix(NODE-7645): use the first instant of year 10000 as the relaxed EJSON date bound

### DIFF
--- a/src/extended_json.ts
+++ b/src/extended_json.ts
@@ -264,7 +264,10 @@ function serializeValue(value: any, options: EJSONSerializeInternalOptions): any
   if (value instanceof Date || isDate(value)) {
     const dateNum = value.getTime(),
       // is it in year range 1970-9999?
-      inRange = dateNum > -1 && dateNum < 253402318800000;
+      // 253402300800000 is the first instant of year 10000 (+010000-01-01T00:00:00Z).
+      // It is the exclusive upper bound: a relaxed date is emitted as an ISO 8601 string,
+      // which only has a 4-digit year, so year 10000 and later are kept as a numeric timestamp.
+      inRange = dateNum > -1 && dateNum < 253402300800000;
 
     if (options.legacy) {
       return options.relaxed && inRange

--- a/test/node/extended_json.test.ts
+++ b/test/node/extended_json.test.ts
@@ -357,6 +357,15 @@ describe('Extended JSON', function () {
             expect(json).to.equal('{"field":{"$date":1452124800000}}');
           });
         });
+
+        context('when the date is the first instant of year 10000', function () {
+          it('stringifies $date as $numberLong instead of an out-of-range ISO string', function () {
+            const date = new Date(253402300800000);
+            const doc = { field: date };
+            const json = EJSON.stringify(doc, { relaxed: true });
+            expect(json).to.equal('{"field":{"$date":{"$numberLong":"253402300800000"}}}');
+          });
+        });
       });
 
       context('when serializing regex', function () {


### PR DESCRIPTION
### Description

Supersedes #909. GitHub auto-closed that PR after I force-pushed its branch to add the constant comment @PavelSafronov asked for in review, and it will not reopen a force-pushed-then-closed PR. This is the same change, with that comment included.

#### Summary of Changes

In relaxed Extended JSON mode, dates in the first five hours of year 10000 are emitted as ISO strings with a six-digit year, which strict Extended JSON consumers (mongosh, the server) reject.

The relaxed-range guard in `src/extended_json.ts` uses `253402318800000`, which is `+010000-01-01T05:00:00Z`, five hours into year 10000. So a `Date` in `[253402300800000, 253402318799999]` passes the "year 1970-9999" check and is serialized as a relaxed ISO string:

```js
EJSON.stringify({ a: new Date(253402300800000) }, { relaxed: true })
// {"a":{"$date":"+010000-01-01T00:00:00Z"}}   invalid 6-digit-year ISO
// should be {"a":{"$date":{"$numberLong":"253402300800000"}}}
```

The correct upper bound is the first instant of year 10000, `Date.UTC(10000, 0, 1) === 253402300800000`, which is exactly the value the repo's own `bson-corpus` `Y10K` fixture uses.

```diff
-      inRange = dateNum > -1 && dateNum < 253402318800000;
+      inRange = dateNum > -1 && dateNum < 253402300800000;
```

##### Notes for Reviewers

Compared to #909, the only addition is the review-requested comment explaining the `253402300800000` bound (year 10000, and why a 4-digit-year ISO string forces the `$numberLong` fallback). Diff is otherwise identical.

#### What is the motivation for this change?

Tracked in NODE-7645.

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fix issue with date boundaries in relaxed EJSON

This release of js-bson fixes an issue where the date boundary for relaxed EJSON was incorrectly set to a date 5 hours after the maximum limit of 10,000 AD.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
