### PR TITLE
fix(NODE-7612): reject subtype-9 vectors shorter than 2 metadata bytes

### DIFF
--- a/src/binary.ts
+++ b/src/binary.ts
@@ -518,6 +518,14 @@ export function validateBinaryVector(vector: Binary): void {
 
   const size = vector.position;
 
+  // Every subtype-9 vector carries two metadata bytes (datatype and padding):
+  // the typed helpers always allocate them, but the raw constructor path may not (NODE-7612)
+  if (size < 2) {
+    throw new BSONError(
+      'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
+    );
+  }
+
   // NOTE: Validation is only applied to **KNOWN** vector types
   // If a new datatype is introduced, a future version of the library will need to add validation
   const datatype = vector.buffer[0];

--- a/test/node/binary.test.ts
+++ b/test/node/binary.test.ts
@@ -551,21 +551,74 @@ describe('class Binary', () => {
       });
 
       it('throws when a vector has a datatype byte but no padding byte (NODE-7612)', () => {
-        const binary = new Binary(
-          new Uint8Array([Binary.VECTOR_TYPE.PackedBit]),
-          Binary.SUBTYPE_VECTOR
+        for (const dtype of [
+          Binary.VECTOR_TYPE.Int8,
+          Binary.VECTOR_TYPE.Float32,
+          Binary.VECTOR_TYPE.PackedBit
+        ]) {
+          const binary = new Binary(new Uint8Array([dtype]), Binary.SUBTYPE_VECTOR);
+          expect(() => BSON.serialize({ bin: binary })).to.throw(
+            BSONError,
+            'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
+          );
+        }
+      });
+
+      it('throws when a zero-length vector is read from the wire and re-serialized (NODE-7612)', () => {
+        // { bin: <binary size=0, subtype=0x09> } — malformed vector on the wire.
+        // Deserialization is lazy and does not validate vector content, but the
+        // malformed value must not round-trip silently through serialization.
+        const wireBytes = new Uint8Array([
+          0x0f,
+          0x00,
+          0x00,
+          0x00, // document size = 15
+          0x05, // type: binary
+          0x62,
+          0x69,
+          0x6e,
+          0x00, // name 'bin'
+          0x00,
+          0x00,
+          0x00,
+          0x00, // binary size = 0
+          0x09, // subtype = 9 (vector)
+          0x00 // document terminator
+        ]);
+        const doc = BSON.deserialize(wireBytes);
+        expect(doc.bin.position).to.equal(0);
+        expect(() => BSON.serialize(doc)).to.throw(
+          BSONError,
+          'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
         );
-        expect(() => BSON.serialize({ bin: binary })).to.throw(
+        expect(() => EJSON.stringify(doc)).to.throw(
+          BSONError,
+          'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
+        );
+      });
+
+      it('throws when a zero-length vector comes from EJSON input (NODE-7612)', () => {
+        const doc = EJSON.parse('{"bin":{"$binary":{"base64":"","subType":"9"}}}');
+        expect(() => EJSON.stringify(doc)).to.throw(
+          BSONError,
+          'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
+        );
+        expect(() => BSON.serialize(doc)).to.throw(
           BSONError,
           'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
         );
       });
 
       it('still accepts metadata-only vectors created by the typed helpers', () => {
-        const binary = Binary.fromInt8Array(new Int8Array(0));
-        expect(binary.buffer).to.have.lengthOf(2);
-        expect(() => BSON.serialize({ bin: binary })).to.not.throw();
-        expect(() => EJSON.stringify({ bin: binary })).to.not.throw();
+        for (const binary of [
+          Binary.fromInt8Array(new Int8Array(0)),
+          Binary.fromFloat32Array(new Float32Array(0)),
+          Binary.fromPackedBits(new Uint8Array(0), 0)
+        ]) {
+          expect(binary.buffer).to.have.lengthOf(2);
+          expect(() => BSON.serialize({ bin: binary })).to.not.throw();
+          expect(() => EJSON.stringify({ bin: binary })).to.not.throw();
+        }
       });
     });
   });

--- a/test/node/binary.test.ts
+++ b/test/node/binary.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as vm from 'node:vm';
-import { __isWeb__, Binary, BSON, BSONError, UUID } from '../register-bson';
+import { __isWeb__, Binary, BSON, BSONError, EJSON, UUID } from '../register-bson';
 import * as util from 'node:util';
 
 describe('class Binary', () => {
@@ -534,6 +534,38 @@ describe('class Binary', () => {
 
       it('throws when values are not 1 or 0', () => {
         expect(() => Binary.fromBits([1, 0, 2])).to.throw(BSONError, /must be 0 or 1/);
+      });
+    });
+
+    describe('validateBinaryVector()', () => {
+      it('throws when a vector constructed from raw bytes has no datatype or padding bytes (NODE-7612)', () => {
+        const binary = new Binary(new Uint8Array(0), Binary.SUBTYPE_VECTOR);
+        expect(() => BSON.serialize({ bin: binary })).to.throw(
+          BSONError,
+          'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
+        );
+        expect(() => EJSON.stringify({ bin: binary })).to.throw(
+          BSONError,
+          'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
+        );
+      });
+
+      it('throws when a vector has a datatype byte but no padding byte (NODE-7612)', () => {
+        const binary = new Binary(
+          new Uint8Array([Binary.VECTOR_TYPE.PackedBit]),
+          Binary.SUBTYPE_VECTOR
+        );
+        expect(() => BSON.serialize({ bin: binary })).to.throw(
+          BSONError,
+          'Invalid Vector: must be at least 2 bytes to hold the datatype and padding bytes'
+        );
+      });
+
+      it('still accepts metadata-only vectors created by the typed helpers', () => {
+        const binary = Binary.fromInt8Array(new Int8Array(0));
+        expect(binary.buffer).to.have.lengthOf(2);
+        expect(() => BSON.serialize({ bin: binary })).to.not.throw();
+        expect(() => EJSON.stringify({ bin: binary })).to.not.throw();
       });
     });
   });


### PR DESCRIPTION
### Description

#### Summary of Changes

`validateBinaryVector()` read `vector.buffer[0]` (datatype) and `vector.buffer[1]` (padding) without first checking that those two bytes exist. A zero-length `Binary` created through the raw constructor — `new Binary(Buffer.alloc(0), Binary.SUBTYPE_VECTOR)` — makes both reads `undefined`, so every dtype-specific validation branch is skipped and the value passes validation. Both `BSON.serialize()` and `EJSON.stringify()` then emit a malformed subtype-9 vector with no dtype/padding metadata.

The typed helper constructors (`fromInt8Array`, `fromFloat32Array`, `fromPackedBits`) always allocate `byteLength + 2`, so the invariant "every subtype-9 value carries 2 metadata bytes" already holds everywhere except the raw constructor path. This PR enforces that invariant in `validateBinaryVector()` by rejecting vectors shorter than 2 bytes, which also closes the 1-byte PackedBit gap (`padding` reads `undefined`, `undefined > 7` is false, so it passed before).

##### Notes for Reviewers

- The existing spec test data (`test/node/specs/bson-binary-vector`) contains no valid sub-2-byte vectors, so no compliance tests are affected.
- The `size !== 0` condition in the existing Float32 check becomes unreachable after this guard; I left it in place to keep the diff minimal, happy to remove it if preferred.

#### What is the motivation for this change?

Fixes NODE-7612 (part of NODE-7598).

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Zero-length `Binary` subtype-9 vectors are now rejected

`BSON.serialize()` and `EJSON.stringify()` now throw a `BSONError` for subtype-9 (Vector) values that do not contain the mandatory datatype and padding metadata bytes, instead of emitting malformed BSON.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket