### PR TITLE
fix(NODE-7611): bounds check findNull scan in on-demand parser

### DIFF
--- a/src/parser/on_demand/parse_to_elements.ts
+++ b/src/parser/on_demand/parse_to_elements.ts
@@ -57,16 +57,20 @@ function getSize(source: Uint8Array, offset: number) {
 
 /**
  * Searches for null terminator of a BSON element's value (Never the document null terminator)
- * **Does not** bounds check since this should **ONLY** be used within parseToElements which has asserted that `bytes` ends with a `0x00`.
- * So this will at most iterate to the document's terminator and error if that is the offset reached.
+ * The scan is bounds checked so malformed inputs (for example, a zero-length string size that
+ * advances the cursor past the end of the document) throw instead of looping forever (NODE-7611).
  */
 function findNull(bytes: Uint8Array, offset: number): number {
   let nullTerminatorOffset = offset;
 
-  for (; bytes[nullTerminatorOffset] !== 0x00; nullTerminatorOffset++);
+  for (
+    ;
+    nullTerminatorOffset < bytes.length && bytes[nullTerminatorOffset] !== 0x00;
+    nullTerminatorOffset++
+  );
 
-  if (nullTerminatorOffset === bytes.length - 1) {
-    // We reached the null terminator of the document, not a value's
+  if (nullTerminatorOffset >= bytes.length - 1) {
+    // We reached the null terminator of the document or the end of the input, not a value's
     throw new BSONOffsetError('Null terminator not found', offset);
   }
 

--- a/src/parser/on_demand/parse_to_elements.ts
+++ b/src/parser/on_demand/parse_to_elements.ts
@@ -182,7 +182,10 @@ export function parseToElements(
       );
     }
 
-    if (length > documentSize) {
+    // The value must fit within the current document: the document's last byte
+    // (startOffset + documentSize - 1) is its null terminator, so a value may
+    // extend at most up to that byte.
+    if (offset + length > startOffset + documentSize - 1) {
       throw new BSONOffsetError('value reports length larger than document', offset);
     }
 

--- a/test/node/parser/on_demand/parse_to_elements.test.ts
+++ b/test/node/parser/on_demand/parse_to_elements.test.ts
@@ -64,13 +64,47 @@ describe('parseToElements()', () => {
   context('when a string element declares a zero length (NODE-7611)', () => {
     it('throws instead of scanning past the end of the input', () => {
       // 10-byte document: string element with empty name declares a stringSize of 0,
-      // which advances the cursor to the declared document end and would otherwise
-      // make findNull scan out of range forever.
+      // which would advance the cursor to the declared document end and previously
+      // made findNull scan out of range forever.
       const test = () =>
         parseToElements(
           new Uint8Array([0x0a, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00])
         );
-      expect(test).to.throw(/Null terminator not found/i);
+      expect(test).to.throw(/value reports length larger than document/i);
+      expect(test).to.throw(BSONOffsetError);
+    });
+  });
+
+  context('when an element value extends past the end of an embedded document', () => {
+    it('throws an error indicating the value is larger than the document', () => {
+      const bytes = new Uint8Array([
+        0x17,
+        0x00,
+        0x00,
+        0x00, // outer documentSize
+        0x03,
+        0x61,
+        0x00, // 'a': embedded document
+        0x08,
+        0x00,
+        0x00,
+        0x00, // embedded documentSize
+        0x10,
+        0x62,
+        0x62,
+        0x00, // int32 named 'bb'
+        0x10,
+        0x63,
+        0x00,
+        0x2a,
+        0x00,
+        0x00,
+        0x00, // 'c': int32 sibling of 'a'
+        0x00 // outer terminator
+      ]);
+
+      const test = () => parseToElements(bytes, 7);
+      expect(test).to.throw(/value reports length larger than document/i);
       expect(test).to.throw(BSONOffsetError);
     });
   });
@@ -214,7 +248,7 @@ describe('parseToElements()', () => {
     },
     {
       name: 'binary',
-      input: ['05', '6100', int32LEToHex(5), '23', '00'],
+      input: ['05', '6100', int32LEToHex(5), '23', '0000000000'],
       output: { type: 5, length: 10 }
     },
     {

--- a/test/node/parser/on_demand/parse_to_elements.test.ts
+++ b/test/node/parser/on_demand/parse_to_elements.test.ts
@@ -61,6 +61,20 @@ describe('parseToElements()', () => {
     });
   });
 
+  context('when a string element declares a zero length (NODE-7611)', () => {
+    it('throws instead of scanning past the end of the input', () => {
+      // 10-byte document: string element with empty name declares a stringSize of 0,
+      // which advances the cursor to the declared document end and would otherwise
+      // make findNull scan out of range forever.
+      const test = () =>
+        parseToElements(
+          new Uint8Array([0x0a, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00])
+        );
+      expect(test).to.throw(/Null terminator not found/i);
+      expect(test).to.throw(BSONOffsetError);
+    });
+  });
+
   context('when given a negative size', () => {
     context('in a document', () => {
       it('throws an error that a size cannot be negative', () => {


### PR DESCRIPTION
### Description

#### Summary of Changes

A malformed document with a string element declaring a zero length passes the on-demand parser's size/terminator guards and advances the cursor to the declared document end. The next loop iteration then calls `findNull` from past the end of the buffer: out-of-range `Uint8Array` reads return `undefined` (which is never `0x00`), so the scan never terminates — a synchronous CPU hang on caller-controlled bytes.

`findNull` now stops at the end of the input and throws a `BSONOffsetError('Null terminator not found')` instead of scanning out of range forever. The existing "reached the document terminator" throw is preserved by folding both conditions into `nullTerminatorOffset >= bytes.length - 1`.

Repro (hangs before this change, throws after):

```javascript
const BSON = require('bson');
// 10-byte document: string element with empty name declaring stringSize = 0
BSON.onDemand.parseToElements(
  new Uint8Array([0x0a, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00])
);
```

##### Notes for Reviewers

- Only the experimental `BSON.onDemand.parseToElements` path is affected; the standard `BSON.deserialize` path already rejects `stringSize <= 0`.
- The ticket also notes the `stringSize <= 0` check is not mirrored on the on-demand path. I kept this PR focused on the non-termination bug; mirroring that check would need per-type care (e.g. a zero length is valid for `binData`) and could be a follow-up.

#### What is the motivation for this change?

Fixes NODE-7611 (part of NODE-7598).

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### `BSON.onDemand.parseToElements` no longer hangs on malformed input

A malformed document containing a string element with a declared length of zero previously caused a non-terminating scan (synchronous CPU hang). The experimental on-demand parser now throws a `BSONOffsetError` instead.

Thanks to @AbinMadathil-Celigo for providing the fix!

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket