### PR TITLE
fix(NODE-7696): calculateObjectSize hangs indefinitely on an object containing a circular reference

### DIFF
--- a/src/parser/calculate_size.ts
+++ b/src/parser/calculate_size.ts
@@ -5,20 +5,46 @@ import * as constants from '../constants';
 import { ByteUtils } from '../utils/byte_utils';
 import { isAnyArrayBuffer, isDate, isMap, isRegExp } from './utils';
 
+/** @internal */
+interface SizeFrame {
+  object: Document;
+  /** Each frame carries its own ignoreUndefined so DBRef fields can force ignoreUndefined=true
+   * regardless of the caller's setting. */
+  ignoreUndefined: boolean;
+  /**
+   * Exit frames carry no work. They mark the point at which obj's entire subtree has been
+   * drained, so obj can leave the ancestor path.
+   */
+  exit: boolean;
+}
+
 export function internalCalculateObjectSize(
   object: Document,
   serializeFunctions?: boolean,
   ignoreUndefined?: boolean
 ): number {
-  // Each stack entry carries its own ignoreUndefined so DBRef fields can force ignoreUndefined=true
-  // regardless of the caller's setting, matching the behavior of serializeInto.
-  const objectStack: Array<{ obj: Document; ignoreUndefined: boolean }> = [
-    { obj: object, ignoreUndefined: ignoreUndefined ?? false }
+  const objectStack: SizeFrame[] = [
+    { object, ignoreUndefined: ignoreUndefined ?? false, exit: false }
   ];
+  // The chain of objects from the root down to the one currently being walked.
+  const path = new Set<Document>();
   let total = 0;
 
   while (objectStack.length > 0) {
-    const { obj, ignoreUndefined: frameIgnoreUndefined } = objectStack.pop()!;
+    const frame = objectStack.pop()!;
+
+    if (frame.exit) {
+      path.delete(frame.object);
+      continue;
+    }
+
+    const { object: obj, ignoreUndefined: frameIgnoreUndefined } = frame;
+    path.add(obj);
+    // Re-push this frame as its own exit marker.
+    // The frame itself is popped when the subtree is exhausted.
+    frame.exit = true;
+    objectStack.push(frame);
+
     total += 5; // 4-byte size field + null terminator
 
     const isObjArray = Array.isArray(obj);
@@ -39,7 +65,8 @@ export function internalCalculateObjectSize(
           serializeFunctions,
           true,
           frameIgnoreUndefined,
-          objectStack
+          objectStack,
+          path
         );
       }
     } else if (isObjMap) {
@@ -50,7 +77,8 @@ export function internalCalculateObjectSize(
           serializeFunctions,
           false,
           frameIgnoreUndefined,
-          objectStack
+          objectStack,
+          path
         );
       }
     } else {
@@ -61,7 +89,8 @@ export function internalCalculateObjectSize(
           serializeFunctions,
           false,
           frameIgnoreUndefined,
-          objectStack
+          objectStack,
+          path
         );
       }
     }
@@ -78,7 +107,8 @@ function calculateElementSize(
   serializeFunctions = false,
   isArray = false,
   ignoreUndefined = false,
-  objectStack: Array<{ obj: Document; ignoreUndefined: boolean }>
+  objectStack: SizeFrame[],
+  path: Set<Document>
 ): number {
   // If we have toBSON defined, override the current object
   if (typeof value?.toBSON === 'function') {
@@ -141,7 +171,10 @@ function calculateElementSize(
       } else if (value._bsontype === 'Code') {
         // Calculate size depending on the availability of a scope
         if (value.scope != null && Object.keys(value.scope).length > 0) {
-          objectStack.push({ obj: value.scope, ignoreUndefined });
+          if (path.has(value.scope)) {
+            throw new BSONError('Cannot convert circular structure to BSON');
+          }
+          objectStack.push({ object: value.scope, ignoreUndefined, exit: false });
           return (
             ByteUtils.utf8ByteLength(name) +
             1 +
@@ -189,7 +222,9 @@ function calculateElementSize(
         }
 
         // DBRef fields always use ignoreUndefined=true to match serializeInto behavior.
-        objectStack.push({ obj: ordered_values, ignoreUndefined: true });
+        // No cycle check: ordered_values is freshly built here, so it can never already be an
+        // ancestor. A cycle through value.fields is caught when its contents are walked.
+        objectStack.push({ object: ordered_values, ignoreUndefined: true, exit: false });
         return ByteUtils.utf8ByteLength(name) + 1 + 1;
       } else if (value instanceof RegExp || isRegExp(value)) {
         return (
@@ -214,7 +249,10 @@ function calculateElementSize(
           1
         );
       } else {
-        objectStack.push({ obj: value, ignoreUndefined });
+        if (path.has(value)) {
+          throw new BSONError('Cannot convert circular structure to BSON');
+        }
+        objectStack.push({ object: value, ignoreUndefined, exit: false });
         return ByteUtils.utf8ByteLength(name) + 1 + 1;
       }
     case 'function':

--- a/test/node/circular_reference.test.ts
+++ b/test/node/circular_reference.test.ts
@@ -60,6 +60,40 @@ describe('Cyclic reference detection', () => {
     });
   });
 
+  context('in calculateObjectSize', () => {
+    for (const test of generateTests()) {
+      it(test.title, () => {
+        expect(() => BSON.calculateObjectSize(test.input), inspect(test.input)).to.throw(
+          /circular/
+        );
+      });
+    }
+
+    it('throws if code.scope is circular', () => {
+      const root: { code: Code | null } = { code: null };
+      root.code = new BSON.Code('function() {}', { a: root });
+      expect(() => BSON.calculateObjectSize(root)).to.throw(/circular/);
+    });
+
+    it('throws if dbref.fields is circular', () => {
+      const root: { dbref: DBRef | null } = { dbref: null };
+      root.dbref = new BSON.DBRef('test', new BSON.ObjectId(), 'test', { a: root });
+      expect(() => BSON.calculateObjectSize(root)).to.throw(/circular/);
+    });
+
+    it('does not throw when sibling keys share a reference', () => {
+      const shared = { a: 1 };
+      const root = { x: shared, y: shared };
+      expect(() => BSON.calculateObjectSize(root)).to.not.throw();
+    });
+
+    it('agrees with serialize on the size of a document sharing a reference', () => {
+      const shared = { a: 1 };
+      const root = { x: shared, y: shared };
+      expect(BSON.calculateObjectSize(root)).to.equal(BSON.serialize(root).byteLength);
+    });
+  });
+
   context('EJSON circular references', () => {
     it('should throw a helpful error message for input with circular references', function () {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### Description

#### Summary of Changes

Add a `path: Set<Document>` similar to [serializer's](https://github.com/mongodb/js-bson/blob/node-7696/src/parser/serializer.ts#L500-L508) so we can detect circular references when calculating BSON size. Also added a formal interface `SizeFrame` for an anonymous object we've been using.

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed `BSON.calculateObjectSize` infinite hang

Fixed a bug where `BSON.calculateObjectSize` would hang indefinitely on an object containing a circular reference. The method now throws an exception when a circular reference is detected.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
