### PR TITLE
fix(NODE-7790): DBRef "$ref" containing dots gets split and stored as "$db"

### DIFF
--- a/src/db_ref.ts
+++ b/src/db_ref.ts
@@ -47,13 +47,6 @@ export class DBRef extends BSONValue {
    */
   constructor(collection: string, oid: ObjectId, db?: string, fields?: Document) {
     super();
-    // check if namespace has been provided
-    const parts = collection.split('.');
-    if (parts.length === 2) {
-      db = parts.shift();
-      collection = parts.shift()!;
-    }
-
     this.collection = collection;
     this.oid = oid;
     this.db = db;

--- a/test/node/db_ref.test.ts
+++ b/test/node/db_ref.test.ts
@@ -1,7 +1,68 @@
 import { expect } from 'chai';
 import * as BSON from '../register-bson';
 
-import { isDBRefLike } from '../../src/db_ref';
+import { DBRef, isDBRefLike } from '../../src/db_ref';
+import { ObjectId } from '../../src/objectid';
+
+describe('DBRef', function () {
+  const oid = new ObjectId('58921b3e6e32ab156a22b59e');
+
+  describe('constructor()', function () {
+    // The DBRef spec requires $ref to be treated as an opaque string:
+    // "Drivers MUST require $ref and $db (if specified) to be strings but MUST NOT
+    //  enforce any naming restrictions on the string values."
+    it('treats a collection name containing a dot as a literal', function () {
+      const ref = new DBRef('foo.bar', oid);
+      expect(ref).to.have.property('collection', 'foo.bar');
+      expect(ref).to.have.property('db', undefined);
+    });
+
+    it('does not override an explicitly provided db', function () {
+      const ref = new DBRef('foo.bar', oid, 'mydb');
+      expect(ref).to.have.property('collection', 'foo.bar');
+      expect(ref).to.have.property('db', 'mydb');
+    });
+
+    it('treats a collection name containing multiple dots as a literal', function () {
+      const ref = new DBRef('foo.bar.baz', oid);
+      expect(ref).to.have.property('collection', 'foo.bar.baz');
+      expect(ref).to.have.property('db', undefined);
+    });
+
+    it('treats a collection name with a leading dot as a literal', function () {
+      const ref = new DBRef('.bar', oid);
+      expect(ref).to.have.property('collection', '.bar');
+      expect(ref).to.have.property('db', undefined);
+    });
+  });
+
+  describe('round tripping a dotted $ref', function () {
+    it('preserves $ref and omits $db when deserializing', function () {
+      const bytes = BSON.serialize({ ref: { $ref: 'foo.bar', $id: oid } });
+
+      const result = BSON.deserialize(bytes) as { ref: DBRef };
+
+      expect(result.ref).to.have.property('collection', 'foo.bar');
+      expect(result.ref).to.have.property('db', undefined);
+    });
+
+    it('produces identical bytes when re-serialized', function () {
+      const bytes = BSON.serialize({ ref: { $ref: 'foo.bar', $id: oid } });
+
+      const roundTripped = BSON.serialize(BSON.deserialize(bytes));
+
+      expect(roundTripped).to.deep.equal(bytes);
+    });
+
+    it('preserves $ref through an EJSON round trip', function () {
+      const ejson = '{"ref":{"$ref":"foo.bar","$id":{"$oid":"58921b3e6e32ab156a22b59e"}}}';
+
+      const roundTripped = BSON.EJSON.stringify(BSON.EJSON.parse(ejson));
+
+      expect(roundTripped).to.equal(ejson);
+    });
+  });
+});
 
 describe('dbpointer tests', function () {
   it('can serialize and deserialize 0xFFFD in dbpointer name', function () {
@@ -26,6 +87,34 @@ describe('dbpointer tests', function () {
       0
     ]);
     expect(() => BSON.deserialize(bsonSnippet)).to.not.throw();
+  });
+
+  // bson-corpus dbpointer.json specifies the upgraded form as
+  // {"$ref": <namespace>, "$id": ...} with no $db, so the namespace is carried over verbatim.
+  it('upgrades a dotted namespace to a DBRef without extracting a db', function () {
+    const bsonSnippet = Buffer.from([
+      // Size
+      32, 0, 0, 0,
+      // BSON type for DBPointer
+      0x0c,
+
+      // CString label "a"
+      0x61, 0,
+
+      // Length prefixed string "db.coll"
+      8, 0, 0, 0, 0x64, 0x62, 0x2e, 0x63, 0x6f, 0x6c, 0x6c, 0,
+
+      // 12-byte pointer
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+
+      // null terminator
+      0
+    ]);
+
+    const result = BSON.deserialize(bsonSnippet) as { a: DBRef };
+
+    expect(result.a).to.have.property('collection', 'db.coll');
+    expect(result.a).to.have.property('db', undefined);
   });
 
   describe('isDBRefLike()', () => {


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
